### PR TITLE
improve app  layout, TalkBack announcements, and document opening logic

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -65,6 +65,7 @@ dependencies {
 	implementation(libs.androidx.compose.ui)
 	implementation(libs.androidx.compose.ui.tooling.preview)
 	implementation(libs.androidx.compose.material3)
+	implementation(libs.androidx.compose.material.icons.core)
 	// Tooling
 	debugImplementation(libs.androidx.compose.ui.tooling)
 	// Instrumented tests

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -13,6 +13,7 @@
         <activity
             android:name="dev.paperback.mobile.MainActivity"
             android:exported="true"
+            android:launchMode="singleTask"
             tools:ignore="Instantiatable">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/android/app/src/main/java/dev/paperback/mobile/MainActivity.kt
+++ b/android/app/src/main/java/dev/paperback/mobile/MainActivity.kt
@@ -23,4 +23,9 @@ class MainActivity : ComponentActivity() {
 			}
 		}
 	}
+
+	override fun onNewIntent(intent: android.content.Intent) {
+		super.onNewIntent(intent)
+		setIntent(intent)
+	}
 }

--- a/android/app/src/main/java/dev/paperback/mobile/ui/MainScreen.kt
+++ b/android/app/src/main/java/dev/paperback/mobile/ui/MainScreen.kt
@@ -92,6 +92,8 @@ fun MainScreen(
 		}
 	}
 
