### PR TITLE
add tabbed documents, links, and headings support.

### DIFF
--- a/android/.editorconfig
+++ b/android/.editorconfig
@@ -1,0 +1,20 @@
+root = true
+
+	[*.{kt,kts}]
+	indent_style = tab
+	indent_size = 4
+	tab_width = 4
+	max_line_length = 120
+	insert_final_newline = true
+	trim_trailing_whitespace = true
+	ktlint_standard_no-consecutive-blank-lines = enabled
+	ktlint_standard_no-wildcard-imports = disabled
+	ktlint_standard_function-naming = disabled
+	ktlint_standard_filename = disabled
+	ktlint_standard_multiline-expression-wrapping = disabled
+	ktlint_standard_argument-list-wrapping = disabled
+	ktlint_standard_trailing-comma-on-call-site = disabled
+	ktlint_standard_trailing-comma-on-declaration-site = disabled
+
+	[**/uniffi/**.kt]
+	ktlint_disabled_rules = *

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -2,6 +2,7 @@ plugins {
 	alias(libs.plugins.android.application)
 	alias(libs.plugins.compose.compiler)
 	alias(libs.plugins.kotlin.serialization)
+	alias(libs.plugins.ktlint)
 }
 
 android {
@@ -41,6 +42,12 @@ android {
 
 kotlin {
 	jvmToolchain(17)
+}
+
+ktlint {
+	filter {
+		exclude("**/uniffi/**")
+	}
 }
 
 dependencies {

--- a/android/app/src/main/java/dev/paperback/mobile/Navigation.kt
+++ b/android/app/src/main/java/dev/paperback/mobile/Navigation.kt
@@ -16,10 +16,13 @@ fun MainNavigation() {
 	NavDisplay(
 		backStack = backStack,
 		onBack = { backStack.removeLastOrNull() },
-		entryProvider = entryProvider {
-			entry<Main> {
-				MainScreen(onItemClick = { navKey -> backStack.add(navKey) }, modifier = Modifier.safeDrawingPadding().padding(16.dp))
-			}
-		},
+		entryProvider =
+			entryProvider {
+				entry<Main> {
+					MainScreen(onItemClick = { navKey ->
+						backStack.add(navKey)
+					}, modifier = Modifier.safeDrawingPadding().padding(16.dp))
+				}
+			},
 	)
 }

--- a/android/app/src/main/java/dev/paperback/mobile/theme/Theme.kt
+++ b/android/app/src/main/java/dev/paperback/mobile/theme/Theme.kt
@@ -20,13 +20,14 @@ fun MyApplicationTheme(
 	dynamicColor: Boolean = true,
 	content: @Composable () -> Unit,
 ) {
-	val colorScheme = when {
-		dynamicColor && Build.VERSION.SDK_INT >= Build.VERSION_CODES.S -> {
-			val context = LocalContext.current
-			if (darkTheme) dynamicDarkColorScheme(context) else dynamicLightColorScheme(context)
+	val colorScheme =
+		when {
+			dynamicColor && Build.VERSION.SDK_INT >= Build.VERSION_CODES.S -> {
+				val context = LocalContext.current
+				if (darkTheme) dynamicDarkColorScheme(context) else dynamicLightColorScheme(context)
+			}
+			darkTheme -> DarkColorScheme
+			else -> LightColorScheme
 		}
-		darkTheme -> DarkColorScheme
-		else -> LightColorScheme
-	}
 	MaterialTheme(colorScheme = colorScheme, typography = Typography, content = content)
 }

--- a/android/app/src/main/java/dev/paperback/mobile/theme/Type.kt
+++ b/android/app/src/main/java/dev/paperback/mobile/theme/Type.kt
@@ -6,12 +6,14 @@ import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.sp
 
-val Typography = Typography(
-	bodyLarge = TextStyle(
-		fontFamily = FontFamily.Default,
-		fontWeight = FontWeight.Normal,
-		fontSize = 16.sp,
-		lineHeight = 24.sp,
-		letterSpacing = 0.5.sp,
+val Typography =
+	Typography(
+		bodyLarge =
+			TextStyle(
+				fontFamily = FontFamily.Default,
+				fontWeight = FontWeight.Normal,
+				fontSize = 16.sp,
+				lineHeight = 24.sp,
+				letterSpacing = 0.5.sp,
+			),
 	)
-)

--- a/android/app/src/main/java/dev/paperback/mobile/ui/MainScreen.kt
+++ b/android/app/src/main/java/dev/paperback/mobile/ui/MainScreen.kt
@@ -1,12 +1,13 @@
 package dev.paperback.mobile.ui
 
+import android.content.Intent
 import android.net.Uri
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.focusable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.text.selection.SelectionContainer
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
@@ -14,12 +15,29 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.semantics.CustomAccessibilityAction
+import androidx.compose.ui.semantics.clearAndSetSemantics
+import androidx.compose.ui.semantics.customActions
+import androidx.compose.ui.semantics.heading
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.stateDescription
+import androidx.compose.ui.semantics.text
+import androidx.compose.ui.text.LinkAnnotation
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.TextLinkStyles
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextDecoration
+import androidx.compose.ui.text.withLink
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation3.runtime.NavKey
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.launch
+import uniffi.paperback.LinkActionFfi
+import uniffi.paperback.MarkerTypeFfi
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -30,34 +48,77 @@ fun MainScreen(
 ) {
 	val state by viewModel.uiState.collectAsStateWithLifecycle()
 	val scope = rememberCoroutineScope()
-	val listState = rememberLazyListState()
+	val listStates = remember { mutableStateMapOf<String, LazyListState>() }
 	var tocSheetOpen by remember { mutableStateOf(false) }
 	var lineIndexToFocus by remember { mutableStateOf<Int?>(null) }
 	var expandedTocIndices by remember { mutableStateOf(setOf<Int>()) }
-	val launcher = rememberLauncherForActivityResult(
-		contract = ActivityResultContracts.OpenDocument()
-	) { uri: Uri? ->
+	val context = LocalContext.current
+
+	val launcher = rememberLauncherForActivityResult(contract = ActivityResultContracts.OpenDocument()) { uri: Uri? ->
 		if (uri != null) {
 			viewModel.openDocument(uri)
 		}
 	}
+
 	Scaffold(
 		topBar = {
-			TopAppBar(
-				title = { Text("Paperback") },
-				navigationIcon = {
-					if (state is MainScreenUiState.Success) {
-						TextButton(onClick = { tocSheetOpen = true }) {
-							Text("Table of Contents")
+			Column {
+				TopAppBar(
+					title = { Text("Paperback") },
+					navigationIcon = {
+						if (state is MainScreenUiState.Success && (state as MainScreenUiState.Success).activeTab != null) {
+							TextButton(onClick = { tocSheetOpen = true }) {
+								Text("Table of Contents")
+							}
+						}
+					},
+					actions = {
+						Button(onClick = { launcher.launch(arrayOf("*/*")) }) {
+							Text("Open Book")
 						}
 					}
