### PR TITLE
Add german translation

### DIFF
--- a/po/de.po
+++ b/po/de.po
@@ -1,0 +1,955 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR Quin Gillespie
+# This file is distributed under the same license as the paperback package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: paperback 0.5\n"
+"Report-Msgid-Bugs-To: https://github.com/trypsynth/paperback/issues\n"
+"POT-Creation-Date: 2025-10-27 21:45-0600\n"
+"PO-Revision-Date: 2025-10-28 19:32+0100\n"
+"Last-Translator: Steffen Schultz <steffenschultz@mailbox.org>\n"
+"Language-Team: Steffen Schultz <steffenschultz@mailbox.org>\n"
+"Language: de\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Generator: Poedit 3.8\n"
+
+#: C:/Users/Quin/git/paperback/src/app.cpp:37
+msgid "Failed to initialize configuration"
+msgstr "Die Konfiguration konnte nicht initialisiert werden"
+
+#: C:/Users/Quin/git/paperback/src/app.cpp:37
+#: C:/Users/Quin/git/paperback/src/app.cpp:96
+#: C:/Users/Quin/git/paperback/src/app.cpp:117
+#: C:/Users/Quin/git/paperback/src/app.cpp:171
+#: C:/Users/Quin/git/paperback/src/app.cpp:194
+#: C:/Users/Quin/git/paperback/src/dialogs.cpp:284
+#: C:/Users/Quin/git/paperback/src/document_manager.cpp:47
+#: C:/Users/Quin/git/paperback/src/document_manager.cpp:67
+#: C:/Users/Quin/git/paperback/src/epub_parser.cpp:103
+#: C:/Users/Quin/git/paperback/src/main_window.cpp:392
+#: C:/Users/Quin/git/paperback/src/main_window.cpp:671
+#: C:/Users/Quin/git/paperback/src/main_window.cpp:679
+#: C:/Users/Quin/git/paperback/src/main_window.cpp:688
+#: C:/Users/Quin/git/paperback/src/update_checker.cpp:30
+#: C:/Users/Quin/git/paperback/src/update_checker.cpp:41
+#: C:/Users/Quin/git/paperback/src/update_checker.cpp:50
+#: C:/Users/Quin/git/paperback/src/update_checker.cpp:90
+#: C:/Users/Quin/git/paperback/src/update_checker.cpp:106
+msgid "Error"
+msgstr "Fehler"
+
+#: C:/Users/Quin/git/paperback/src/app.cpp:69
+msgid "Failed to create IPC server"
+msgstr "IPC-Server konnte nicht erstellt werden"
+
+#: C:/Users/Quin/git/paperback/src/app.cpp:69
+#: C:/Users/Quin/git/paperback/src/epub_parser.cpp:285
+#: C:/Users/Quin/git/paperback/src/pptx_parser.cpp:127
+msgid "Warning"
+msgstr "Warnung"
+
+#: C:/Users/Quin/git/paperback/src/app.cpp:96
+#: C:/Users/Quin/git/paperback/src/app.cpp:171
+#: C:/Users/Quin/git/paperback/src/document_manager.cpp:47
+#, c-format
+msgid "File not found: %s"
+msgstr "Datei nicht gefunden: %s"
+
+#: C:/Users/Quin/git/paperback/src/app.cpp:117
+#: C:/Users/Quin/git/paperback/src/app.cpp:194
+#: C:/Users/Quin/git/paperback/src/document_manager.cpp:67
+msgid "Failed to load document."
+msgstr "Das Dokument konnte nicht geladen werden."
+
+#: C:/Users/Quin/git/paperback/src/dialogs.cpp:71
+msgid "All Documents"
+msgstr "Alle Dokumente"
+
+#: C:/Users/Quin/git/paperback/src/dialogs.cpp:79
+msgid "File Name"
+msgstr "Dateiname"
+
+#: C:/Users/Quin/git/paperback/src/dialogs.cpp:80
+msgid "Status"
+msgstr "Status"
+
+#: C:/Users/Quin/git/paperback/src/dialogs.cpp:81
+msgid "Path"
+msgstr "Pfad"
+
+#: C:/Users/Quin/git/paperback/src/dialogs.cpp:85
+msgid "&Open"
+msgstr "Ö&ffnen"
+
+#: C:/Users/Quin/git/paperback/src/dialogs.cpp:86
+msgid "&Remove"
+msgstr "Entfe&rnen"
+
+#: C:/Users/Quin/git/paperback/src/dialogs.cpp:101
+#: C:/Users/Quin/git/paperback/src/dialogs.cpp:152
+#: C:/Users/Quin/git/paperback/src/dialogs.cpp:175
+#: C:/Users/Quin/git/paperback/src/dialogs.cpp:189
+msgid "Missing"
+msgstr "Nicht vorhanden"
+
+#: C:/Users/Quin/git/paperback/src/dialogs.cpp:122
+msgid ""
+"Are you sure you want to remove this document from the list? This will also "
+"remove its reading position."
+msgstr ""
+"Soll dieses Dokument wirklich aus der Liste entfernt werden? Dadurch wird "
+"auch die Leseposition gelöscht."
+
+#: C:/Users/Quin/git/paperback/src/dialogs.cpp:122
+msgid "Confirm"
+msgstr "Bestätigen"
+
+#: C:/Users/Quin/git/paperback/src/dialogs.cpp:177
+msgid "Open"
+msgstr "Öffnen"
+
+#: C:/Users/Quin/git/paperback/src/dialogs.cpp:179
+msgid "Closed"
+msgstr "Geschlossen"
+
+#: C:/Users/Quin/git/paperback/src/dialogs.cpp:194
+msgid "Jump to Bookmark"
+msgstr "Springe zu Lesezeichen"
+
+#: C:/Users/Quin/git/paperback/src/dialogs.cpp:208
+#: C:/Users/Quin/git/paperback/src/dialogs.cpp:214
+#: C:/Users/Quin/git/paperback/src/dialogs.cpp:339
+#: C:/Users/Quin/git/paperback/src/dialogs.cpp:345
+msgid "blank"
+msgstr "leer"
+
+#: C:/Users/Quin/git/paperback/src/dialogs.cpp:234
+msgid "&Edit Note"
+msgstr "Notiz &bearbeiten"
+
+#: C:/Users/Quin/git/paperback/src/dialogs.cpp:235
+msgid "&Delete"
+msgstr "&Löschen"
+
+#: C:/Users/Quin/git/paperback/src/dialogs.cpp:236
+msgid "&Jump"
+msgstr "&Springen"
+
+#: C:/Users/Quin/git/paperback/src/dialogs.cpp:237
+msgid "&Cancel"
+msgstr "&Abbrechen"
+
+#: C:/Users/Quin/git/paperback/src/dialogs.cpp:284
+msgid "Please select a bookmark to jump to."
+msgstr "Bitte ein Lesezeichen zum Anspringen auswählen."
+
+#: C:/Users/Quin/git/paperback/src/dialogs.cpp:324
+#: C:/Users/Quin/git/paperback/src/document_manager.cpp:912
+msgid "Edit bookmark note:"
+msgstr "Lesezeichennotiz bearbeiten:"
+
+#: C:/Users/Quin/git/paperback/src/dialogs.cpp:324
+#: C:/Users/Quin/git/paperback/src/document_manager.cpp:913
+msgid "Bookmark Note"
+msgstr "Lesezeichennotiz"
+
+#: C:/Users/Quin/git/paperback/src/dialogs.cpp:357
+msgid "Document Info"
+msgstr "Dokumentinfo"
+
+#: C:/Users/Quin/git/paperback/src/dialogs.cpp:362
+msgid "Title: "
+msgstr "Titel: "
+
+#: C:/Users/Quin/git/paperback/src/dialogs.cpp:363
+msgid "Author: "
+msgstr "Autor: "
+
+#: C:/Users/Quin/git/paperback/src/dialogs.cpp:364
+msgid "Total number of words: "
+msgstr "Wortanzahl: "
+
+#: C:/Users/Quin/git/paperback/src/dialogs.cpp:365
+msgid "Total number of lines: "
+msgstr "Zeilen insgesamt: "
+
+#: C:/Users/Quin/git/paperback/src/dialogs.cpp:366
+msgid "Total number of characters: "
+msgstr "Anzahl Zeichen insgesamt: "
+
+#: C:/Users/Quin/git/paperback/src/dialogs.cpp:367
+msgid "Total number of characters (excluding whitespace): "
+msgstr "Zeichenanzahl ohne Leerzeichen: "
+
+#: C:/Users/Quin/git/paperback/src/dialogs.cpp:375
+msgid "Find"
+msgstr "Suchen"
+
+#: C:/Users/Quin/git/paperback/src/dialogs.cpp:381
+msgid "Find &what:"
+msgstr "&Suche nach:"
+
+#: C:/Users/Quin/git/paperback/src/dialogs.cpp:385
+#: C:/Users/Quin/git/paperback/src/dialogs.cpp:616
+msgid "Options"
+msgstr "Optionen"
+
+#: C:/Users/Quin/git/paperback/src/dialogs.cpp:386
+msgid "&Match case"
+msgstr "&Großschreibung beachten"
+
+#: C:/Users/Quin/git/paperback/src/dialogs.cpp:387
+msgid "Match &whole word"
+msgstr "Nur ganze &Wörter"
+
+#: C:/Users/Quin/git/paperback/src/dialogs.cpp:388
+msgid "Use &regular expressions"
+msgstr "Verwende &reguläre Ausdrücke"
+
+#: C:/Users/Quin/git/paperback/src/dialogs.cpp:393
+msgid "Find &Previous"
+msgstr "&Vorheriges suchen"
+
+#: C:/Users/Quin/git/paperback/src/dialogs.cpp:394
+msgid "Find &Next"
+msgstr "&Nächstes suchen"
+
+#: C:/Users/Quin/git/paperback/src/dialogs.cpp:395
+msgid "Cancel"
+msgstr "Abbrechen"
+
+#: C:/Users/Quin/git/paperback/src/dialogs.cpp:486
+msgid "Go to Line"
+msgstr "Gehe zu Zeile"
+
+#: C:/Users/Quin/git/paperback/src/dialogs.cpp:489
+msgid "&Line number:"
+msgstr "&Zeilennummer:"
+
+#: C:/Users/Quin/git/paperback/src/dialogs.cpp:511
+msgid "Go to page"
+msgstr "Gehe zu Seite"
+
+#: C:/Users/Quin/git/paperback/src/dialogs.cpp:514
+#, c-format
+msgid "Go to page (1/%d):"
+msgstr "Gehe zu Seite (1/%d):"
+
+#: C:/Users/Quin/git/paperback/src/dialogs.cpp:540
+msgid "Go to Percent"
+msgstr "Gehe zu Prozent"
+
+#: C:/Users/Quin/git/paperback/src/dialogs.cpp:546
+msgid "P&ercent:"
+msgstr "Pr&ozent:"
+
+#: C:/Users/Quin/git/paperback/src/dialogs.cpp:548
+msgid "&Percent"
+msgstr "&Prozent"
+
+#: C:/Users/Quin/git/paperback/src/dialogs.cpp:579
+msgid "Open As"
+msgstr "Öffnen als"
+
+#: C:/Users/Quin/git/paperback/src/dialogs.cpp:582
+#, c-format
+msgid ""
+"No suitable parser was found for %s.\n"
+"How would you like to open this file?"
+msgstr ""
+"Es wurde kein passender Parser für %s gefunden.\n"
+"Wie soll diese Datei geöffnet werden?"
+
+#: C:/Users/Quin/git/paperback/src/dialogs.cpp:585
+msgid "Open &as:"
+msgstr "Öffnen &als:"
+
+#: C:/Users/Quin/git/paperback/src/dialogs.cpp:587
+msgid "Plain Text"
+msgstr "Nur Text"
+
+#: C:/Users/Quin/git/paperback/src/dialogs.cpp:588
+msgid "HTML"
+msgstr "HTML"
+
+#: C:/Users/Quin/git/paperback/src/dialogs.cpp:589
+msgid "Markdown"
+msgstr "Markdown"
+
+#: C:/Users/Quin/git/paperback/src/dialogs.cpp:620
+msgid "General"
+msgstr "Allgemein"
+
+#: C:/Users/Quin/git/paperback/src/dialogs.cpp:621
+msgid "&Restore previously opened documents on startup"
+msgstr "Zuletzt geöffnete Dokumente beim Start wieder&herstellen"
+
+#: C:/Users/Quin/git/paperback/src/dialogs.cpp:623
+msgid "&Word wrap"
+msgstr "&Wortumbruch"
+
+#: C:/Users/Quin/git/paperback/src/dialogs.cpp:625
+msgid "&Minimize to system tray"
+msgstr "In den Infobereich &minimieren"
+
+#: C:/Users/Quin/git/paperback/src/dialogs.cpp:627
+msgid "Show compact &go menu"
+msgstr "&Gehe-zu-Menü kompakt anzeigen"
+
+#: C:/Users/Quin/git/paperback/src/dialogs.cpp:629
+msgid "&Wrap navigation"
+msgstr "&Kreisförmige Navigation"
+
+#: C:/Users/Quin/git/paperback/src/dialogs.cpp:631
+msgid "Check for &updates on startup"
+msgstr "Beim Start auf &Updates prüfen"
+
+#: C:/Users/Quin/git/paperback/src/dialogs.cpp:634
+msgid "Number of &recent documents to show:"
+msgstr "Anzahl &zuletzt geöffneter Dokumente:"
+
+#: C:/Users/Quin/git/paperback/src/dialogs.cpp:640
+msgid "&Language:"
+msgstr "&Sprache:"
+
+#: C:/Users/Quin/git/paperback/src/dialogs.cpp:759
+msgid "Sleep Timer"
+msgstr "Schlaftimer"
+
+#: C:/Users/Quin/git/paperback/src/dialogs.cpp:762
+msgid "&Minutes:"
+msgstr "&Minuten:"
+
+#: C:/Users/Quin/git/paperback/src/dialogs.cpp:774
+msgid "Table of Contents"
+msgstr "Inhaltsverzeichnis"
+
+#: C:/Users/Quin/git/paperback/src/dialogs.cpp:777
+msgid "Root"
+msgstr "Wurzel"
+
+#: C:/Users/Quin/git/paperback/src/dialogs.cpp:795
+msgid "Untitled"
+msgstr "Unbenannt"
+
+#: C:/Users/Quin/git/paperback/src/dialogs.cpp:843
+msgid "Please select a section from the table of contents."
+msgstr "Bitte einen Abschnitt aus dem Inhaltsverzeichnis wählen."
+
+#: C:/Users/Quin/git/paperback/src/dialogs.cpp:843
+msgid "No Selection"
+msgstr "Keine Auswahl"
+
+#: C:/Users/Quin/git/paperback/src/document_manager.cpp:204
+#: C:/Users/Quin/git/paperback/src/document_manager.cpp:262
+msgid "No sections."
+msgstr "Keine Abschnitte."
+
+#: C:/Users/Quin/git/paperback/src/document_manager.cpp:238
+msgid "No previous section"
+msgstr "Kein vorheriger Abschnitt"
+
+#: C:/Users/Quin/git/paperback/src/document_manager.cpp:248
+#: C:/Users/Quin/git/paperback/src/document_manager.cpp:340
+#: C:/Users/Quin/git/paperback/src/document_manager.cpp:431
+#: C:/Users/Quin/git/paperback/src/document_manager.cpp:516
+#: C:/Users/Quin/git/paperback/src/document_manager.cpp:684
+#: C:/Users/Quin/git/paperback/src/document_manager.cpp:790
+msgid "Wrapping to end. "
+msgstr "Springe zum Ende. "
+
+#: C:/Users/Quin/git/paperback/src/document_manager.cpp:276
+msgid "No next section"
+msgstr "Kein weiterer Abschnitt"
+
+#: C:/Users/Quin/git/paperback/src/document_manager.cpp:286
+#: C:/Users/Quin/git/paperback/src/document_manager.cpp:379
+#: C:/Users/Quin/git/paperback/src/document_manager.cpp:481
+#: C:/Users/Quin/git/paperback/src/document_manager.cpp:552
+#: C:/Users/Quin/git/paperback/src/document_manager.cpp:735
+#: C:/Users/Quin/git/paperback/src/document_manager.cpp:845
+msgid "Wrapping to start. "
+msgstr "Springe zum Anfang. "
+
+#: C:/Users/Quin/git/paperback/src/document_manager.cpp:315
+#: C:/Users/Quin/git/paperback/src/document_manager.cpp:354
+#: C:/Users/Quin/git/paperback/src/main_window.cpp:475
+msgid "No pages."
+msgstr "Keine Seiten."
+
+#: C:/Users/Quin/git/paperback/src/document_manager.cpp:329
+msgid "No previous page."
+msgstr "Keine vorherige Seite."
+
+#: C:/Users/Quin/git/paperback/src/document_manager.cpp:338
+#: C:/Users/Quin/git/paperback/src/document_manager.cpp:342
+#: C:/Users/Quin/git/paperback/src/document_manager.cpp:377
+#: C:/Users/Quin/git/paperback/src/document_manager.cpp:381
+#, c-format
+msgid "Page %d: %s"
+msgstr "Seite %d: %s"
+
+#: C:/Users/Quin/git/paperback/src/document_manager.cpp:368
+msgid "No next page."
+msgstr "Keine weitere Seite."
+
+#: C:/Users/Quin/git/paperback/src/document_manager.cpp:403
+msgid "No previous bookmark"
+msgstr "Kein vorheriges Lesezeichen"
+
+#: C:/Users/Quin/git/paperback/src/document_manager.cpp:426
+#: C:/Users/Quin/git/paperback/src/document_manager.cpp:476
+#, c-format
+msgid "%s - %s - Bookmark %d"
+msgstr "%s - %s - Lesezeichen %d"
+
+#: C:/Users/Quin/git/paperback/src/document_manager.cpp:428
+#: C:/Users/Quin/git/paperback/src/document_manager.cpp:478
+#, c-format
+msgid "%s - Bookmark %d"
+msgstr "%s - Lesezeichen %d"
+
+#: C:/Users/Quin/git/paperback/src/document_manager.cpp:453
+msgid "No next bookmark"
+msgstr "Kein weiteres Lesezeichen"
+
+#: C:/Users/Quin/git/paperback/src/document_manager.cpp:493
+#: C:/Users/Quin/git/paperback/src/document_manager.cpp:529
+msgid "No links."
+msgstr "Keine Links."
+
+#: C:/Users/Quin/git/paperback/src/document_manager.cpp:507
+msgid "No previous link."
+msgstr "Kein vorheriger Link."
+
+#: C:/Users/Quin/git/paperback/src/document_manager.cpp:514
+#: C:/Users/Quin/git/paperback/src/document_manager.cpp:550
+msgid " link"
+msgstr " Link"
+
+#: C:/Users/Quin/git/paperback/src/document_manager.cpp:543
+msgid "No next link."
+msgstr "Kein weiterer Link."
+
+#: C:/Users/Quin/git/paperback/src/document_manager.cpp:583
+msgid "Opening link in default browser."
+msgstr "Link wird im Standardbrowser geöffnet."
+
+#: C:/Users/Quin/git/paperback/src/document_manager.cpp:585
+msgid "Failed to open link."
+msgstr "Link konnte nicht geöffnet werden."
+
+#: C:/Users/Quin/git/paperback/src/document_manager.cpp:592
+#: C:/Users/Quin/git/paperback/src/document_manager.cpp:623
+#: C:/Users/Quin/git/paperback/src/document_manager.cpp:631
+msgid "Navigated to internal link."
+msgstr "Zu internem Link navigiert."
+
+#: C:/Users/Quin/git/paperback/src/document_manager.cpp:594
+#: C:/Users/Quin/git/paperback/src/document_manager.cpp:635
+msgid "Internal link target not found."
+msgstr "Internes Linkziel nicht gefunden."
+
+#: C:/Users/Quin/git/paperback/src/document_manager.cpp:647
+#: C:/Users/Quin/git/paperback/src/document_manager.cpp:651
+#: C:/Users/Quin/git/paperback/src/document_manager.cpp:698
+#: C:/Users/Quin/git/paperback/src/document_manager.cpp:702
+#: C:/Users/Quin/git/paperback/src/document_manager.cpp:749
+#: C:/Users/Quin/git/paperback/src/document_manager.cpp:804
+msgid "No lists."
+msgstr "Keine Listen."
+
+#: C:/Users/Quin/git/paperback/src/document_manager.cpp:665
+msgid "No previous list."
+msgstr "Keine vorherige Liste."
+
+#: C:/Users/Quin/git/paperback/src/document_manager.cpp:671
+#: C:/Users/Quin/git/paperback/src/document_manager.cpp:722
+#, c-format
+msgid "List with %d items"
+msgstr "Liste mit %d Einträgen"
+
+#: C:/Users/Quin/git/paperback/src/document_manager.cpp:716
+msgid "No next list."
+msgstr "Keine weitere Liste."
+
+#: C:/Users/Quin/git/paperback/src/document_manager.cpp:753
+#: C:/Users/Quin/git/paperback/src/document_manager.cpp:808
+msgid "No list items."
+msgstr "Keine Listeneinträge."
+
+#: C:/Users/Quin/git/paperback/src/document_manager.cpp:773
+msgid "No previous list item."
+msgstr "Kein vorheriger Listeneintrag."
+
+#: C:/Users/Quin/git/paperback/src/document_manager.cpp:783
+#: C:/Users/Quin/git/paperback/src/document_manager.cpp:838
+#, c-format
+msgid "List with %d items "
+msgstr "Liste mit %d Einträgen "
+
+#: C:/Users/Quin/git/paperback/src/document_manager.cpp:828
+msgid "No next list item."
+msgstr "Kein weiterer Listeneintrag."
+
+#: C:/Users/Quin/git/paperback/src/document_manager.cpp:880
+msgid "Bookmark removed"
+msgstr "Lesezeichen entfernt"
+
+#: C:/Users/Quin/git/paperback/src/document_manager.cpp:880
+msgid "Bookmarked"
+msgstr "Lesezeichen gesetzt"
+
+#: C:/Users/Quin/git/paperback/src/document_manager.cpp:912
+msgid "Enter bookmark note:"
+msgstr "Lesezeichennotiz eingeben:"
+
+#: C:/Users/Quin/git/paperback/src/document_manager.cpp:920
+msgid "Bookmark note updated"
+msgstr "Lesezeichennotiz aktualisiert"
+
+#: C:/Users/Quin/git/paperback/src/document_manager.cpp:923
+msgid "Bookmarked with note"
+msgstr "Lesezeichen mit Notiz gesetzt"
+
+#: C:/Users/Quin/git/paperback/src/document_manager.cpp:936
+msgid "No bookmarks"
+msgstr "Keine Lesezeichen"
+
+#: C:/Users/Quin/git/paperback/src/document_manager.cpp:968
+#, c-format
+msgid "Bookmark: %s - %s"
+msgstr "Lesezeichen: %s - %s"
+
+#: C:/Users/Quin/git/paperback/src/document_manager.cpp:970
+#, c-format
+msgid "Bookmark: %s"
+msgstr "Lesezeichen: %s"
+
+#: C:/Users/Quin/git/paperback/src/document_manager.cpp:984
+msgid "No table of contents."
+msgstr "Kein Inhaltsverzeichnis."
+
+#: C:/Users/Quin/git/paperback/src/document_manager.cpp:988
+msgid "Table of contents is empty."
+msgstr "Inhaltsverzeichnis ist leer."
+
+#: C:/Users/Quin/git/paperback/src/document_manager.cpp:1043
+#: C:/Users/Quin/git/paperback/src/document_manager.cpp:1047
+#: C:/Users/Quin/git/paperback/src/main_window.cpp:40
+msgid "Ready"
+msgstr "Bereit"
+
+#: C:/Users/Quin/git/paperback/src/document_manager.cpp:1056
+#, c-format
+msgid "line %ld, character %ld, reading %d%%"
+msgstr "Zeile %ld, Zeichen %ld, Lesefortschritt %d%%"
+
+#: C:/Users/Quin/git/paperback/src/document_manager.cpp:1120
+msgid "Previous heading\tShift+H"
+msgstr "Vorherige Überschrift\tShift+H"
+
+#: C:/Users/Quin/git/paperback/src/document_manager.cpp:1121
+msgid "Next heading\tH"
+msgstr "Nächste Überschrift\tH"
+
+#: C:/Users/Quin/git/paperback/src/document_manager.cpp:1124
+#, c-format
+msgid "Previous heading level %d\tShift+%d"
+msgstr "Vorherige Überschrift auf Ebene %d\tShift+%d"
+
+#: C:/Users/Quin/git/paperback/src/document_manager.cpp:1125
+#, c-format
+msgid "Next heading level %d\t%d"
+msgstr "Nächste Überschrift auf Ebene %d\t%d"
+
+#: C:/Users/Quin/git/paperback/src/document_manager.cpp:1172
+msgid "No headings."
+msgstr "Keine Überschriften."
+
+#: C:/Users/Quin/git/paperback/src/document_manager.cpp:1187
+#, c-format
+msgid "No %s heading"
+msgstr "Keine %s Überschrift"
+
+#: C:/Users/Quin/git/paperback/src/document_manager.cpp:1187
+msgid "next"
+msgstr "weitere"
+
+#: C:/Users/Quin/git/paperback/src/document_manager.cpp:1187
+msgid "previous"
+msgstr "vorherige"
+
+#: C:/Users/Quin/git/paperback/src/document_manager.cpp:1187
+#, c-format
+msgid "No %s heading at level %d"
+msgstr "Keine %s Überschrift auf Ebene %d"
+
+#: C:/Users/Quin/git/paperback/src/document_manager.cpp:1198
+#, c-format
+msgid "Wrapping to %s. %s Heading level %d"
+msgstr "Springe zum %s. %s Überschrift Ebene %d"
+
+#: C:/Users/Quin/git/paperback/src/document_manager.cpp:1198
+msgid "start"
+msgstr "Anfang"
+
+#: C:/Users/Quin/git/paperback/src/document_manager.cpp:1198
+msgid "end"
+msgstr "Ende"
+
+#: C:/Users/Quin/git/paperback/src/document_manager.cpp:1200
+#, c-format
+msgid "%s Heading level %d"
+msgstr "%s Überschrift Ebene %d"
+
+#: C:/Users/Quin/git/paperback/src/epub_parser.cpp:285
+#, c-format
+msgid "Couldn't parse table of contents: %s"
+msgstr "Konnte Inhaltsverzeichnis nicht lesen: %s"
+
+#: C:/Users/Quin/git/paperback/src/main_window.cpp:76
+msgid "&File"
+msgstr "&Datei"
+
+#: C:/Users/Quin/git/paperback/src/main_window.cpp:77
+msgid "&Go"
+msgstr "&Gehe zu"
+
+#: C:/Users/Quin/git/paperback/src/main_window.cpp:78
+msgid "&Tools"
+msgstr "&Werkzeuge"
+
+#: C:/Users/Quin/git/paperback/src/main_window.cpp:79
+msgid "&Help"
+msgstr "&Hilfe"
+
+#: C:/Users/Quin/git/paperback/src/main_window.cpp:85
+msgid "&Open...\tCtrl+O"
+msgstr "Ö&ffnen...\tCtrl+O"
+
+#: C:/Users/Quin/git/paperback/src/main_window.cpp:86
+msgid "Close\tCtrl+F4"
+msgstr "Schließen\tCtrl+F4"
+
+#: C:/Users/Quin/git/paperback/src/main_window.cpp:87
+msgid "Close &All\tCtrl+Shift+F4"
+msgstr "&Alles schließen\tCtrl+Shift+F4"
+
+#: C:/Users/Quin/git/paperback/src/main_window.cpp:90
+msgid "&Recent Documents"
+msgstr "&Zuletzt geöffnete Dokumente"
+
+#: C:/Users/Quin/git/paperback/src/main_window.cpp:93
+msgid "&Export...\tCtrl+E"
+msgstr "&Exportieren...\tCtrl+E"
+
+#: C:/Users/Quin/git/paperback/src/main_window.cpp:95
+#: C:/Users/Quin/git/paperback/src/task_bar_icon.cpp:31
+msgid "E&xit"
+msgstr "&Beenden"
+
+#: C:/Users/Quin/git/paperback/src/main_window.cpp:103
+msgid "&Find...\tCtrl+F"
+msgstr "&Suchen...\tCtrl+F"
+
+#: C:/Users/Quin/git/paperback/src/main_window.cpp:104
+msgid "Find Ne&xt\tF3"
+msgstr "&Nächstes suchen\tF3"
+
+#: C:/Users/Quin/git/paperback/src/main_window.cpp:105
+msgid "Find P&revious\tShift+F3"
+msgstr "&Vorheriges suchen\tShift+F3"
+
+#: C:/Users/Quin/git/paperback/src/main_window.cpp:107
+msgid "Go to &line...\tCtrl+G"
+msgstr "Gehe zu &Zeile...\tCtrl+G"
+
+#: C:/Users/Quin/git/paperback/src/main_window.cpp:108
+msgid "Go to &percent...\tCtrl+Shift+G"
+msgstr "Gehe zu &Prozent...\tCtrl+Shift+G"
+
+#: C:/Users/Quin/git/paperback/src/main_window.cpp:112
+#: C:/Users/Quin/git/paperback/src/main_window.cpp:142
+msgid "Previous section\t["
+msgstr "Vorheriger Abschnitt\tShift+A"
+
+#: C:/Users/Quin/git/paperback/src/main_window.cpp:113
+#: C:/Users/Quin/git/paperback/src/main_window.cpp:143
+msgid "Next section\t]"
+msgstr "Nächster Abschnitt\tA"
+
+#: C:/Users/Quin/git/paperback/src/main_window.cpp:114
+msgid "&Sections"
+msgstr "&Abschnitte"
+
+#: C:/Users/Quin/git/paperback/src/main_window.cpp:117
+msgid "&Headings"
+msgstr "Übersc&hriften"
+
+#: C:/Users/Quin/git/paperback/src/main_window.cpp:119
+#: C:/Users/Quin/git/paperback/src/main_window.cpp:140
+msgid "Go to &page...\tCtrl+P"
+msgstr "Gehe zu &Seite...\tCtrl+P"
+
+#: C:/Users/Quin/git/paperback/src/main_window.cpp:121
+#: C:/Users/Quin/git/paperback/src/main_window.cpp:147
+msgid "Previous &page\tShift+P"
+msgstr "Vorherige &Seite\tShift+P"
+
+#: C:/Users/Quin/git/paperback/src/main_window.cpp:122
+#: C:/Users/Quin/git/paperback/src/main_window.cpp:148
+msgid "&Next page\tP"
+msgstr "&Nächste Seite\tP"
+
+#: C:/Users/Quin/git/paperback/src/main_window.cpp:123
+msgid "&Pages"
+msgstr "&Seiten"
+
+#: C:/Users/Quin/git/paperback/src/main_window.cpp:125
+#: C:/Users/Quin/git/paperback/src/main_window.cpp:150
+msgid "Previous &bookmark\tShift+B"
+msgstr "Vorheriges &Lesezeichen\tShift+B"
+
+#: C:/Users/Quin/git/paperback/src/main_window.cpp:126
+#: C:/Users/Quin/git/paperback/src/main_window.cpp:151
+msgid "Next b&ookmark\tB"
+msgstr "Nächstes L&esezeichen\tB"
+
+#: C:/Users/Quin/git/paperback/src/main_window.cpp:127
+#: C:/Users/Quin/git/paperback/src/main_window.cpp:154
+msgid "Jump to bookmark...\tCtrl+B"
+msgstr "Springe zu Lesezeichen...\tCtrl+B"
+
+#: C:/Users/Quin/git/paperback/src/main_window.cpp:128
+msgid "&Bookmarks"
+msgstr "L&esezeichen"
+
+#: C:/Users/Quin/git/paperback/src/main_window.cpp:130
+#: C:/Users/Quin/git/paperback/src/main_window.cpp:156
+msgid "Previous lin&k\tShift+K"
+msgstr "Vorheriger Lin&k\tShift+K"
+
+#: C:/Users/Quin/git/paperback/src/main_window.cpp:131
+#: C:/Users/Quin/git/paperback/src/main_window.cpp:157
+msgid "Next lin&k\tK"
+msgstr "Nächster Lin&k\tK"
+
+#: C:/Users/Quin/git/paperback/src/main_window.cpp:132
+msgid "&Links"
+msgstr "&Links"
+
+#: C:/Users/Quin/git/paperback/src/main_window.cpp:134
+#: C:/Users/Quin/git/paperback/src/main_window.cpp:159
+msgid "Previous lis&t\tShift+L"
+msgstr "Vorherige Lis&te\tShift+L"
+
+#: C:/Users/Quin/git/paperback/src/main_window.cpp:135
+#: C:/Users/Quin/git/paperback/src/main_window.cpp:160
+msgid "Next lis&t\tL"
+msgstr "Nächste Lis&te\tL"
+
+#: C:/Users/Quin/git/paperback/src/main_window.cpp:136
+#: C:/Users/Quin/git/paperback/src/main_window.cpp:161
+msgid "Previous list &item\tShift+I"
+msgstr "Vorheriger L&isteneintrag\tShift+I"
+
+#: C:/Users/Quin/git/paperback/src/main_window.cpp:137
+#: C:/Users/Quin/git/paperback/src/main_window.cpp:162
+msgid "Next list &item\tI"
+msgstr "Nächster L&isteneintrag\tI"
+
+#: C:/Users/Quin/git/paperback/src/main_window.cpp:138
+msgid "&Lists"
+msgstr "&Listen"
+
+#: C:/Users/Quin/git/paperback/src/main_window.cpp:152
+#: C:/Users/Quin/git/paperback/src/main_window.cpp:174
+msgid "Toggle bookmark\tCtrl+Shift+B"
+msgstr "Lesezeichen umschalten\tCtrl+Shift+B"
+
+#: C:/Users/Quin/git/paperback/src/main_window.cpp:153
+#: C:/Users/Quin/git/paperback/src/main_window.cpp:175
+msgid "Bookmark with &note\tCtrl+Shift+N"
+msgstr "Lesezeichen mit &Notiz\tCtrl+Shift+N"
+
+#: C:/Users/Quin/git/paperback/src/main_window.cpp:169
+msgid "&Word count\tCtrl+W"
+msgstr "&Wortanzahl\tCtrl+W"
+
+#: C:/Users/Quin/git/paperback/src/main_window.cpp:170
+msgid "Document &info\tCtrl+I"
+msgstr "Dokument&info\tCtrl+I"
+
+#: C:/Users/Quin/git/paperback/src/main_window.cpp:172
+msgid "Table of contents\tCtrl+T"
+msgstr "Inhaltsverzeichnis\tCtrl+T"
+
+#: C:/Users/Quin/git/paperback/src/main_window.cpp:177
+msgid "&Options\tCtrl+,"
+msgstr "&Optionen\tCtrl+,"
+
+#: C:/Users/Quin/git/paperback/src/main_window.cpp:178
+msgid "&Sleep Timer...\tCtrl+Shift+S"
+msgstr "&Schlaftimer...\tCtrl+Shift+S"
+
+#: C:/Users/Quin/git/paperback/src/main_window.cpp:184
+#, c-format
+msgid "About %s\tCtrl+F1"
+msgstr "Über %s\tCtrl+F1"
+
+#: C:/Users/Quin/git/paperback/src/main_window.cpp:185
+msgid "View &help in default browser\tF1"
+msgstr "&Hilfe im Standardbrowser anzeigen\tF1"
+
+#: C:/Users/Quin/git/paperback/src/main_window.cpp:186
+#, c-format
+msgid "View Help in %s\tShift+F1"
+msgstr "Hilfe in %s anzeigen\tShift+F1"
+
+#: C:/Users/Quin/git/paperback/src/main_window.cpp:188
+msgid "Check for &Updates"
+msgstr "Suche nach &Updates"
+
+#: C:/Users/Quin/git/paperback/src/main_window.cpp:190
+msgid "&Donate\tCtrl+D"
+msgstr "&Spenden\tCtrl+D"
+
+#: C:/Users/Quin/git/paperback/src/main_window.cpp:351
+#, c-format
+msgid " | Sleep timer: %02d:%02d"
+msgstr " | Schlaftimer: %02d:%02d"
+
+#: C:/Users/Quin/git/paperback/src/main_window.cpp:358
+msgid "Select a document to read"
+msgstr "Ein Dokument zum Lesen auswählen"
+
+#: C:/Users/Quin/git/paperback/src/main_window.cpp:386
+msgid "Export Document"
+msgstr "Dokument exportieren"
+
+#: C:/Users/Quin/git/paperback/src/main_window.cpp:386
+msgid "Text files (*.txt)|*.txt|All files (*.*)|*.*"
+msgstr "Textdateien (*.txt)|*.txt|Alle Dateien (*.*)|*.*"
+
+#: C:/Users/Quin/git/paperback/src/main_window.cpp:392
+msgid "Failed to export document."
+msgstr "Das Dokument konnte nicht exportiert werden."
+
+#: C:/Users/Quin/git/paperback/src/main_window.cpp:600
+#, c-format
+msgid "The document contains %d word"
+msgid_plural "The document contains %d words"
+msgstr[0] "Das Dokument enthält %d Wort"
+msgstr[1] "Das Dokument enthält %d Wörter"
+
+#: C:/Users/Quin/git/paperback/src/main_window.cpp:600
+msgid "Word count"
+msgstr "Wortanzahl"
+
+#: C:/Users/Quin/git/paperback/src/main_window.cpp:671
+msgid "Failed to launch default browser."
+msgstr "Der Standardbrowser konnte nicht gestartet werden."
+
+#: C:/Users/Quin/git/paperback/src/main_window.cpp:679
+msgid ""
+"readme.html not found. Please ensure the application was built properly."
+msgstr ""
+"readme.html nicht gefunden. Bitte stelle sicher, dass die Anwendung korrekt "
+"erstellt wurde."
+
+#: C:/Users/Quin/git/paperback/src/main_window.cpp:688
+msgid "Failed to open donation page in browser."
+msgstr "Die Spendenseite konnte nicht im Browser geöffnet werden."
+
+#: C:/Users/Quin/git/paperback/src/main_window.cpp:701
+msgid "Sleep timer canceled."
+msgstr "Schlaftimer abgebrochen."
+
+#: C:/Users/Quin/git/paperback/src/main_window.cpp:715
+#, c-format
+msgid "Sleep timer set for %d minute%s."
+msgstr "Schlaftimer für %d Minute%s gesetzt."
+
+#: C:/Users/Quin/git/paperback/src/main_window.cpp:878
+msgid "(No recent documents)"
+msgstr "(Keine zuletzt geöffneten Dokumente)"
+
+#: C:/Users/Quin/git/paperback/src/main_window.cpp:882
+msgid "Show All...\tCtrl+R"
+msgstr "Zeige alle...\tCtrl+R"
+
+#: C:/Users/Quin/git/paperback/src/main_window.cpp:917
+msgid "No more results. Wrapping search."
+msgstr "Keine weiteren Ergebnisse. Beginne von vorn."
+
+#: C:/Users/Quin/git/paperback/src/main_window.cpp:921
+msgid "Not found."
+msgstr "Nicht gefunden."
+
+#: C:/Users/Quin/git/paperback/src/pptx_parser.cpp:127
+msgid "Parsing of links in the document failed."
+msgstr "Das Parsen der Links im Dokument war nicht erfolgreich."
+
+#: C:/Users/Quin/git/paperback/src/task_bar_icon.cpp:29
+msgid "&Restore"
+msgstr "&Wiederherstellen"
+
+#: C:/Users/Quin/git/paperback/src/update_checker.cpp:30
+msgid "Failed to create update request."
+msgstr "Die Update-Anforderung konnte nicht erstellt werden."
+
+#: C:/Users/Quin/git/paperback/src/update_checker.cpp:41
+msgid "error checking for updates."
+msgstr "Fehler beim Prüfen auf Updates."
+
+#: C:/Users/Quin/git/paperback/src/update_checker.cpp:50
+#, c-format
+msgid "Failed to check for updates. HTTP status: %d"
+msgstr "Fehler beim Prüfen auf Updates. HTTP-Status: %d"
+
+#: C:/Users/Quin/git/paperback/src/update_checker.cpp:64
+msgid "No updates available."
+msgstr "Keine Updates verfügbar."
+
+#: C:/Users/Quin/git/paperback/src/update_checker.cpp:64
+msgid "Info"
+msgstr "Info"
+
+#: C:/Users/Quin/git/paperback/src/update_checker.cpp:90
+msgid "Update is available but download link could not be found."
+msgstr ""
+"Es ist ein Update verfügbar, doch der Downloadlink konnte nicht gefunden "
+"werden."
+
+#: C:/Users/Quin/git/paperback/src/update_checker.cpp:95
+#, c-format
+msgid ""
+"There is an update available.\n"
+"Your version: %s\n"
+"Latest version: %s\n"
+"Description:\n"
+"%s\n"
+"Do you want to open the direct download link?"
+msgstr ""
+"Es ist ein Update verfügbar.\n"
+"Installierte Version: %s\n"
+"Neueste Version: %s\n"
+"Beschreibung:\n"
+"%s\n"
+"Soll der direkte Downloadlink geöffnet werden?"
+
+#: C:/Users/Quin/git/paperback/src/update_checker.cpp:97
+msgid "Update available"
+msgstr "Update verfügbar"
+
+#: C:/Users/Quin/git/paperback/src/update_checker.cpp:106
+#, c-format
+msgid "Error checking for updates: %s"
+msgstr "Fehler beim Prüfen auf Updates: %s"


### PR DESCRIPTION
This adds a German translation file. I changed the keyboard shortcuts for jumping between sections in my language file, since square brackets are rather inconvenient to use on German keyboard layouts. The German word for section is "Abschnitt", so I used the keys A and Shift+A for this purpose. Hope this won't break something in the future. 🙂

Steffen