+	val supportedMimeTypes by viewModel.supportedMimeTypes.collectAsStateWithLifecycle()
+
 	val launcher = rememberLauncherForActivityResult(contract = ActivityResultContracts.OpenDocument()) { uri: Uri? ->
 		if (uri != null) {
 			viewModel.openDocument(uri)
@@ -135,7 +137,7 @@ fun MainScreen(
 							Spacer(modifier = Modifier.height(8.dp))
 						}
 						Button(
-							onClick = { launcher.launch(viewModel.supportedMimeTypes) },
+							onClick = { launcher.launch(supportedMimeTypes) },
 							modifier = Modifier.semantics {
 								traversalIndex =
 									2f

--- a/android/app/src/main/java/dev/paperback/mobile/ui/MainScreen.kt
+++ b/android/app/src/main/java/dev/paperback/mobile/ui/MainScreen.kt
@@ -58,11 +58,29 @@ fun MainScreen(
 	val context = LocalContext.current
 
 	val activity = context as? android.app.Activity
-	LaunchedEffect(activity?.intent) {
+	DisposableEffect(activity) {
+		val listener = androidx.core.util.Consumer<Intent> { newIntent ->
+			val uri = newIntent.data
+			if (uri != null && newIntent.action == Intent.ACTION_VIEW) {
+				viewModel.openDocument(uri)
+				newIntent.action = Intent.ACTION_MAIN
+			}
+		}
+		if (activity is androidx.activity.ComponentActivity) {
+			activity.addOnNewIntentListener(listener)
+		}
+		onDispose {
+			if (activity is androidx.activity.ComponentActivity) {
+				activity.removeOnNewIntentListener(listener)
+			}
+		}
+	}
+
+	LaunchedEffect(Unit) {
 		val uri = activity?.intent?.data
-		if (uri != null && activity.intent?.action == android.content.Intent.ACTION_VIEW) {
+		if (uri != null && activity?.intent?.action == Intent.ACTION_VIEW) {
 			viewModel.openDocument(uri)
-			activity.intent?.action = android.content.Intent.ACTION_MAIN
+			activity.intent?.action = Intent.ACTION_MAIN
 		}
 	}
 
@@ -74,29 +92,48 @@ fun MainScreen(
 
 	Scaffold(
 		topBar = {
-			Column {
-				TopAppBar(
-					title = { Text("Paperback") },
-					navigationIcon = {
+			Column(
+				modifier = Modifier
+					.fillMaxWidth()
+					.windowInsetsPadding(WindowInsets.statusBars)
+					.padding(horizontal = 16.dp, vertical = 8.dp)
+			) {
+				val titleText = if (state is MainScreenUiState.Success) {
+					val successState = state as MainScreenUiState.Success
+					successState.activeTab?.title ?: "Paperback"
+				} else {
+					"Paperback"
+				}
+				Text(
+					text = titleText,
+					style = MaterialTheme.typography.headlineSmall,
+					fontWeight = FontWeight.Bold,
+					modifier = Modifier.padding(bottom = 16.dp).semantics { heading() }
+				)
+
+				Row(
+					modifier = Modifier.fillMaxWidth().padding(bottom = 16.dp),
+					horizontalArrangement = Arrangement.SpaceBetween,
+					verticalAlignment = Alignment.Top
+				) {
+					Column(horizontalAlignment = Alignment.Start) {
 						if (state is MainScreenUiState.Success && (state as MainScreenUiState.Success).activeTab != null) {
-							TextButton(onClick = { tocSheetOpen = true }) {
+							Button(onClick = { tocSheetOpen = true }) {
 								Text("Table of Contents")
 							}
+							Spacer(modifier = Modifier.height(8.dp))
 						}
-					},
-					actions = {
-						if (state is MainScreenUiState.Success && (state as MainScreenUiState.Success).tabs.isNotEmpty()) {
-							TextButton(onClick = { recentsDialogOpen = true }) {
-								Text("Recent Books")
-							}
-						}
-						Button(onClick = {
-							launcher.launch(viewModel.supportedMimeTypes)
-						}) {
+						Button(onClick = { launcher.launch(viewModel.supportedMimeTypes) }) {
 							Text("Open Book")
 						}
 					}
-				)
+
+					if (state is MainScreenUiState.Success && (state as MainScreenUiState.Success).tabs.isNotEmpty()) {
+						Button(onClick = { recentsDialogOpen = true }) {
+							Text("Recent Books")
+						}
+					}
+				}
 				if (state is MainScreenUiState.Success) {
 					val successState = state as MainScreenUiState.Success
 					if (successState.tabs.isNotEmpty()) {
@@ -210,7 +247,7 @@ fun MainScreen(
 						LazyColumn(
 							state = listState,
 							modifier = Modifier.fillMaxSize().semantics { isTraversalGroup = true },
-							contentPadding = PaddingValues(16.dp)
+							contentPadding = PaddingValues(start = 16.dp, end = 16.dp, top = 4.dp, bottom = 16.dp)
 						) {
 							items(
 								count = docState.lineCount.toInt(),

--- a/android/app/src/main/java/dev/paperback/mobile/ui/MainScreen.kt
+++ b/android/app/src/main/java/dev/paperback/mobile/ui/MainScreen.kt
@@ -20,16 +20,14 @@ import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.semantics.CustomAccessibilityAction
 import androidx.compose.ui.semantics.clearAndSetSemantics
+import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.customActions
 import androidx.compose.ui.semantics.heading
 import androidx.compose.ui.semantics.isTraversalGroup
-import androidx.compose.ui.semantics.semantics
-import androidx.compose.ui.semantics.stateDescription
-import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.onClick
 import androidx.compose.ui.semantics.paneTitle
-import androidx.compose.ui.semantics.Role
-import androidx.compose.ui.semantics.role
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.stateDescription
 import androidx.compose.ui.semantics.traversalIndex
 import androidx.compose.ui.text.LinkAnnotation
 import androidx.compose.ui.text.SpanStyle
@@ -118,8 +116,8 @@ fun MainScreen(
 					text = titleText,
 					style = MaterialTheme.typography.headlineSmall,
 					fontWeight = FontWeight.Bold,
-					modifier = Modifier.padding(bottom = 16.dp).semantics { 
-						heading() 
+					modifier = Modifier.padding(bottom = 16.dp).semantics {
+						heading()
 						traversalIndex = 0f
 					}
 				)
@@ -136,7 +134,13 @@ fun MainScreen(
 							}
 							Spacer(modifier = Modifier.height(8.dp))
 						}
-						Button(onClick = { launcher.launch(viewModel.supportedMimeTypes) }, modifier = Modifier.semantics { traversalIndex = 2f }) {
+						Button(
+							onClick = { launcher.launch(viewModel.supportedMimeTypes) },
+							modifier = Modifier.semantics {
+								traversalIndex =
+									2f
+							}
+						) {
 							Text("Open Book")
 						}
 					}

--- a/android/app/src/main/java/dev/paperback/mobile/ui/MainScreen.kt
+++ b/android/app/src/main/java/dev/paperback/mobile/ui/MainScreen.kt
@@ -9,6 +9,8 @@ import androidx.compose.foundation.focusable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListState
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
@@ -23,6 +25,12 @@ import androidx.compose.ui.semantics.heading
 import androidx.compose.ui.semantics.isTraversalGroup
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.semantics.stateDescription
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.onClick
+import androidx.compose.ui.semantics.paneTitle
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.role
+import androidx.compose.ui.semantics.traversalIndex
 import androidx.compose.ui.text.LinkAnnotation
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.TextLinkStyles
@@ -53,6 +61,7 @@ fun MainScreen(
 	val listStates = remember { mutableStateMapOf<String, LazyListState>() }
 	var tocSheetOpen by remember { mutableStateOf(false) }
 	var recentsDialogOpen by remember { mutableStateOf(false) }
+	var moreOptionsExpanded by remember { mutableStateOf(false) }
 	var lineIndexToFocus by remember { mutableStateOf<Int?>(null) }
 	var expandedTocIndices by remember { mutableStateOf(setOf<Int>()) }
 	val context = LocalContext.current
@@ -77,10 +86,11 @@ fun MainScreen(
 	}
 
 	LaunchedEffect(Unit) {
-		val uri = activity?.intent?.data
-		if (uri != null && activity?.intent?.action == Intent.ACTION_VIEW) {
+		val intent = activity?.intent
+		val uri = intent?.data
+		if (uri != null && intent.action == Intent.ACTION_VIEW) {
 			viewModel.openDocument(uri)
-			activity.intent?.action = Intent.ACTION_MAIN
+			intent.action = Intent.ACTION_MAIN
 		}
 	}
 
@@ -108,29 +118,61 @@ fun MainScreen(
 					text = titleText,
 					style = MaterialTheme.typography.headlineSmall,
 					fontWeight = FontWeight.Bold,
-					modifier = Modifier.padding(bottom = 16.dp).semantics { heading() }
+					modifier = Modifier.padding(bottom = 16.dp).semantics { 
+						heading() 
+						traversalIndex = 0f
+					}
 				)
 
 				Row(
-					modifier = Modifier.fillMaxWidth().padding(bottom = 16.dp),
+					modifier = Modifier.fillMaxWidth().padding(bottom = 16.dp).semantics { isTraversalGroup = true },
 					horizontalArrangement = Arrangement.SpaceBetween,
 					verticalAlignment = Alignment.Top
 				) {
-					Column(horizontalAlignment = Alignment.Start) {
+					Column(horizontalAlignment = Alignment.Start, modifier = Modifier.semantics { isTraversalGroup = true }) {
 						if (state is MainScreenUiState.Success && (state as MainScreenUiState.Success).activeTab != null) {
-							Button(onClick = { tocSheetOpen = true }) {
+							Button(onClick = { tocSheetOpen = true }, modifier = Modifier.semantics { traversalIndex = 1f }) {
 								Text("Table of Contents")
 							}
 							Spacer(modifier = Modifier.height(8.dp))
 						}
-						Button(onClick = { launcher.launch(viewModel.supportedMimeTypes) }) {
+						Button(onClick = { launcher.launch(viewModel.supportedMimeTypes) }, modifier = Modifier.semantics { traversalIndex = 2f }) {
 							Text("Open Book")
 						}
 					}
 
 					if (state is MainScreenUiState.Success && (state as MainScreenUiState.Success).tabs.isNotEmpty()) {
-						Button(onClick = { recentsDialogOpen = true }) {
-							Text("Recent Books")
+						Box(modifier = Modifier.semantics { isTraversalGroup = true }) {
+							IconButton(
+								onClick = { moreOptionsExpanded = true },
+								modifier = Modifier.semantics {
+									traversalIndex = 3f
+									this.onClick(label = "show all options in a menu") {
+										moreOptionsExpanded = true
+										true
+									}
+									customActions = listOf(
+										CustomAccessibilityAction("Recent Documents") {
+											recentsDialogOpen = true
+											true
+										}
+									)
+								}
+							) {
+								Icon(Icons.Filled.MoreVert, contentDescription = "More Options")
+							}
+							DropdownMenu(
+								expanded = moreOptionsExpanded,
+								onDismissRequest = { moreOptionsExpanded = false }
+							) {
+								DropdownMenuItem(
+									text = { Text("Recent Documents") },
+									onClick = {
+										moreOptionsExpanded = false
+										recentsDialogOpen = true
+									}
+								)
+							}
 						}
 					}
 				}
@@ -218,6 +260,7 @@ fun MainScreen(
 									lazyItems(successState.recentDocuments.take(5)) { recentDoc ->
 										RecentDocumentItemRow(
 											item = recentDoc,
+											showClosedStatus = false,
 											onOpen = { viewModel.openDocument(Uri.parse(recentDoc.uri)) },
 											onRemove = { viewModel.removeRecentDocument(recentDoc.uri) }
 										)
@@ -227,7 +270,7 @@ fun MainScreen(
 									onClick = { recentsDialogOpen = true },
 									modifier = Modifier.padding(top = 8.dp)
 								) {
-									Text("Recent Books")
+									Text("Recent Documents")
 								}
 							}
 						}
@@ -429,6 +472,7 @@ fun MainScreen(
 					if (recentsDialogOpen) {
 						AlertDialog(
 							onDismissRequest = { recentsDialogOpen = false },
+							modifier = Modifier.semantics { paneTitle = "Recent Documents" },
 							title = { Text("Recent Documents") },
 							text = {
 								LazyColumn(
@@ -467,6 +511,7 @@ fun MainScreen(
 @Composable
 fun RecentDocumentItemRow(
 	item: RecentDocumentItem,
+	showClosedStatus: Boolean = true,
 	onOpen: () -> Unit,
 	onRemove: () -> Unit
 ) {
@@ -484,12 +529,17 @@ fun RecentDocumentItemRow(
 						true
 					}
 				)
-				stateDescription = if (item.isMissing) {
+				val desc = if (item.isMissing) {
 					"Missing"
 				} else if (item.isOpen) {
 					"Open"
-				} else {
+				} else if (showClosedStatus) {
 					"Closed"
+				} else {
+					null
+				}
+				if (desc != null) {
+					stateDescription = desc
 				}
 			}.padding(vertical = 12.dp, horizontal = 8.dp),
 		verticalAlignment = Alignment.CenterVertically
@@ -504,17 +554,19 @@ fun RecentDocumentItemRow(
 					MaterialTheme.colorScheme.onSurface
 				}
 			)
-			Text(
-				text = if (item.isMissing) {
-					"File Missing"
-				} else if (item.isOpen) {
-					"Currently Open"
-				} else {
-					"Closed"
-				},
-				style = MaterialTheme.typography.bodySmall,
-				color = if (item.isMissing) MaterialTheme.colorScheme.error else MaterialTheme.colorScheme.onSurfaceVariant
-			)
+			if (item.isMissing || item.isOpen || showClosedStatus) {
+				Text(
+					text = if (item.isMissing) {
+						"File Missing"
+					} else if (item.isOpen) {
+						"Currently Open"
+					} else {
+						"Closed"
+					},
+					style = MaterialTheme.typography.bodySmall,
+					color = if (item.isMissing) MaterialTheme.colorScheme.error else MaterialTheme.colorScheme.onSurfaceVariant
+				)
+			}
 		}
 		TextButton(
 			onClick = onRemove,

--- a/android/app/src/main/java/dev/paperback/mobile/ui/MainScreenViewModel.kt
+++ b/android/app/src/main/java/dev/paperback/mobile/ui/MainScreenViewModel.kt
@@ -7,6 +7,7 @@ import android.provider.OpenableColumns
 import android.webkit.MimeTypeMap
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -60,9 +61,7 @@ class MainScreenViewModel(
 ) : AndroidViewModel(application) {
 	private val context get() = getApplication<Application>()
 
-	private val config = ConfigManagerFfi().also {
-		it.initialize(context.filesDir.absolutePath + "/config.toml")
-	}
+	private val config = ConfigManagerFfi()
 
 	private val _uiState = MutableStateFlow<MainScreenUiState>(MainScreenUiState.Idle)
 	val uiState: StateFlow<MainScreenUiState> = _uiState
@@ -71,17 +70,42 @@ class MainScreenViewModel(
 	private var currentActiveIndex = -1
 	private var recentDocumentsList = emptyList<RecentDocumentItem>()
 
-	val supportedMimeTypes: Array<String> = run {
+	private val _supportedMimeTypes = MutableStateFlow<Array<String>>(arrayOf("*/*"))
+	val supportedMimeTypes: StateFlow<Array<String>> = _supportedMimeTypes
+
+	init {
+		viewModelScope.launch(Dispatchers.IO) {
+			config.initialize(context.filesDir.absolutePath + "/config.toml")
+			_supportedMimeTypes.value = buildSupportedMimeTypes()
+
+			val openedUris = config.getOpenedDocuments()
+			if (openedUris.isNotEmpty()) {
+				openedUris.forEach { uriString ->
+					loadDocument(Uri.parse(uriString), false)
+				}
+			}
+			
+			val initialRecents = getRecentDocumentsListIO()
+			
+			withContext(Dispatchers.Main) {
+				recentDocumentsList = initialRecents
+				if (currentTabs.isEmpty()) {
+					_uiState.value = MainScreenUiState.Success(currentTabs.toList(), currentActiveIndex, recentDocumentsList)
+				}
+			}
+		}
+	}
+
+	private fun buildSupportedMimeTypes(): Array<String> {
 		val extensions = config.getSupportedExtensions()
 		val mimeMap = MimeTypeMap.getSingleton()
 		val mimes = mutableSetOf<String>()
 		for (ext in extensions) {
-			val extStr = ext.toString()
-			val mime: String? = mimeMap.getMimeTypeFromExtension(extStr)
+			val mime: String? = mimeMap.getMimeTypeFromExtension(ext)
 			if (mime != null) {
 				mimes.add(mime)
 			}
-			when (extStr.lowercase()) {
+			when (ext.lowercase()) {
 				"epub" -> mimes.add("application/epub+zip")
 				"fb2" -> mimes.add("application/x-fictionbook+xml")
 				"md" -> mimes.add("text/markdown")
@@ -107,23 +131,7 @@ class MainScreenViewModel(
 				"mobi" -> mimes.add("application/x-mobipocket-ebook")
 			}
 		}
-		if (mimes.isEmpty()) arrayOf("*/*") else mimes.toTypedArray()
-	}
-
-	init {
-		viewModelScope.launch {
-			val openedUris = config.getOpenedDocuments()
-			if (openedUris.isNotEmpty()) {
-				openedUris.forEach { uriString ->
-					loadDocument(Uri.parse(uriString), false)
-				}
-			}
-			updateRecentDocuments()
-			
-			if (currentTabs.isEmpty()) {
-				_uiState.value = MainScreenUiState.Success(currentTabs.toList(), currentActiveIndex, recentDocumentsList)
-			}
-		}
+		return if (mimes.isEmpty()) arrayOf("*/*") else mimes.toTypedArray()
 	}
 
 	private suspend fun updateRecentDocuments() {
@@ -150,7 +158,7 @@ class MainScreenViewModel(
 							isMissing = true
 						}
 					} ?: run { isMissing = true }
-				
+
 					if (!isMissing) {
 						context.contentResolver.openAssetFileDescriptor(uri, "r")?.close()
 					}
@@ -197,9 +205,9 @@ class MainScreenViewModel(
 				withContext(Dispatchers.Main) {
 					currentActiveIndex = if (currentTabs.isEmpty()) -1 else currentActiveIndex.coerceIn(0, currentTabs.size - 1)
 					if (currentActiveIndex != -1) {
+						val activeKey = currentTabs[currentActiveIndex].docKey
 						viewModelScope.launch(Dispatchers.IO) {
-							config
-								.setAppString("active_document", currentTabs[currentActiveIndex].docKey)
+							config.setAppString("active_document", activeKey)
 						}
 					}
 					_uiState.value = MainScreenUiState.Success(currentTabs.toList(), currentActiveIndex, recentDocumentsList)
@@ -232,7 +240,9 @@ class MainScreenViewModel(
 	}
 
 	override fun onCleared() {
-		config.flush()
+		CoroutineScope(Dispatchers.IO).launch {
+			config.flush()
+		}
 	}
 
 	private suspend fun loadDocument(
@@ -247,7 +257,7 @@ class MainScreenViewModel(
 				_uiState.value = MainScreenUiState.Error("Failed to open file")
 				return@withContext
 			}
-			
+
 			var displayName = ""
 			context.contentResolver.query(uri, null, null, null, null)?.use { cursor ->
 				if (cursor.moveToFirst()) {
@@ -255,7 +265,7 @@ class MainScreenViewModel(
 					if (nameIndex != -1) displayName = cursor.getString(nameIndex)
 				}
 			}
-			
+
 			val ext = displayName.substringAfterLast('.', "epub").lowercase()
 			val tempFile = File(context.cacheDir, "doc_${UUID.randomUUID()}.$ext")
 			FileOutputStream(tempFile).use { inputStream.copyTo(it) }
@@ -284,6 +294,7 @@ class MainScreenViewModel(
 			)
 
 			val recentDocsUpdated = getRecentDocumentsListIO()
+			val activeDocKey = config.getAppString("active_document", "")
 
 			withContext(Dispatchers.Main) {
 				recentDocumentsList = recentDocsUpdated
@@ -301,12 +312,12 @@ class MainScreenViewModel(
 					if (makeActive) {
 						currentActiveIndex = existingIndex
 						viewModelScope.launch(Dispatchers.IO) { config.setAppString("active_document", docKey) }
-					} else if (config.getAppString("active_document", "") == docKey) {
+					} else if (activeDocKey == docKey) {
 						currentActiveIndex = existingIndex
 					}
 				} else {
 					currentTabs.add(tabState)
-					if (makeActive || config.getAppString("active_document", "") == docKey) {
+					if (makeActive || activeDocKey == docKey) {
 						currentActiveIndex = currentTabs.size - 1
 						viewModelScope.launch(Dispatchers.IO) { config.setAppString("active_document", docKey) }
 					} else if (currentActiveIndex == -1) {

--- a/android/app/src/main/java/dev/paperback/mobile/ui/MainScreenViewModel.kt
+++ b/android/app/src/main/java/dev/paperback/mobile/ui/MainScreenViewModel.kt
@@ -7,7 +7,6 @@ import android.provider.OpenableColumns
 import android.webkit.MimeTypeMap
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -79,18 +78,45 @@ class MainScreenViewModel(
 			_supportedMimeTypes.value = buildSupportedMimeTypes()
 
 			val openedUris = config.getOpenedDocuments()
+			val activeDocKey = config.getAppString("active_document", "")
+
 			if (openedUris.isNotEmpty()) {
-				openedUris.forEach { uriString ->
-					loadDocument(Uri.parse(uriString), false)
+				val restoredTabs = mutableListOf<DocumentTabState>()
+				for (uriString in openedUris) {
+					val tab = prepareDocumentTabIO(Uri.parse(uriString))
+					if (tab != null) {
+						restoredTabs.add(tab)
+					}
 				}
-			}
-			
-			val initialRecents = getRecentDocumentsListIO()
-			
-			withContext(Dispatchers.Main) {
-				recentDocumentsList = initialRecents
-				if (currentTabs.isEmpty()) {
-					_uiState.value = MainScreenUiState.Success(currentTabs.toList(), currentActiveIndex, recentDocumentsList)
+
+				val initialRecents = getRecentDocumentsListIO()
+
+				withContext(Dispatchers.Main) {
+					currentTabs.addAll(restoredTabs)
+					recentDocumentsList = initialRecents
+
+					if (currentTabs.isNotEmpty()) {
+						val matchingIndex = currentTabs.indexOfFirst { it.docKey == activeDocKey }
+						currentActiveIndex = if (matchingIndex != -1) matchingIndex else 0
+					} else {
+						currentActiveIndex = -1
+					}
+
+					_uiState.value = MainScreenUiState.Success(
+						tabs = currentTabs.toList(),
+						activeTabIndex = currentActiveIndex,
+						recentDocuments = recentDocumentsList
+					)
+				}
+			} else {
+				val initialRecents = getRecentDocumentsListIO()
+				withContext(Dispatchers.Main) {
+					recentDocumentsList = initialRecents
+					_uiState.value = MainScreenUiState.Success(
+						tabs = currentTabs.toList(),
+						activeTabIndex = currentActiveIndex,
+						recentDocuments = recentDocumentsList
+					)
 				}
 			}
 		}
@@ -240,10 +266,57 @@ class MainScreenViewModel(
 	}
 
 	override fun onCleared() {
-		CoroutineScope(Dispatchers.IO).launch {
-			config.flush()
-		}
+		super.onCleared()
+		Thread {
+			try {
+				config.flush()
+			} catch (_: Exception) {
+			}
+		}.start()
 	}
+
+	private suspend fun prepareDocumentTabIO(uri: Uri): DocumentTabState? =
+		withContext(Dispatchers.IO) {
+			try {
+				val inputStream = context.contentResolver.openInputStream(uri) ?: return@withContext null
+				var displayName = ""
+				context.contentResolver.query(uri, null, null, null, null)?.use { cursor ->
+					if (cursor.moveToFirst()) {
+						val nameIndex = cursor.getColumnIndex(OpenableColumns.DISPLAY_NAME)
+						if (nameIndex != -1) displayName = cursor.getString(nameIndex)
+					}
+				}
+
+				val ext = displayName.substringAfterLast('.', "epub").lowercase()
+				val tempFile = File(context.cacheDir, "doc_${UUID.randomUUID()}.$ext")
+				FileOutputStream(tempFile).use { inputStream.copyTo(it) }
+				inputStream.close()
+
+				config.associateUriWithLocalFile(uri.toString(), tempFile.absolutePath)
+				val docKey = config.getDocKey(uri.toString())
+				val savedPosition = config.getDocumentPosition(uri.toString())
+
+				val session = DocumentSession.newFfi(tempFile.absolutePath, "", "")
+				val initialScrollIndex = if (savedPosition > 0L) {
+					(session.lineFromPosition(savedPosition) - 1L).toInt().coerceAtLeast(0)
+				} else {
+					0
+				}
+
+				DocumentTabState(
+					session = session,
+					title = session.title().ifBlank { displayName },
+					author = session.author(),
+					lineCount = session.lineCount(),
+					toc = session.getToc(),
+					documentUri = uri.toString(),
+					docKey = docKey,
+					initialScrollIndex = initialScrollIndex
+				)
+			} catch (e: Exception) {
+				null
+			}
+		}
 
 	private suspend fun loadDocument(
 		uri: Uri,
@@ -252,88 +325,51 @@ class MainScreenViewModel(
 		if (currentTabs.isEmpty()) {
 			_uiState.value = MainScreenUiState.Loading
 		}
-		try {
-			val inputStream = context.contentResolver.openInputStream(uri) ?: run {
+		
+		val tabState = prepareDocumentTabIO(uri)
+		if (tabState == null) {
+			withContext(Dispatchers.Main) {
 				_uiState.value = MainScreenUiState.Error("Failed to open file")
-				return@withContext
-			}
-
-			var displayName = ""
-			context.contentResolver.query(uri, null, null, null, null)?.use { cursor ->
-				if (cursor.moveToFirst()) {
-					val nameIndex = cursor.getColumnIndex(OpenableColumns.DISPLAY_NAME)
-					if (nameIndex != -1) displayName = cursor.getString(nameIndex)
-				}
-			}
-
-			val ext = displayName.substringAfterLast('.', "epub").lowercase()
-			val tempFile = File(context.cacheDir, "doc_${UUID.randomUUID()}.$ext")
-			FileOutputStream(tempFile).use { inputStream.copyTo(it) }
-			inputStream.close()
-
-			config.associateUriWithLocalFile(uri.toString(), tempFile.absolutePath)
-			val docKey = config.getDocKey(uri.toString())
-			val savedPosition = config.getDocumentPosition(uri.toString())
-
-			val session = DocumentSession.newFfi(tempFile.absolutePath, "", "")
-			val initialScrollIndex = if (savedPosition > 0L) {
-				(session.lineFromPosition(savedPosition) - 1L).toInt().coerceAtLeast(0)
-			} else {
-				0
-			}
-
-			val tabState = DocumentTabState(
-				session = session,
-				title = session.title().ifBlank { displayName },
-				author = session.author(),
-				lineCount = session.lineCount(),
-				toc = session.getToc(),
-				documentUri = uri.toString(),
-				docKey = docKey,
-				initialScrollIndex = initialScrollIndex
-			)
-
-			val recentDocsUpdated = getRecentDocumentsListIO()
-			val activeDocKey = config.getAppString("active_document", "")
-
-			withContext(Dispatchers.Main) {
-				recentDocumentsList = recentDocsUpdated
-				val existingIndex = currentTabs.indexOfFirst { it.docKey == docKey }
-				if (existingIndex != -1) {
-					val oldTab = currentTabs[existingIndex]
-					if (oldTab.documentUri != uri.toString()) {
-						viewModelScope.launch(Dispatchers.IO) {
-							config.removeOpenedDocument(oldTab.documentUri)
-							config.addOpenedDocument(uri.toString())
-							config.flush()
-						}
-						currentTabs[existingIndex] = tabState
-					}
-					if (makeActive) {
-						currentActiveIndex = existingIndex
-						viewModelScope.launch(Dispatchers.IO) { config.setAppString("active_document", docKey) }
-					} else if (activeDocKey == docKey) {
-						currentActiveIndex = existingIndex
-					}
-				} else {
-					currentTabs.add(tabState)
-					if (makeActive || activeDocKey == docKey) {
-						currentActiveIndex = currentTabs.size - 1
-						viewModelScope.launch(Dispatchers.IO) { config.setAppString("active_document", docKey) }
-					} else if (currentActiveIndex == -1) {
-						currentActiveIndex = 0
-					}
-				}
-				_uiState.value =
-					MainScreenUiState.Success(tabs = currentTabs.toList(), activeTabIndex = currentActiveIndex, recentDocumentsList)
-			}
-		} catch (e: Exception) {
-			withContext(Dispatchers.Main) {
-				_uiState.value = MainScreenUiState.Error(e.message ?: "Unknown error")
 				if (currentTabs.isNotEmpty()) {
 					_uiState.value = MainScreenUiState.Success(currentTabs.toList(), currentActiveIndex, recentDocumentsList)
 				}
 			}
+			return@withContext
+		}
+
+		val recentDocsUpdated = getRecentDocumentsListIO()
+		val activeDocKey = config.getAppString("active_document", "")
+
+		withContext(Dispatchers.Main) {
+			recentDocumentsList = recentDocsUpdated
+			val existingIndex = currentTabs.indexOfFirst { it.docKey == tabState.docKey }
+			if (existingIndex != -1) {
+				val oldTab = currentTabs[existingIndex]
+				if (oldTab.documentUri != uri.toString()) {
+					viewModelScope.launch(Dispatchers.IO) {
+						config.removeOpenedDocument(oldTab.documentUri)
+						config.addOpenedDocument(uri.toString())
+						config.flush()
+					}
+					currentTabs[existingIndex] = tabState
+				}
+				if (makeActive) {
+					currentActiveIndex = existingIndex
+					viewModelScope.launch(Dispatchers.IO) { config.setAppString("active_document", tabState.docKey) }
+				} else if (activeDocKey == tabState.docKey) {
+					currentActiveIndex = existingIndex
+				}
+			} else {
+				currentTabs.add(tabState)
+				if (makeActive || activeDocKey == tabState.docKey) {
+					currentActiveIndex = currentTabs.size - 1
+					viewModelScope.launch(Dispatchers.IO) { config.setAppString("active_document", tabState.docKey) }
+				} else if (currentActiveIndex == -1) {
+					currentActiveIndex = 0
+				}
+			}
+			_uiState.value =
+				MainScreenUiState.Success(tabs = currentTabs.toList(), activeTabIndex = currentActiveIndex, recentDocumentsList)
 		}
 	}
 }

--- a/android/app/src/main/java/dev/paperback/mobile/ui/MainScreenViewModel.kt
+++ b/android/app/src/main/java/dev/paperback/mobile/ui/MainScreenViewModel.kt
@@ -26,6 +26,7 @@ data class DocumentTabState(
 	val lineCount: Long,
 	val toc: List<TocEntry>,
 	val documentUri: String,
+	val docKey: String,
 	val initialScrollIndex: Int = 0
 )
 
@@ -114,8 +115,7 @@ class MainScreenViewModel(
 			val openedUris = config.getOpenedDocuments()
 			if (openedUris.isNotEmpty()) {
 				openedUris.forEach { uriString ->
-					val savedPosition = config.getDocumentPosition(uriString)
-					loadDocument(Uri.parse(uriString), savedPosition)
+					loadDocument(Uri.parse(uriString), false)
 				}
 			}
 			updateRecentDocuments()
@@ -126,11 +126,18 @@ class MainScreenViewModel(
 		}
 	}
 
-	private suspend fun updateRecentDocuments() =
+	private suspend fun updateRecentDocuments() {
+		val updatedList = getRecentDocumentsListIO()
+		withContext(Dispatchers.Main) {
+			recentDocumentsList = updatedList
+		}
+	}
+
+	private suspend fun getRecentDocumentsListIO(): List<RecentDocumentItem> =
 		withContext(Dispatchers.IO) {
 			val recents = config.getRecentDocuments()
 			val opened = config.getOpenedDocuments().toSet()
-			val updatedList = recents.map { uriString ->
+			recents.map { uriString ->
 				val uri = Uri.parse(uriString)
 				var displayName = uri.lastPathSegment ?: uriString
 				var isMissing = false
@@ -152,9 +159,6 @@ class MainScreenViewModel(
 				}
 				RecentDocumentItem(uriString, displayName, opened.contains(uriString), isMissing)
 			}
-			withContext(Dispatchers.Main) {
-				recentDocumentsList = updatedList
-			}
 		}
 
 	fun removeRecentDocument(uriString: String) {
@@ -163,11 +167,7 @@ class MainScreenViewModel(
 			config.flush()
 			updateRecentDocuments()
 			withContext(Dispatchers.Main) {
-				if (currentTabs.isEmpty()) {
-					_uiState.value = MainScreenUiState.Success(currentTabs.toList(), currentActiveIndex, recentDocumentsList)
-				} else {
-					_uiState.value = MainScreenUiState.Success(currentTabs.toList(), currentActiveIndex, recentDocumentsList)
-				}
+				_uiState.value = MainScreenUiState.Success(currentTabs.toList(), currentActiveIndex, recentDocumentsList)
 			}
 		}
 	}
@@ -182,8 +182,7 @@ class MainScreenViewModel(
 			config.addRecentDocument(uriString)
 			config.addOpenedDocument(uriString)
 			config.flush()
-			val savedPosition = config.getDocumentPosition(uriString)
-			loadDocument(uri, savedPosition)
+			loadDocument(uri, true)
 		}
 	}
 
@@ -197,6 +196,12 @@ class MainScreenViewModel(
 				updateRecentDocuments()
 				withContext(Dispatchers.Main) {
 					currentActiveIndex = if (currentTabs.isEmpty()) -1 else currentActiveIndex.coerceIn(0, currentTabs.size - 1)
+					if (currentActiveIndex != -1) {
+						viewModelScope.launch(Dispatchers.IO) {
+							config
+								.setAppString("active_document", currentTabs[currentActiveIndex].docKey)
+						}
+					}
 					_uiState.value = MainScreenUiState.Success(currentTabs.toList(), currentActiveIndex, recentDocumentsList)
 				}
 			}
@@ -206,6 +211,10 @@ class MainScreenViewModel(
 	fun setActiveTab(index: Int) {
 		if (index in currentTabs.indices && index != currentActiveIndex) {
 			currentActiveIndex = index
+			viewModelScope.launch(Dispatchers.IO) {
+				config.setAppString("active_document", currentTabs[index].docKey)
+				config.flush()
+			}
 			_uiState.value = MainScreenUiState.Success(currentTabs.toList(), currentActiveIndex, recentDocumentsList)
 		}
 	}
@@ -228,7 +237,7 @@ class MainScreenViewModel(
 
 	private suspend fun loadDocument(
 		uri: Uri,
-		savedPosition: Long
+		makeActive: Boolean
 	) = withContext(Dispatchers.IO) {
 		if (currentTabs.isEmpty()) {
 			_uiState.value = MainScreenUiState.Loading
@@ -252,6 +261,10 @@ class MainScreenViewModel(
 			FileOutputStream(tempFile).use { inputStream.copyTo(it) }
 			inputStream.close()
 
+			config.associateUriWithLocalFile(uri.toString(), tempFile.absolutePath)
+			val docKey = config.getDocKey(uri.toString())
+			val savedPosition = config.getDocumentPosition(uri.toString())
+
 			val session = DocumentSession.newFfi(tempFile.absolutePath, "", "")
 			val initialScrollIndex = if (savedPosition > 0L) {
 				(session.lineFromPosition(savedPosition) - 1L).toInt().coerceAtLeast(0)
@@ -266,25 +279,49 @@ class MainScreenViewModel(
 				lineCount = session.lineCount(),
 				toc = session.getToc(),
 				documentUri = uri.toString(),
+				docKey = docKey,
 				initialScrollIndex = initialScrollIndex
 			)
 
-			// Check if already open
-			val existingIndex = currentTabs.indexOfFirst { it.documentUri == tabState.documentUri }
-			if (existingIndex != -1) {
-				currentActiveIndex = existingIndex
-			} else {
-				currentTabs.add(tabState)
-				currentActiveIndex = currentTabs.size - 1
-			}
+			val recentDocsUpdated = getRecentDocumentsListIO()
 
-			updateRecentDocuments()
-			_uiState.value =
-				MainScreenUiState.Success(tabs = currentTabs.toList(), activeTabIndex = currentActiveIndex, recentDocumentsList)
+			withContext(Dispatchers.Main) {
+				recentDocumentsList = recentDocsUpdated
+				val existingIndex = currentTabs.indexOfFirst { it.docKey == docKey }
+				if (existingIndex != -1) {
+					val oldTab = currentTabs[existingIndex]
+					if (oldTab.documentUri != uri.toString()) {
+						viewModelScope.launch(Dispatchers.IO) {
+							config.removeOpenedDocument(oldTab.documentUri)
+							config.addOpenedDocument(uri.toString())
+							config.flush()
+						}
+						currentTabs[existingIndex] = tabState
+					}
+					if (makeActive) {
+						currentActiveIndex = existingIndex
+						viewModelScope.launch(Dispatchers.IO) { config.setAppString("active_document", docKey) }
+					} else if (config.getAppString("active_document", "") == docKey) {
+						currentActiveIndex = existingIndex
+					}
+				} else {
+					currentTabs.add(tabState)
+					if (makeActive || config.getAppString("active_document", "") == docKey) {
+						currentActiveIndex = currentTabs.size - 1
+						viewModelScope.launch(Dispatchers.IO) { config.setAppString("active_document", docKey) }
+					} else if (currentActiveIndex == -1) {
+						currentActiveIndex = 0
+					}
+				}
+				_uiState.value =
+					MainScreenUiState.Success(tabs = currentTabs.toList(), activeTabIndex = currentActiveIndex, recentDocumentsList)
+			}
 		} catch (e: Exception) {
-			_uiState.value = MainScreenUiState.Error(e.message ?: "Unknown error")
-			if (currentTabs.isNotEmpty()) {
-				_uiState.value = MainScreenUiState.Success(currentTabs.toList(), currentActiveIndex, recentDocumentsList)
+			withContext(Dispatchers.Main) {
+				_uiState.value = MainScreenUiState.Error(e.message ?: "Unknown error")
+				if (currentTabs.isNotEmpty()) {
+					_uiState.value = MainScreenUiState.Success(currentTabs.toList(), currentActiveIndex, recentDocumentsList)
+				}
 			}
 		}
 	}

--- a/android/app/src/main/java/dev/paperback/mobile/ui/MainScreenViewModel.kt
+++ b/android/app/src/main/java/dev/paperback/mobile/ui/MainScreenViewModel.kt
@@ -356,12 +356,15 @@ class MainScreenViewModel(
 				if (makeActive) {
 					currentActiveIndex = existingIndex
 					viewModelScope.launch(Dispatchers.IO) { config.setAppString("active_document", tabState.docKey) }
-				} else if (activeDocKey == tabState.docKey) {
+				} else if (activeDocKey == tabState.docKey && !makeActive) {
 					currentActiveIndex = existingIndex
 				}
 			} else {
 				currentTabs.add(tabState)
-				if (makeActive || activeDocKey == tabState.docKey) {
+				if (makeActive) {
+					currentActiveIndex = currentTabs.size - 1
+					viewModelScope.launch(Dispatchers.IO) { config.setAppString("active_document", tabState.docKey) }
+				} else if (activeDocKey == tabState.docKey) {
 					currentActiveIndex = currentTabs.size - 1
 					viewModelScope.launch(Dispatchers.IO) { config.setAppString("active_document", tabState.docKey) }
 				} else if (currentActiveIndex == -1) {

--- a/android/app/src/main/java/dev/paperback/mobile/ui/TocSheet.kt
+++ b/android/app/src/main/java/dev/paperback/mobile/ui/TocSheet.kt
@@ -13,7 +13,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.semantics.CustomAccessibilityAction
 import androidx.compose.ui.semantics.clearAndSetSemantics
-import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.customActions
 import androidx.compose.ui.semantics.paneTitle
 import androidx.compose.ui.semantics.semantics
@@ -79,7 +78,6 @@ fun TocSheet(
 								onItemClick(item)
 							}
 						}.semantics(mergeDescendants = true) {
-							contentDescription = "${item.title}, Level ${item.level + 1}"
 							if (hasChildren) {
 								stateDescription = if (isExpanded) "Expanded" else "Collapsed"
 								customActions = listOf(
@@ -114,9 +112,9 @@ fun TocSheet(
 						Spacer(modifier = Modifier.width(36.dp))
 					}
 					Text(
-						text = item.title,
+						text = "${item.title}, Level ${item.level + 1}",
 						style = MaterialTheme.typography.bodyLarge,
-						modifier = Modifier.weight(1f).padding(start = 8.dp).clearAndSetSemantics { }
+						modifier = Modifier.weight(1f).padding(start = 8.dp)
 					)
 				}
 			}

--- a/android/gradle/libs.versions.toml
+++ b/android/gradle/libs.versions.toml
@@ -20,6 +20,7 @@ androidx-core-ktx = { module = "androidx.core:core-ktx", version.ref = "androidx
 androidx-activity-compose = { module = "androidx.activity:activity-compose", version.ref = "androidxActivity" }
 androidx-compose-bom = { group = "androidx.compose", name = "compose-bom", version.ref = "androidxComposeBom" }
 androidx-compose-material3 = { group = "androidx.compose.material3", name = "material3"}
+androidx-compose-material-icons-core = { group = "androidx.compose.material", name = "material-icons-core"}
 androidx-compose-ui = { group = "androidx.compose.ui", name = "ui"}
 androidx-compose-ui-tooling-preview = { group = "androidx.compose.ui", name = "ui-tooling-preview"}
 androidx-compose-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit4"}

--- a/crates/paperback-core/src/config.rs
+++ b/crates/paperback-core/src/config.rs
@@ -326,6 +326,16 @@ impl ConfigManager {
 		}
 	}
 
+	pub fn associate_uri_with_local_file(&self, uri: &str, local_path: &str) {
+		let digest = compute_document_hash(local_path);
+		let encoded = URL_SAFE_NO_PAD.encode(digest);
+		let new_key = format!("doc_{encoded}");
+
+		let mut data = self.data.borrow_mut();
+		data.path_hashes.insert(uri.to_string(), new_key.clone());
+		self.dirty.set(true);
+	}
+
 	pub fn get_doc_key(&self, path: &str) -> String {
 		{
 			let data = self.data.borrow();

--- a/crates/paperback-core/src/ffi_config.rs
+++ b/crates/paperback-core/src/ffi_config.rs
@@ -17,6 +17,22 @@ impl ConfigManagerFfi {
 		self.inner.lock().unwrap().initialize(config_path.into())
 	}
 
+	pub fn get_doc_key(&self, path: String) -> String {
+		self.inner.lock().unwrap().get_doc_key(&path)
+	}
+
+	pub fn get_app_string(&self, key: String, default_value: String) -> String {
+		self.inner.lock().unwrap().get_app_string(&key, &default_value)
+	}
+
+	pub fn set_app_string(&self, key: String, value: String) {
+		self.inner.lock().unwrap().set_app_string(&key, &value);
+	}
+
+	pub fn associate_uri_with_local_file(&self, uri: String, local_path: String) {
+		self.inner.lock().unwrap().associate_uri_with_local_file(&uri, &local_path);
+	}
+
 	pub fn set_document_position(&self, path: String, position: i64) {
 		self.inner.lock().unwrap().set_document_position(&path, position);
 	}

--- a/crates/paperback-core/src/paperback.udl
+++ b/crates/paperback-core/src/paperback.udl
@@ -59,6 +59,10 @@ interface ConfigManagerFfi {
 	constructor();
 
 	boolean initialize(string config_path);
+	string get_doc_key(string path);
+	string get_app_string(string key, string default_value);
+	void set_app_string(string key, string value);
+	void associate_uri_with_local_file(string uri, string local_path);
 	void set_document_position(string path, i64 position);
 	i64 get_document_position(string path);
 	void add_recent_document(string path);


### PR DESCRIPTION
- Document Tracking Consistency: Implemented `associate\_uri\_with\_local\_file` in the Rust core and exposed it via UniFFI. Opening a document from a new location now successfully ties back to its hashed document key. This ensures reading positions and history are correctly preserved even if the file path changes, matching the Windows behavior. 
- Intent Focus Switching: Handled `onNewIntent` in the main activity and `LaunchedEffect` in Compose. Opening a new book from an external file manager while the app is already running will now properly load the document and switch the active tab focus. Tested
- add More Options Menu: Replaced the Recent Books button with a more options menu that has the recent documents option and more in the future. also added custom actions so TalkBack users can activate Recent Documents directly without opening the menu, the hint on double tap does tell that double tapping will show all the options in a menu. 
- Table of Contents TalkBack Fix: TalkBack can now read chapter titles character by character.
- Globally renamed "Recent Books" to "Recent Documents".
- Added the paneTitle to the Recent Documents dialog so it announces recent documents  instead of just "Dialog".
- Hid the redundant "Closed" status text when viewing recent documents on the empty home screen.