-				},
-				actions = {
-					Button(onClick = { launcher.launch(arrayOf("*/*")) }) {
-						Text("Open Book")
+				)
+				if (state is MainScreenUiState.Success) {
+					val successState = state as MainScreenUiState.Success
+					if (successState.tabs.isNotEmpty()) {
+						PrimaryScrollableTabRow(
+							selectedTabIndex = successState.activeTabIndex,
+							edgePadding = 8.dp,
+							modifier = Modifier.fillMaxWidth()
+						) {
+							successState.tabs.forEachIndexed { index, tab ->
+								Tab(
+									selected = successState.activeTabIndex == index,
+									onClick = { viewModel.setActiveTab(index) },
+									modifier = Modifier.semantics {
+										customActions = listOf(
+											CustomAccessibilityAction(
+												label = "Close ${tab.title}",
+												action = {
+													viewModel.closeTab(index)
+													true
+												}
+											)
+										)
+									},
+									text = {
+										Row(verticalAlignment = Alignment.CenterVertically) {
+											Text(tab.title, maxLines = 1, modifier = Modifier.widthIn(max = 150.dp))
+											Spacer(modifier = Modifier.width(4.dp))
+											IconButton(
+												onClick = { viewModel.closeTab(index) },
+												modifier = Modifier.size(24.dp).clearAndSetSemantics { }
+											) {
+												Text("X", fontWeight = FontWeight.Bold)
+											}
+										}
+									}
+								)
+							}
+						}
 					}
 				}
-			)
+			}
 		}
 	) { padding ->
 		Column(modifier = modifier.fillMaxSize().padding(padding)) {
@@ -73,82 +134,200 @@ fun MainScreen(
 					}
 				}
 				is MainScreenUiState.Success -> {
-					val docState = state as MainScreenUiState.Success
+					val successState = state as MainScreenUiState.Success
+					val docState = successState.activeTab
 
-					// Scroll to saved position (or top for new books) then start tracking
-					LaunchedEffect(docState.session) {
-						listState.scrollToItem(docState.initialScrollIndex)
-						snapshotFlow { listState.firstVisibleItemIndex }
-							.distinctUntilChanged()
-							.collect { index -> viewModel.savePosition(docState.session, docState.documentUri, index) }
-					}
+					if (docState != null) {
+						val listState = listStates.getOrPut(docState.documentUri) {
+							LazyListState(firstVisibleItemIndex = docState.initialScrollIndex)
+						}
 
-					SelectionContainer {
-						LazyColumn(
-							state = listState,
-							modifier = Modifier.fillMaxSize(),
-							contentPadding = PaddingValues(16.dp)
-						) {
-							items(docState.lineCount.toInt()) { index ->
-								val pos = docState.session.positionFromLine((index + 1).toLong())
-								val lineText = docState.session.getLineText(pos)
-								if (lineText.isNotBlank()) {
-									val focusRequester = remember { FocusRequester() }
-									var isTemporaryFocusTarget by remember { mutableStateOf(lineIndexToFocus == index) }
-									LaunchedEffect(lineIndexToFocus) {
-										if (lineIndexToFocus == index) {
-											isTemporaryFocusTarget = true
-										}
-									}
-									val textModifier = if (isTemporaryFocusTarget) {
-										Modifier.focusRequester(focusRequester).focusable()
-									} else {
-										Modifier
-									}
-									Text(
-										text = lineText.trimEnd(),
-										style = MaterialTheme.typography.bodyLarge,
-										modifier = textModifier.padding(vertical = 4.dp)
-									)
-									if (isTemporaryFocusTarget) {
-										LaunchedEffect(Unit) {
-											kotlinx.coroutines.delay(700)
-											try {
-												focusRequester.requestFocus()
-											} catch (e: Exception) {}
-											kotlinx.coroutines.delay(1500)
-											isTemporaryFocusTarget = false
+						// Track the scroll position
+						LaunchedEffect(docState.documentUri) {
+							snapshotFlow { listState.firstVisibleItemIndex }
+								.distinctUntilChanged()
+								.collect { index -> viewModel.savePosition(docState.session, docState.documentUri, index) }
+						}
+
+						SelectionContainer {
+							LazyColumn(
+								state = listState,
+								modifier = Modifier.fillMaxSize(),
+								contentPadding = PaddingValues(16.dp)
+							) {
+								items(docState.lineCount.toInt()) { index ->
+									val lineNum = (index + 1).toLong()
+									val pos = docState.session.positionFromLine(lineNum)
+									val lineText = docState.session.getLineText(pos).trimEnd()
+									val markers = docState.session.getLineMarkers(lineNum)
+									
+									if (lineText.isNotBlank()) {
+										val focusRequester = remember { FocusRequester() }
+										var isTemporaryFocusTarget by remember { mutableStateOf(lineIndexToFocus == index) }
+										LaunchedEffect(lineIndexToFocus) {
 											if (lineIndexToFocus == index) {
-												lineIndexToFocus = null
+												isTemporaryFocusTarget = true
+											}
+										}
+										
+										var textModifier = Modifier.padding(vertical = 4.dp)
+										var isHeading = false
+										var headingLevel = 0
+										
+										val annotatedString = buildAnnotatedString {
+											var currentIdx = 0
+											val sortedMarkers = markers.sortedBy { it.position }
+										
+											sortedMarkers.forEach { marker ->
+												when (marker.mtype) {
+													MarkerTypeFfi.HEADING1 -> {
+														isHeading = true
+														headingLevel = 1
+													}
+													MarkerTypeFfi.HEADING2 -> {
+														isHeading = true
+														headingLevel = 2
+													}
+													MarkerTypeFfi.HEADING3 -> {
+														isHeading = true
+														headingLevel = 3
+													}
+													MarkerTypeFfi.HEADING4 -> {
+														isHeading = true
+														headingLevel = 4
+													}
+													MarkerTypeFfi.HEADING5 -> {
+														isHeading = true
+														headingLevel = 5
+													}
+													MarkerTypeFfi.HEADING6 -> {
+														isHeading = true
+														headingLevel = 6
+													}
+													MarkerTypeFfi.LINK -> {
+														val markerStartInLine = (marker.position - pos).toInt().coerceAtLeast(0)
+														val markerTextLength = marker.text.length
+													
+														if (markerStartInLine > currentIdx) {
+															append(lineText.substring(currentIdx, markerStartInLine.coerceAtMost(lineText.length)))
+															currentIdx = markerStartInLine
+														}
+													
+														if (currentIdx < lineText.length) {
+															val linkEnd = (currentIdx + markerTextLength).coerceAtMost(lineText.length)
+															val linkText = lineText.substring(currentIdx, linkEnd)
+														
+															val linkAnnotation = LinkAnnotation.Clickable(
+																tag = marker.position.toString(),
+																styles = TextLinkStyles(
+																	style = SpanStyle(
+																		color = MaterialTheme.colorScheme.primary,
+																		textDecoration = TextDecoration.Underline
+																	)
+																)
+															) {
+																val result = docState.session.activateLinkFfi(marker.position)
+																if (result.found) {
+																	when (result.action) {
+																		LinkActionFfi.EXTERNAL -> {
+																			val intent = Intent(Intent.ACTION_VIEW, Uri.parse(result.url))
+																			context.startActivity(intent)
+																		}
+																		LinkActionFfi.INTERNAL -> {
+																			val targetLine = docState.session.lineFromPosition(result.offset)
+																			val targetIndex = (targetLine - 1).toInt().coerceAtLeast(0)
+																			scope.launch {
+																				listState.scrollToItem(targetIndex)
+																				lineIndexToFocus = targetIndex
+																			}
+																		}
+																		else -> {}
+																	}
+																}
+															}
+														
+															withLink(linkAnnotation) {
+																append(linkText)
+															}
+															currentIdx = linkEnd
+														}
+													}
+													else -> {}
+												}
+											}
+										
+											if (currentIdx < lineText.length) {
+												append(lineText.substring(currentIdx))
+											}
+										}
+										
+										if (isHeading) {
+											textModifier = textModifier.semantics {
+												heading()
+												if (headingLevel > 0) {
+													stateDescription = "Heading $headingLevel"
+												}
+											}
+										}
+
+										if (isTemporaryFocusTarget) {
+											textModifier = textModifier.focusRequester(focusRequester).focusable()
+										}
+										
+										val textStyle = if (isHeading) {
+											MaterialTheme.typography.bodyLarge.copy(fontWeight = FontWeight.Bold)
+										} else {
+											MaterialTheme.typography.bodyLarge
+										}
+										
+										Text(
+											text = annotatedString,
+											style = textStyle,
+											modifier = textModifier
+										)
+										
+										if (isTemporaryFocusTarget) {
+											LaunchedEffect(Unit) {
+												kotlinx.coroutines.delay(700)
+												try {
+													focusRequester.requestFocus()
+												} catch (e: Exception) {
+												}
+												kotlinx.coroutines.delay(1500)
+												isTemporaryFocusTarget = false
+												if (lineIndexToFocus == index) {
+													lineIndexToFocus = null
+												}
 											}
 										}
 									}
 								}
 							}
 						}
-					}
-					if (tocSheetOpen) {
-						TocSheet(
-							toc = docState.toc,
-							expandedTocIndices = expandedTocIndices,
-							onToggleExpand = { originalIndex ->
-								expandedTocIndices = if (expandedTocIndices.contains(originalIndex)) {
-									expandedTocIndices - originalIndex
-								} else {
-									expandedTocIndices + originalIndex
-								}
-							},
-							onItemClick = { item ->
-								val line = docState.session.lineFromPosition(item.position)
-								val indexToScroll = (line - 1).toInt().coerceAtLeast(0)
-								scope.launch {
-									tocSheetOpen = false
-									listState.scrollToItem(indexToScroll)
-									lineIndexToFocus = indexToScroll
-								}
-							},
-							onDismiss = { tocSheetOpen = false }
-						)
+						
+						if (tocSheetOpen) {
+							TocSheet(
+								toc = docState.toc,
+								expandedTocIndices = expandedTocIndices,
+								onToggleExpand = { originalIndex ->
+									expandedTocIndices = if (expandedTocIndices.contains(originalIndex)) {
+										expandedTocIndices - originalIndex
+									} else {
+										expandedTocIndices + originalIndex
+									}
+								},
+								onItemClick = { item ->
+									val line = docState.session.lineFromPosition(item.position)
+									val indexToScroll = (line - 1).toInt().coerceAtLeast(0)
+									scope.launch {
+										tocSheetOpen = false
+										listState.scrollToItem(indexToScroll)
+										lineIndexToFocus = indexToScroll
+									}
+								},
+								onDismiss = { tocSheetOpen = false }
+							)
+						}
 					}
 				}
 				is MainScreenUiState.Error -> {

--- a/android/app/src/main/java/dev/paperback/mobile/ui/MainScreenViewModel.kt
+++ b/android/app/src/main/java/dev/paperback/mobile/ui/MainScreenViewModel.kt
@@ -16,23 +16,38 @@ import uniffi.paperback.DocumentSession
 import uniffi.paperback.TocEntry
 import java.io.File
 import java.io.FileOutputStream
+import java.util.UUID
+
+data class DocumentTabState(
+	val session: DocumentSession,
+	val title: String,
+	val author: String,
+	val lineCount: Long,
+	val toc: List<TocEntry>,
+	val documentUri: String,
+	val initialScrollIndex: Int = 0
+)
 
 sealed class MainScreenUiState {
 	object Idle : MainScreenUiState()
+
 	object Loading : MainScreenUiState()
+
 	data class Success(
-		val session: DocumentSession,
-		val title: String,
-		val author: String,
-		val lineCount: Long,
-		val toc: List<TocEntry>,
-		val documentUri: String,
-		val initialScrollIndex: Int = 0,
+		val tabs: List<DocumentTabState>,
+		val activeTabIndex: Int
+	) : MainScreenUiState() {
+		val activeTab: DocumentTabState? get() = tabs.getOrNull(activeTabIndex)
+	}
+
+	data class Error(
+		val message: String
 	) : MainScreenUiState()
-	data class Error(val message: String) : MainScreenUiState()
 }
 
-class MainScreenViewModel(application: Application) : AndroidViewModel(application) {
+class MainScreenViewModel(
+	application: Application
+) : AndroidViewModel(application) {
 	private val context get() = getApplication<Application>()
 
 	private val config = ConfigManagerFfi().also {
@@ -42,12 +57,23 @@ class MainScreenViewModel(application: Application) : AndroidViewModel(applicati
 	private val _uiState = MutableStateFlow<MainScreenUiState>(MainScreenUiState.Idle)
 	val uiState: StateFlow<MainScreenUiState> = _uiState
 
+	private val currentTabs = mutableListOf<DocumentTabState>()
+	private var currentActiveIndex = -1
+
 	init {
-		val lastUri = config.getRecentDocuments().firstOrNull()
-		if (lastUri != null) {
-			viewModelScope.launch {
-				val savedPosition = config.getDocumentPosition(lastUri)
-				loadDocument(Uri.parse(lastUri), savedPosition)
+		viewModelScope.launch {
+			val openedUris = config.getOpenedDocuments()
+			if (openedUris.isNotEmpty()) {
+				openedUris.forEach { uriString ->
+					val savedPosition = config.getDocumentPosition(uriString)
+					loadDocument(Uri.parse(uriString), savedPosition)
+				}
+			} else {
+				val lastUri = config.getRecentDocuments().firstOrNull()
+				if (lastUri != null) {
+					val savedPosition = config.getDocumentPosition(lastUri)
+					loadDocument(Uri.parse(lastUri), savedPosition)
+				}
 			}
 		}
 	}
@@ -56,17 +82,44 @@ class MainScreenViewModel(application: Application) : AndroidViewModel(applicati
 		val uriString = uri.toString()
 		viewModelScope.launch(Dispatchers.IO) {
 			try {
-				context.contentResolver.takePersistableUriPermission(
-					uri, Intent.FLAG_GRANT_READ_URI_PERMISSION
-				)
-			} catch (_: SecurityException) {}
+				context.contentResolver.takePersistableUriPermission(uri, Intent.FLAG_GRANT_READ_URI_PERMISSION)
+			} catch (_: SecurityException) {
+			}
 			config.addRecentDocument(uriString)
+			config.addOpenedDocument(uriString)
 			config.setDocumentPosition(uriString, 0L)
 			loadDocument(uri, 0L)
 		}
 	}
 
-	fun savePosition(session: DocumentSession, documentUri: String, scrollIndex: Int) {
+	fun closeTab(index: Int) {
+		if (index in currentTabs.indices) {
+			val closedTab = currentTabs.removeAt(index)
+			viewModelScope.launch(Dispatchers.IO) {
+				config.removeOpenedDocument(closedTab.documentUri)
+			}
+			if (currentTabs.isEmpty()) {
+				currentActiveIndex = -1
+				_uiState.value = MainScreenUiState.Idle
+			} else {
+				currentActiveIndex = currentActiveIndex.coerceIn(0, currentTabs.size - 1)
+				_uiState.value = MainScreenUiState.Success(currentTabs.toList(), currentActiveIndex)
+			}
+		}
+	}
+
+	fun setActiveTab(index: Int) {
+		if (index in currentTabs.indices && index != currentActiveIndex) {
+			currentActiveIndex = index
+			_uiState.value = MainScreenUiState.Success(currentTabs.toList(), currentActiveIndex)
+		}
+	}
+
+	fun savePosition(
+		session: DocumentSession,
+		documentUri: String,
+		scrollIndex: Int
+	) {
 		val position = session.positionFromLine((scrollIndex + 1).toLong())
 		config.setDocumentPosition(documentUri, position)
 	}
@@ -75,14 +128,17 @@ class MainScreenViewModel(application: Application) : AndroidViewModel(applicati
 		config.flush()
 	}
 
-	private suspend fun loadDocument(uri: Uri, savedPosition: Long) = withContext(Dispatchers.IO) {
+	private suspend fun loadDocument(
+		uri: Uri,
+		savedPosition: Long
+	) = withContext(Dispatchers.IO) {
 		_uiState.value = MainScreenUiState.Loading
 		try {
-			val inputStream = context.contentResolver.openInputStream(uri)
-				?: run {
-					_uiState.value = MainScreenUiState.Error("Failed to open file")
-					return@withContext
-				}
+			val inputStream = context.contentResolver.openInputStream(uri) ?: run {
+				_uiState.value = MainScreenUiState.Error("Failed to open file")
+				return@withContext
+			}
+			
 			var displayName = ""
 			context.contentResolver.query(uri, null, null, null, null)?.use { cursor ->
 				if (cursor.moveToFirst()) {
@@ -90,27 +146,45 @@ class MainScreenViewModel(application: Application) : AndroidViewModel(applicati
 					if (nameIndex != -1) displayName = cursor.getString(nameIndex)
 				}
 			}
+			
 			val ext = displayName.substringAfterLast('.', "epub").lowercase()
-			val tempFile = File(context.cacheDir, "doc_${java.util.UUID.randomUUID()}.$ext")
+			val tempFile = File(context.cacheDir, "doc_${UUID.randomUUID()}.$ext")
 			FileOutputStream(tempFile).use { inputStream.copyTo(it) }
 			inputStream.close()
+
 			val session = DocumentSession.newFfi(tempFile.absolutePath, "", "")
 			val initialScrollIndex = if (savedPosition > 0L) {
 				(session.lineFromPosition(savedPosition) - 1L).toInt().coerceAtLeast(0)
 			} else {
 				0
 			}
-			_uiState.value = MainScreenUiState.Success(
+
+			val tabState = DocumentTabState(
 				session = session,
-				title = session.title(),
+				title = session.title().ifBlank { displayName },
 				author = session.author(),
 				lineCount = session.lineCount(),
 				toc = session.getToc(),
 				documentUri = uri.toString(),
-				initialScrollIndex = initialScrollIndex,
+				initialScrollIndex = initialScrollIndex
 			)
+
+			// Check if already open
+			val existingIndex = currentTabs.indexOfFirst { it.documentUri == tabState.documentUri }
+			if (existingIndex != -1) {
+				currentActiveIndex = existingIndex
+			} else {
+				currentTabs.add(tabState)
+				currentActiveIndex = currentTabs.size - 1
+			}
+
+			_uiState.value = MainScreenUiState.Success(tabs = currentTabs.toList(), activeTabIndex = currentActiveIndex)
 		} catch (e: Exception) {
 			_uiState.value = MainScreenUiState.Error(e.message ?: "Unknown error")
+			// Restore previous success state if possible
+			if (currentTabs.isNotEmpty()) {
+				_uiState.value = MainScreenUiState.Success(currentTabs.toList(), currentActiveIndex)
+			}
 		}
 	}
 }

--- a/android/app/src/main/java/dev/paperback/mobile/ui/TocSheet.kt
+++ b/android/app/src/main/java/dev/paperback/mobile/ui/TocSheet.kt
@@ -11,7 +11,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.semantics.clearAndSetSemantics
 import androidx.compose.ui.semantics.contentDescription
-import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.semantics.stateDescription
 import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.launch
@@ -45,10 +44,8 @@ fun TocSheet(
 		}
 		result
 	}
-	ModalBottomSheet(
-		onDismissRequest = onDismiss,
-		sheetState = sheetState
-	) {
+	
+	ModalBottomSheet(onDismissRequest = onDismiss, sheetState = sheetState) {
 		LazyColumn(contentPadding = PaddingValues(bottom = 32.dp)) {
 			item {
 				Text(
@@ -74,14 +71,12 @@ fun TocSheet(
 									onItemClick(item)
 								}
 							}
-						}
-						.clearAndSetSemantics {
+						}.clearAndSetSemantics {
 							contentDescription = "${item.title}, Level ${item.level + 1}"
 							if (hasChildren) {
 								stateDescription = if (isExpanded) "Expanded" else "Collapsed"
 							}
-						}
-						.padding(start = paddingLeft, end = 16.dp, top = 12.dp, bottom = 12.dp),
+						}.padding(start = paddingLeft, end = 16.dp, top = 12.dp, bottom = 12.dp),
 					verticalAlignment = Alignment.CenterVertically
 				) {
 					if (hasChildren) {

--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -2,4 +2,5 @@ plugins {
 	alias(libs.plugins.android.application) apply false
 	alias(libs.plugins.compose.compiler) apply false
 	alias(libs.plugins.kotlin.serialization) apply false
+	alias(libs.plugins.ktlint)
 }

--- a/android/gradle/libs.versions.toml
+++ b/android/gradle/libs.versions.toml
@@ -11,6 +11,7 @@ androidxTestEspresso = "3.7.0"
 coroutines = "1.10.2"
 junit = "4.13.2"
 kotlin = "2.3.20"
+ktlintPlugin = "14.2.0"
 nav3Core = "1.0.1"
 lifecycleViewmodelNav3 = "2.10.0"
 
@@ -41,3 +42,4 @@ androidx-lifecycle-viewmodel-navigation3 = { module = "androidx.lifecycle:lifecy
 android-application = { id = "com.android.application", version.ref = "androidGradlePlugin" }
 compose-compiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
+ktlint = { id = "org.jlleitschuh.gradle.ktlint", version.ref = "ktlintPlugin" }

--- a/crates/paperback-core/src/ffi_config.rs
+++ b/crates/paperback-core/src/ffi_config.rs
@@ -33,6 +33,18 @@ impl ConfigManagerFfi {
 		self.inner.lock().unwrap().get_recent_documents()
 	}
 
+	pub fn add_opened_document(&self, path: String) {
+		self.inner.lock().unwrap().add_opened_document(&path);
+	}
+
+	pub fn remove_opened_document(&self, path: String) {
+		self.inner.lock().unwrap().remove_opened_document(&path);
+	}
+
+	pub fn get_opened_documents(&self) -> Vec<String> {
+		self.inner.lock().unwrap().get_opened_documents()
+	}
+
 	pub fn flush(&self) {
 		self.inner.lock().unwrap().flush();
 	}

--- a/crates/paperback-core/src/lib.rs
+++ b/crates/paperback-core/src/lib.rs
@@ -13,7 +13,7 @@ pub mod version;
 
 pub use crate::{
 	ffi_config::ConfigManagerFfi,
-	session::{DocumentError, DocumentSession, TocEntry},
+	session::{DocumentError, DocumentSession, TocEntry, LineMarker, MarkerTypeFfi, LinkActivationResultFfi, LinkActionFfi},
 };
 
 uniffi::include_scaffolding!("paperback");

--- a/crates/paperback-core/src/lib.rs
+++ b/crates/paperback-core/src/lib.rs
@@ -13,7 +13,9 @@ pub mod version;
 
 pub use crate::{
 	ffi_config::ConfigManagerFfi,
-	session::{DocumentError, DocumentSession, TocEntry, LineMarker, MarkerTypeFfi, LinkActivationResultFfi, LinkActionFfi},
+	session::{
+		DocumentError, DocumentSession, LineMarker, LinkActionFfi, LinkActivationResultFfi, MarkerTypeFfi, TocEntry,
+	},
 };
 
 uniffi::include_scaffolding!("paperback");

--- a/crates/paperback-core/src/paperback.udl
+++ b/crates/paperback-core/src/paperback.udl
@@ -11,6 +11,32 @@ dictionary TocEntry {
 	i32 level;
 };
 
+enum MarkerTypeFfi {
+	"Heading1", "Heading2", "Heading3", "Heading4", "Heading5", "Heading6",
+	"PageBreak", "SectionBreak", "TocItem", "Link",
+	"List", "ListItem", "Table", "Separator", "Image", "Figure"
+};
+
+dictionary LineMarker {
+	MarkerTypeFfi mtype;
+	i64 position;
+	string text;
+	string reference;
+	i32 level;
+	i64 length;
+};
+
+enum LinkActionFfi {
+	"Internal", "External", "NotFound"
+};
+
+dictionary LinkActivationResultFfi {
+	boolean found;
+	LinkActionFfi action;
+	i64 offset;
+	string url;
+};
+
 interface DocumentSession {
 	[Name=new_ffi, Throws=DocumentError]
 	constructor(string file_path, string password, string forced_extension);
@@ -23,6 +49,8 @@ interface DocumentSession {
 	i64 line_count();
 	i64 position_from_line(i64 line);
 	i64 line_from_position(i64 position);
+	sequence<LineMarker> get_line_markers(i64 line);
+	LinkActivationResultFfi activate_link_ffi(i64 position);
 
 	sequence<TocEntry> get_toc();
 };
@@ -35,5 +63,8 @@ interface ConfigManagerFfi {
 	i64 get_document_position(string path);
 	void add_recent_document(string path);
 	sequence<string> get_recent_documents();
+	void add_opened_document(string path);
+	void remove_opened_document(string path);
+	sequence<string> get_opened_documents();
 	void flush();
 };

--- a/crates/paperback-core/src/session.rs
+++ b/crates/paperback-core/src/session.rs
@@ -94,6 +94,31 @@ pub enum LinkAction {
 	NotFound,
 }
 
+#[derive(Debug, Clone, Copy)]
+pub enum LinkActionFfi {
+	Internal,
+	External,
+	NotFound,
+}
+
+impl From<LinkAction> for LinkActionFfi {
+	fn from(a: LinkAction) -> Self {
+		match a {
+			LinkAction::Internal => Self::Internal,
+			LinkAction::External => Self::External,
+			LinkAction::NotFound => Self::NotFound,
+		}
+	}
+}
+
+#[derive(Debug, Clone)]
+pub struct LinkActivationResultFfi {
+	pub found: bool,
+	pub action: LinkActionFfi,
+	pub offset: i64,
+	pub url: String,
+}
+
 #[derive(Debug, thiserror::Error)]
 pub enum DocumentError {
 	#[error("Parse error: {0}")]
@@ -135,6 +160,46 @@ pub struct TocEntry {
 	pub title: String,
 	pub position: i64,
 	pub level: i32,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub enum MarkerTypeFfi {
+	Heading1, Heading2, Heading3, Heading4, Heading5, Heading6,
+	PageBreak, SectionBreak, TocItem, Link,
+	List, ListItem, Table, Separator, Image, Figure,
+}
+
+impl From<crate::document::MarkerType> for MarkerTypeFfi {
+	fn from(m: crate::document::MarkerType) -> Self {
+		match m {
+			crate::document::MarkerType::Heading1 => Self::Heading1,
+			crate::document::MarkerType::Heading2 => Self::Heading2,
+			crate::document::MarkerType::Heading3 => Self::Heading3,
+			crate::document::MarkerType::Heading4 => Self::Heading4,
+			crate::document::MarkerType::Heading5 => Self::Heading5,
+			crate::document::MarkerType::Heading6 => Self::Heading6,
+			crate::document::MarkerType::PageBreak => Self::PageBreak,
+			crate::document::MarkerType::SectionBreak => Self::SectionBreak,
+			crate::document::MarkerType::TocItem => Self::TocItem,
+			crate::document::MarkerType::Link => Self::Link,
+			crate::document::MarkerType::List => Self::List,
+			crate::document::MarkerType::ListItem => Self::ListItem,
+			crate::document::MarkerType::Table => Self::Table,
+			crate::document::MarkerType::Separator => Self::Separator,
+			crate::document::MarkerType::Image => Self::Image,
+			crate::document::MarkerType::Figure => Self::Figure,
+		}
+	}
+}
+
+#[derive(Debug, Clone)]
+pub struct LineMarker {
+	pub mtype: MarkerTypeFfi,
+	pub position: i64,
+	pub text: String,
+	pub reference: String,
+	pub level: i32,
+	pub length: i64,
 }
 
 impl DocumentSession {
@@ -561,6 +626,17 @@ impl DocumentSession {
 	}
 
 	#[must_use]
+	pub fn activate_link_ffi(&self, position: i64) -> LinkActivationResultFfi {
+		let res = self.activate_link(position);
+		LinkActivationResultFfi {
+			found: res.found,
+			action: res.action.into(),
+			offset: res.offset,
+			url: res.url,
+		}
+	}
+
+	#[must_use]
 	pub fn get_table_at_position(&self, position: i64) -> Option<String> {
 		let pos_usize = usize::try_from(position.max(0)).unwrap_or(0);
 		let table_index = self.handle.current_marker_index(pos_usize, MarkerType::Table)?;
@@ -760,6 +836,32 @@ impl DocumentSession {
 		let chars_after_start: String = content.chars().skip(line_start).collect();
 		let line_end = chars_after_start.find('\n').map_or(chars_after_start.len(), |idx| idx);
 		chars_after_start.chars().take(line_end).collect()
+	}
+
+	#[must_use]
+	pub fn get_line_markers(&self, line: i64) -> Vec<LineMarker> {
+		let start_pos = self.position_from_line(line);
+		let end_pos = self.position_from_line(line + 1);
+		let start_usize = usize::try_from(start_pos.max(0)).unwrap_or(0);
+		// If line + 1 overflows or is the end, end_pos might be equal to start_pos
+		let end_usize = if start_pos == end_pos { usize::MAX } else { usize::try_from(end_pos.max(0)).unwrap_or(0) };
+		
+		let mut res = Vec::new();
+		for marker in &self.handle.document().buffer.markers {
+			if marker.position >= start_usize && marker.position < end_usize {
+				res.push(LineMarker {
+					mtype: MarkerTypeFfi::from(marker.mtype),
+					position: i64::try_from(marker.position).unwrap_or(0),
+					text: marker.text.clone(),
+					reference: marker.reference.clone(),
+					level: marker.level,
+					length: i64::try_from(marker.length).unwrap_or(0),
+				});
+			} else if marker.position > end_usize {
+				break;
+			}
+		}
+		res
 	}
 
 	fn has_headings(&self, level: Option<i32>) -> bool {

--- a/crates/paperback-core/src/session.rs
+++ b/crates/paperback-core/src/session.rs
@@ -164,9 +164,22 @@ pub struct TocEntry {
 
 #[derive(Debug, Clone, Copy)]
 pub enum MarkerTypeFfi {
-	Heading1, Heading2, Heading3, Heading4, Heading5, Heading6,
-	PageBreak, SectionBreak, TocItem, Link,
-	List, ListItem, Table, Separator, Image, Figure,
+	Heading1,
+	Heading2,
+	Heading3,
+	Heading4,
+	Heading5,
+	Heading6,
+	PageBreak,
+	SectionBreak,
+	TocItem,
+	Link,
+	List,
+	ListItem,
+	Table,
+	Separator,
+	Image,
+	Figure,
 }
 
 impl From<crate::document::MarkerType> for MarkerTypeFfi {
@@ -628,12 +641,7 @@ impl DocumentSession {
 	#[must_use]
 	pub fn activate_link_ffi(&self, position: i64) -> LinkActivationResultFfi {
 		let res = self.activate_link(position);
-		LinkActivationResultFfi {
-			found: res.found,
-			action: res.action.into(),
-			offset: res.offset,
-			url: res.url,
-		}
+		LinkActivationResultFfi { found: res.found, action: res.action.into(), offset: res.offset, url: res.url }
 	}
 
 	#[must_use]
@@ -845,7 +853,7 @@ impl DocumentSession {
 		let start_usize = usize::try_from(start_pos.max(0)).unwrap_or(0);
 		// If line + 1 overflows or is the end, end_pos might be equal to start_pos
 		let end_usize = if start_pos == end_pos { usize::MAX } else { usize::try_from(end_pos.max(0)).unwrap_or(0) };
-		
+
 		let mut res = Vec::new();
 		for marker in &self.handle.document().buffer.markers {
 			if marker.position >= start_usize && marker.position < end_usize {

--- a/crates/xtask/src/main.rs
+++ b/crates/xtask/src/main.rs
@@ -77,6 +77,7 @@ fn android() -> Result<(), Box<dyn Error>> {
 			"kotlin",
 			"--out-dir",
 			"android/app/src/main/java",
+			"--no-format",
 		])
 		.status()?;
 	if !status.success() {


### PR DESCRIPTION
- Tabbed Documents: Added support for opening multiple documents simultaneously using
 `PrimaryScrollableTabRow`. The list of opened documents is tracked via
 `ConfigManager` and automatically restored on startup. - Tab State
 Preservation: `MainScreenViewModel` and the Compose UI now cache a
 `LazyListState` for each open tab. This ensures the scroll position is
 perfectly preserved when navigating between books. - Exposed the core
 `activate_link` logic through UniFFI. Tapping internal links now
 automatically scrolls the view to the relevant section within the document -
 configured formatting for android. mite have some unintended Consequences
