### PR TITLE
Wire up document navigation methods to use DocumentSession APIs

### DIFF
--- a/app/dialogs.hpp
+++ b/app/dialogs.hpp
@@ -145,7 +145,7 @@ private:
 
 class elements_dialog : public dialog {
 public:
-	elements_dialog(wxWindow* parent, const document* doc, long current_pos);
+	elements_dialog(wxWindow* parent, session_document* session_doc, long current_pos);
 	~elements_dialog() override = default;
 	elements_dialog(const elements_dialog&) = delete;
 	elements_dialog& operator=(const elements_dialog&) = delete;
@@ -161,7 +161,7 @@ public:
 	}
 
 private:
-	const document* doc{nullptr};
+	session_document* session_doc_{nullptr};
 	wxComboBox* view_choice{nullptr};
 	wxListBox* links_list{nullptr};
 	wxTreeCtrl* headings_tree{nullptr};
@@ -226,7 +226,7 @@ private:
 
 class go_to_page_dialog : public dialog {
 public:
-	go_to_page_dialog(wxWindow* parent, document* doc, const parser_info* parser, int current_page = 1);
+	go_to_page_dialog(wxWindow* parent, session_document* session_doc, int current_page = 1);
 	~go_to_page_dialog() override = default;
 	go_to_page_dialog(const go_to_page_dialog&) = delete;
 	go_to_page_dialog& operator=(const go_to_page_dialog&) = delete;
@@ -235,8 +235,7 @@ public:
 	[[nodiscard]] int get_page_number() const;
 
 private:
-	document* doc_{nullptr};
-	const parser_info* parser_{nullptr};
+	session_document* session_doc_{nullptr};
 	wxSpinCtrl* input_ctrl{nullptr};
 
 	[[nodiscard]] int get_max_page() const;
@@ -384,7 +383,7 @@ public:
 
 class toc_dialog : public dialog {
 public:
-	toc_dialog(wxWindow* parent, const document* doc, int current_offset = -1);
+	toc_dialog(wxWindow* parent, session_document* session_doc, int current_offset = -1);
 	~toc_dialog() override = default;
 	toc_dialog(const toc_dialog&) = delete;
 	toc_dialog& operator=(const toc_dialog&) = delete;

--- a/app/document_data.hpp
+++ b/app/document_data.hpp
@@ -58,6 +58,8 @@ struct session_document {
 	[[nodiscard]] wxString get_author() const { return wxString::FromUTF8(session_author(*session).c_str()); }
 	[[nodiscard]] const DocumentHandle& get_handle() const { return session_handle(*session); }
 	[[nodiscard]] uint32_t get_parser_flags() const { return session_parser_flags(*session); }
+	void ensure_toc_loaded();
+	[[nodiscard]] size_t find_closest_toc_offset(size_t position) const { return document_find_closest_toc_offset(get_handle(), position); }
 };
 
 // Legacy type - kept for compilation compatibility during migration

--- a/app/main_window.cpp
+++ b/app/main_window.cpp
@@ -604,12 +604,12 @@ void main_window::on_go_forward(wxCommandEvent&) {
 }
 
 void main_window::on_go_to_page(wxCommandEvent&) {
-	auto* const doc = doc_manager->get_active_document();
-	const auto* const parser = doc_manager->get_active_parser();
-	if (doc == nullptr || parser == nullptr) {
+	auto* const tab = doc_manager->get_active_tab();
+	if (tab == nullptr || tab->session_doc == nullptr) {
 		return;
 	}
-	if (!parser_supports(parser->flags, parser_flags::supports_pages)) {
+	const size_t total_pages = doc_manager->marker_count(marker_type::PageBreak);
+	if (total_pages == 0) {
 		speak(_("No pages."));
 		return;
 	}
@@ -623,12 +623,11 @@ void main_window::on_go_to_page(wxCommandEvent&) {
 	if (current_page_idx >= 0) {
 		current_page = current_page_idx + 1; // Convert to 1-based index
 	}
-	go_to_page_dialog dlg(this, doc, parser, current_page);
+	go_to_page_dialog dlg(this, tab->session_doc.get(), current_page);
 	if (dlg.ShowModal() != wxID_OK) {
 		return;
 	}
 	const int page = dlg.get_page_number();
-	const size_t total_pages = doc_manager->marker_count(marker_type::PageBreak);
 	if (page >= 1 && std::cmp_less_equal(static_cast<size_t>(page), total_pages)) {
 		const size_t offset = doc_manager->marker_position_by_index(marker_type::PageBreak, page - 1); // Convert to 0-based index
 		doc_manager->go_to_position(static_cast<long>(offset));
@@ -806,8 +805,8 @@ void main_window::on_toc(wxCommandEvent&) {
 }
 
 void main_window::on_list_elements(wxCommandEvent&) {
-	auto* const doc = doc_manager->get_active_document();
-	if (doc == nullptr) {
+	auto* const tab = doc_manager->get_active_tab();
+	if (tab == nullptr || tab->session_doc == nullptr) {
 		return;
 	}
 	auto* const text_ctrl = doc_manager->get_active_text_ctrl();
@@ -815,7 +814,7 @@ void main_window::on_list_elements(wxCommandEvent&) {
 		return;
 	}
 	const long current_pos = text_ctrl->GetInsertionPoint();
-	elements_dialog dlg(this, doc, current_pos);
+	elements_dialog dlg(this, tab->session_doc.get(), current_pos);
 	if (dlg.ShowModal() != wxID_OK) {
 		return;
 	}


### PR DESCRIPTION
## Summary

This PR completes the DocumentSession migration started in 2c040ee, restoring all navigation functionality that was temporarily disabled.

- Wire up all navigation methods (page, heading, link, list, table, section) to use DocumentSession APIs
- Fix "Go to Page" dialog to work with the new session-based architecture
- Fix "Elements" dialog (headings/links list) to properly populate from DocumentSession
- Implement `page_index`, `marker_count`, and `marker_position_by_index` methods that were stubbed out

Fixes #232
