### PR TITLE
Fix missing node import in html_to_text.rs

### DIFF
--- a/lib/src/html_to_text.rs
+++ b/lib/src/html_to_text.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 
 use bitflags::bitflags;
 use ego_tree::NodeRef;
-use scraper::{ElementRef, Html, Node};
+use scraper::{Html, ElementRef, Node, node};
 
 use crate::utils::text::{collapse_whitespace, display_len, format_list_item, remove_soft_hyphens, trim_string};
 


### PR DESCRIPTION
This PR fixes a compilation error introduced in commit 6a8c03f (#213).
# Problem
The project fails to build with the following error:
error[E0433]: failed to resolve: use of unresolved module or unlinked crate `node`
   --> src\html_to_text.rs:377:40
    |
377 |     fn handle_text_node(&mut self, text: &node::Text) {
    |                                           ^^^^ use of unresolved module or unlinked crate `node`
Cause
Commit 6a8c03f changed line 377 from &scraper::node::Text to &node::Text but did not add the corresponding import for the node module.
# Solution
Added node to the import statement on line 5:
use scraper::{Html, ElementRef, Node, node};
# Testing
Project builds successfully with this change
the build was broken at HEAD before this fix
I have Verified the build works at HEAD~2 (before the problematic commit).