### PR TITLE
Initial work on progress saving

### DIFF
--- a/src/app.cpp
+++ b/src/app.cpp
@@ -29,7 +29,7 @@ int app::OnExit() {
 				long position = data->textbox->GetInsertionPoint();
 				wxConfigBase* config = wxConfigBase::Get();
 				if (config) {
-					config->SetPath("/DocumentPositions");
+					config->SetPath("/documents");
 					config->Write(data->file_path, position);
 				}
 			}

--- a/src/app.cpp
+++ b/src/app.cpp
@@ -3,6 +3,7 @@
 #include "parser.hpp"
 #include <wx/filename.h>
 #include <wx/stdpaths.h>
+#include <wx/config.h>
 
 bool app::OnInit() {
 	wxString exePath = wxStandardPaths::Get().GetExecutablePath();
@@ -18,6 +19,23 @@ bool app::OnInit() {
 }
 
 int app::OnExit() {
+	// Save positions for all open documents before exit
+	if (frame) {
+		wxNotebook* notebook = frame->get_notebook();
+		for (size_t i = 0; i < notebook->GetPageCount(); ++i) {
+			auto* page = notebook->GetPage(i);
+			auto* data = static_cast<user_data*>(page->GetClientObject());
+			if (data && data->textbox) {
+				long position = data->textbox->GetInsertionPoint();
+				wxConfigBase* config = wxConfigBase::Get();
+				if (config) {
+					config->SetPath("/DocumentPositions");
+					config->Write(data->file_path, position);
+				}
+			}
+		}
+	}
+	
 	if (conf) conf->Flush();
 	return wxApp::OnExit();
 }

--- a/src/main_window.cpp
+++ b/src/main_window.cpp
@@ -425,7 +425,7 @@ void main_window::save_document_position(const wxString& path, long position) {
 	wxConfigBase* config = wxConfigBase::Get();
 	if (!config) return;
 	
-	config->SetPath("/DocumentPositions");
+	config->SetPath("/documents");
 	config->Write(path, position);
 	config->Flush();
 }
@@ -434,7 +434,7 @@ long main_window::load_document_position(const wxString& path) {
 	wxConfigBase* config = wxConfigBase::Get();
 	if (!config) return 0;
 	
-	config->SetPath("/DocumentPositions");
+	config->SetPath("/documents");
 	return config->Read(path, 0L);
 }
 

--- a/src/main_window.cpp
+++ b/src/main_window.cpp
@@ -12,6 +12,7 @@
 #include <wx/fdrepdlg.h>
 #include <wx/filename.h>
 #include <wx/tokenzr.h>
+#include <wx/timer.h>
 
 main_window::main_window() : wxFrame(nullptr, wxID_ANY, APP_NAME) {
 	auto* panel = new wxPanel(this);
@@ -77,6 +78,11 @@ main_window::main_window() : wxFrame(nullptr, wxID_ANY, APP_NAME) {
 	Bind(wxEVT_CLOSE_WINDOW, &main_window::on_close_window, this);
 	for (const int id : doc_command_ids)
 		Bind(wxEVT_UPDATE_UI, &main_window::update_doc_commands, this, id);
+	
+	// Initialize periodic position saving timer (30 seconds)
+	position_save_timer = new wxTimer(this);
+	Bind(wxEVT_TIMER, &main_window::on_position_save_timer, this, position_save_timer->GetId());
+	position_save_timer->Start(30000); // 30 seconds
 }
 
 wxTextCtrl* main_window::active_text_ctrl() const {
@@ -459,6 +465,18 @@ void main_window::on_close_window(wxCloseEvent& event) {
 		}
 	}
 	
+	// Stop the position save timer
+	if (position_save_timer) {
+		position_save_timer->Stop();
+		delete position_save_timer;
+		position_save_timer = nullptr;
+	}
+	
 	// Allow the window to close
 	event.Skip();
+}
+
+void main_window::on_position_save_timer(wxTimerEvent& event) {
+	// Periodically save the current tab position
+	save_current_tab_position();
 }

--- a/src/main_window.hpp
+++ b/src/main_window.hpp
@@ -38,6 +38,7 @@ constexpr int doc_command_ids[] = {
 struct user_data : public wxClientData {
 	wxTextCtrl* textbox = nullptr;
 	std::unique_ptr<document> doc;
+	wxString file_path;
 };
 
 class main_window : public wxFrame {
@@ -46,6 +47,7 @@ public:
 	wxTextCtrl* active_text_ctrl() const;
 	document* active_document() const;
 	void open_document(const wxString& path, const parser* par);
+	wxNotebook* get_notebook() const { return notebook; }
 
 private:
 	wxNotebook* notebook = nullptr;
@@ -76,4 +78,10 @@ private:
 	void on_find_dialog(wxFindDialogEvent& event);
 	void on_find_close(wxFindDialogEvent& event);
 	void on_text_cursor_changed(wxEvent& event);
+	void on_close_window(wxCloseEvent& event);
+	
+	// Position persistence helpers
+	void save_document_position(const wxString& path, long position);
+	long load_document_position(const wxString& path);
+	void save_current_tab_position();
 };

--- a/src/main_window.hpp
+++ b/src/main_window.hpp
@@ -54,6 +54,7 @@ private:
 	wxFindReplaceDialog* find_dialog = nullptr;
 	wxFindReplaceData find_data;
 	wxStatusBar* status_bar = nullptr;
+	wxTimer* position_save_timer = nullptr;
 
 	user_data* active_user_data() const;
 	void update_doc_commands(wxUpdateUIEvent& event);
@@ -79,6 +80,7 @@ private:
 	void on_find_close(wxFindDialogEvent& event);
 	void on_text_cursor_changed(wxEvent& event);
 	void on_close_window(wxCloseEvent& event);
+	void on_position_save_timer(wxTimerEvent& event);
 	
 	// Position persistence helpers
 	void save_document_position(const wxString& path, long position);


### PR DESCRIPTION
Hi,
Here's my initial draft for document position saving. currently, it saves on tab switch, tab exit, close all tabs, window close and application exit.
the last one is due to the fact that positions weren't saving when the application was exited with alt+f4, so it's essentially to catch that.
If you have any ideas to handle this any better, feel free to suggest or make those changes.
There are a few issues with the current way I've done this, as I see it. if a user switches tabs very quickly, the position will be saved every time.
I'm going to be doing some testing in the nexxt few days of this feature in practice, but wanted to open this at least as a draft so you can have a look and let me know your thoughts.
