### PR TITLE
Apply cargo +nightly fmt to fix CI format check

### DIFF
--- a/src/ui/dialogs.rs
+++ b/src/ui/dialogs.rs
@@ -216,8 +216,7 @@ fn build_options_dialog_ui(parent: &Frame, config: &ConfigManager) -> OptionsDia
 	let bg_group_box = StaticBox::builder(&readability_panel).with_label(&t("Background Color")).build();
 	let bg_group_sizer = StaticBoxSizerBuilder::new_with_box(&bg_group_box, Orientation::Vertical).build();
 	let bg_color_label = StaticText::builder(&readability_panel).with_label("").build();
-	let choose_bg_button =
-		Button::builder(&readability_panel).with_label(&t("Choose &Background Color...")).build();
+	let choose_bg_button = Button::builder(&readability_panel).with_label(&t("Choose &Background Color...")).build();
 	let reset_bg_button = Button::builder(&readability_panel).with_label(&t("Reset to &Default Background")).build();
 	bg_group_sizer.add(&bg_color_label, 0, SizerFlag::All, option_padding);
 	bg_group_sizer.add(&choose_bg_button, 0, SizerFlag::All, option_padding);
@@ -234,8 +233,7 @@ fn build_options_dialog_ui(parent: &Frame, config: &ConfigManager) -> OptionsDia
 	line_spacing_sizer.add(&line_spacing_label, 0, SizerFlag::AlignCenterVertical | SizerFlag::Right, DIALOG_PADDING);
 	line_spacing_sizer.add(&line_spacing_ctrl, 0, SizerFlag::AlignCenterVertical, 0);
 
-	let paragraph_spacing_label =
-		StaticText::builder(&readability_panel).with_label(&t("&Paragraph spacing:")).build();
+	let paragraph_spacing_label = StaticText::builder(&readability_panel).with_label(&t("&Paragraph spacing:")).build();
 	let paragraph_spacing_ctrl = Choice::builder(&readability_panel).build();
 	paragraph_spacing_ctrl.append(&t("Normal"));
 	paragraph_spacing_ctrl.append(&t("Relaxed"));
@@ -249,8 +247,7 @@ fn build_options_dialog_ui(parent: &Frame, config: &ConfigManager) -> OptionsDia
 	);
 	paragraph_spacing_sizer.add(&paragraph_spacing_ctrl, 0, SizerFlag::AlignCenterVertical, 0);
 
-	let letter_spacing_label =
-		StaticText::builder(&readability_panel).with_label(&t("L&etter spacing:")).build();
+	let letter_spacing_label = StaticText::builder(&readability_panel).with_label(&t("L&etter spacing:")).build();
 	let letter_spacing_ctrl = Choice::builder(&readability_panel).build();
 	letter_spacing_ctrl.append(&t("Normal"));
 	letter_spacing_ctrl.append(&t("Wide"));
@@ -264,8 +261,7 @@ fn build_options_dialog_ui(parent: &Frame, config: &ConfigManager) -> OptionsDia
 	);
 	letter_spacing_sizer.add(&letter_spacing_ctrl, 0, SizerFlag::AlignCenterVertical, 0);
 
-	let text_alignment_label =
-		StaticText::builder(&readability_panel).with_label(&t("Text &alignment:")).build();
+	let text_alignment_label = StaticText::builder(&readability_panel).with_label(&t("Text &alignment:")).build();
 	let text_alignment_ctrl = Choice::builder(&readability_panel).build();
 	text_alignment_ctrl.append(&t("Left"));
 	text_alignment_ctrl.append(&t("Center"));

--- a/src/ui/document_manager.rs
+++ b/src/ui/document_manager.rs
@@ -674,7 +674,7 @@ pub fn apply_text_alignment_to_ctrl(text_ctrl: TextCtrl, alignment: i32) {
 	use windows::Win32::{
 		Foundation::{HWND, LPARAM, WPARAM},
 		UI::{
-			Controls::RichEdit::{PARAFORMAT2, PFM_ALIGNMENT, PFA_CENTER, PFA_JUSTIFY, PFA_LEFT, PFA_RIGHT},
+			Controls::RichEdit::{PARAFORMAT2, PFA_CENTER, PFA_JUSTIFY, PFA_LEFT, PFA_RIGHT, PFM_ALIGNMENT},
 			WindowsAndMessaging::SendMessageW,
 		},
 	};
@@ -708,8 +708,10 @@ pub fn apply_text_alignment_to_ctrl(_text_ctrl: TextCtrl, _alignment: i32) {}
 pub fn apply_letter_spacing_to_ctrl(text_ctrl: TextCtrl, spacing: i32) {
 	use windows::Win32::{
 		Foundation::{HWND, LPARAM, WPARAM},
-		UI::Controls::RichEdit::{CHARFORMAT2W, CFM_SPACING},
-		UI::WindowsAndMessaging::SendMessageW,
+		UI::{
+			Controls::RichEdit::{CFM_SPACING, CHARFORMAT2W},
+			WindowsAndMessaging::SendMessageW,
+		},
 	};
 	const EM_SETSEL: u32 = 177;
 	const EM_SETCHARFORMAT: u32 = 1092;
@@ -731,12 +733,7 @@ pub fn apply_letter_spacing_to_ctrl(text_ctrl: TextCtrl, spacing: i32) {
 		cf.Base.cbSize = std::mem::size_of::<CHARFORMAT2W>() as u32;
 		cf.Base.dwMask = CFM_SPACING;
 		cf.sSpacing = spacing_twips;
-		SendMessageW(
-			hwnd,
-			EM_SETCHARFORMAT,
-			Some(WPARAM(SCF_ALL as usize)),
-			Some(LPARAM(&raw const cf as isize)),
-		);
+		SendMessageW(hwnd, EM_SETCHARFORMAT, Some(WPARAM(SCF_ALL as usize)), Some(LPARAM(&raw const cf as isize)));
 	}
 }
 


### PR DESCRIPTION
## Summary

The CI `Format check` job (`cargo +nightly fmt --check`) has been failing on `master` since commits c2d7b35 (readability options) and 068ea5e (format and new strings) landed on Apr 8. The recent bitflags dependabot PR (#415) just happened to surface it again because CI re-ran on that commit.

This PR applies `cargo +nightly fmt` to bring the two affected files back in line with `rustfmt.toml`. Purely mechanical — no behavior changes.

**Affected files:**
- `src/ui/dialogs.rs` — collapse 4 multi-line `let` declarations to single lines (rustfmt.toml uses `use_small_heuristics = "Max"` with `max_width = 120`, so these fit on one line)
- `src/ui/document_manager.rs` — alphabetize one import list, merge two separate `UI::...` imports into one grouped form, collapse a multi-line `SendMessageW(...)` call

Verified locally with `cargo +nightly fmt --check` (clean after applying).

## Test plan

- [x] `cargo +nightly fmt --check` passes locally
- [ ] CI `Format check` job passes on this PR
- [ ] CI `Tests and clippy` job still passes (no logic changed, so expected)