### PR TITLE
feat: add Polish translation

### DIFF
--- a/doc/readme-pl.md
+++ b/doc/readme-pl.md
@@ -1,0 +1,382 @@
+# Paperback - wersja 0.8.5
+
+## Wprowadzenie
+
+Paperback to lekki, szybki i dostępny czytnik e-booków i dokumentów dla wszystkich: od osób czytających okazjonalnie po zaawansowanych użytkowników. Został zaprojektowany z myślą o dostępności dla czytników ekranu, dużej szybkości działania i wygodzie bez zbędnych dodatków.
+
+## Wymagania systemowe
+
+Paperback działa obecnie w systemach Windows 10/11 i Linux. Obsługa systemu macOS jest planowana.
+
+## Funkcje
+
+* Całkowicie samodzielna aplikacja, która nie wymaga instalowania dodatkowego oprogramowania na komputerze, aby zacząć czytać.
+* Bardzo szybkie działanie, nawet na starszym sprzęcie.
+* Prosty interfejs z kartami, który pozwala otworzyć obok siebie tyle dokumentów, ile potrzebujesz.
+* Zapisuje pozycję kursora w każdym otwieranym dokumencie.
+* Opcjonalnie zapamiętuje dokumenty otwarte przy zamknięciu programu i przywraca je przy następnym uruchomieniu.
+* Zaprojektowany przez użytkownika czytnika ekranu dla użytkowników czytników ekranu.
+* Zawiera funkcje nawigacji podobne do tych znanych z trybu przeglądania stron internetowych w wielu czytnikach ekranu, aby szybko i łatwo poruszać się po dokumentach.
+* Zawiera rozbudowany dialog Znajdź, między innymi z historią i obsługą wyrażeń regularnych.
+* Może działać w pełni przenośnie albo zostać zainstalowany z automatycznym skojarzeniem typów plików.
+
+## Aktualnie obsługiwane typy plików
+
+Paperback obsługuje następujące formaty i rozszerzenia:
+
+* Pliki pomocy CHM (`.chm`)
+* Książki EPUB (`.epub`)
+* E-booki FB2 (`.fb2`)
+* Dokumenty HTML (`.htm`, `.html`, `.xhtml`)
+* Dokumenty Markdown (`.md`, `.markdown`, `.mdx`, `.mdown`, `.mdwn`, `.mkd`, `.mkdn`, `.mkdown`, `.ronn`)
+* Dokumenty Microsoft Word (`.docx`, `.docm`)
+* Prezentacje OpenDocument (`.odp`, `.fodp`)
+* Pliki tekstowe OpenDocument (`.odt`, `.fodt`)
+* Dokumenty PDF (`.pdf`)
+* Prezentacje PowerPoint (`.pptx`, `.pptm`)
+* Dokumenty RTF (`.rtf`)
+* Pliki zwykłego tekstu i dzienników (`.txt`, `.log`)
+* Dokumenty XML (`.xml`)
+
+## Skróty klawiszowe
+
+Paperback został zaprojektowany przede wszystkim do pracy z klawiaturą i czytnikiem ekranu. Poniżej znajdują się aktualne skróty.
+
+### Menu Plik
+
+* `Ctrl+O`: Otwórz dokument.
+* `Ctrl+F4`: Zamknij bieżący dokument.
+* `Ctrl+Shift+F4`: Zamknij wszystkie otwarte dokumenty.
+* `Ctrl+R`: Pokaż dialog Wszystkie dokumenty (z menu Ostatnie dokumenty).
+
+### Menu Przejdź
+
+* `Ctrl+F`: Pokaż dialog Znajdź.
+* `F3`: Znajdź następne.
+* `Shift+F3`: Znajdź poprzednie.
+* `Ctrl+G`: Przejdź do wiersza.
+* `Ctrl+Shift+G`: Przejdź do procentu.
+* `Ctrl+P`: Przejdź do strony (gdy jest obsługiwana przez bieżący dokument).
+* `Alt+Left`: Przejdź wstecz w historii nawigacji.
+* `Alt+Right`: Przejdź do przodu w historii nawigacji.
+* `[`: Poprzednia sekcja.
+* `]`: Następna sekcja.
+* `Shift+H`: Poprzedni nagłówek.
+* `H`: Następny nagłówek.
+* `Shift+1` do `Shift+6`: Poprzedni nagłówek poziomu 1-6.
+* `1` do `6`: Następny nagłówek poziomu 1-6.
+* `Shift+P`: Poprzednia strona.
+* `P`: Następna strona.
+* `Shift+B`: Poprzednia zakładka.
+* `B`: Następna zakładka.
+* `Shift+N`: Poprzednia notatka.
+* `N`: Następna notatka.
+* `Ctrl+B`: Przejdź do wszystkich zakładek i notatek.
+* `Ctrl+Alt+B`: Przejdź tylko do zakładek.
+* `Ctrl+Alt+M`: Przejdź tylko do notatek.
+* `Ctrl+Shift+W`: Wyświetl tekst notatki w bieżącej pozycji.
+* `Shift+K`: Poprzedni odnośnik.
+* `K`: Następny odnośnik.
+* `Shift+T`: Poprzednia tabela.
+* `T`: Następna tabela.
+* `Shift+S`: Poprzedni separator.
+* `S`: Następny separator.
+* `Shift+L`: Poprzednia lista.
+* `L`: Następna lista.
+* `Shift+I`: Poprzedni element listy.
+* `I`: Następny element listy.
+
+### Menu Narzędzia
+
+* `Ctrl+W`: Pokaż liczbę słów w bieżącym dokumencie.
+* `Ctrl+I`: Pokaż informacje o dokumencie.
+* `Ctrl+T`: Pokaż Spis treści.
+* `F7`: Pokaż Listę elementów.
+* `Ctrl+Shift+C`: Otwórz folder zawierający.
+* `Ctrl+Shift+V`: Otwórz bieżącą treść w Widoku WWW.
+* `Ctrl+Shift+E`: Eksportuj dane dokumentu (`.paperback`).
+* `Ctrl+Shift+I`: Importuj dane dokumentu (`.paperback`).
+* `Ctrl+E`: Eksportuj bieżący dokument do zwykłego tekstu.
+* `Ctrl+Shift+B`: Przełącz zakładkę przy bieżącym zaznaczeniu lub kursorze.
+* `Ctrl+Shift+N`: Dodaj lub edytuj notatkę zakładki przy bieżącym zaznaczeniu lub kursorze.
+* `Ctrl+,`: Otwórz Opcje.
+* `Ctrl+Shift+S`: Przełącz Wyłącznik czasowy.
+
+### Menu Pomoc
+
+* `Ctrl+F1`: Pokaż dialog O programie Paperback.
+* `F1`: Wyświetl pomoc w domyślnej przeglądarce.
+* `Shift+F1`: Wyświetl pomoc w Paperbacku.
+* `Ctrl+Shift+U`: Sprawdź aktualizacje.
+* `Ctrl+D`: Otwórz stronę wsparcia w domyślnej przeglądarce.
+
+### Dodatkowe klawisze w widoku dokumentu
+
+* `Delete` / `Numpad Delete` na kontrolce kart: zamknij kartę wybranego dokumentu.
+* `Enter` w tekście dokumentu: aktywuj odnośnik pod kursorem albo otwórz Widok tabeli, jeśli kursor znajduje się na znaczniku tabeli.
+* `Shift+F10` w tekście dokumentu: otwórz menu kontekstowe.
+
+## Obsługiwane języki
+
+Paperback jest tłumaczony na wiele języków, a kolejne są stale dodawane. Pełna lista znajduje się poniżej.
+
+Aby dowiedzieć się, jak pomóc w tłumaczeniu, przeczytaj [Przewodnik po tłumaczeniach](https://paperback.dev/translations/).
+
+* Bośniacki
+* Chiński uproszczony
+* Czeski
+* Fiński
+* Francuski
+* Hiszpański
+* Japoński
+* Niemiecki
+* Polski
+* Portugalski (Brazylia)
+* Rosyjski
+* Serbski
+* Wietnamski
+
+## Podziękowania
+### Tworzenie programu
+* Quin Gillespie: główny programista i założyciel projektu.
+* Aryan Choudhary: główny współtwórca.
+
+### Darowizny
+Poniższe osoby przekazały darowizny na rozwój Paperbacka. Jeśli przekażesz darowiznę, Twoje imię i nazwisko nie zostanie tu dodane automatycznie. Dodaję tylko osoby, które chcą, aby ich wsparcie było publiczne.
+
+Uwaga: publiczne sponsorowanie w GitHub traktuję jako podstawę do automatycznego dodania do tej listy.
+
+* Alex Hall
+* Brandon McGinty
+* Brian Hartgen
+* Debbie Yuille
+* Devin Prater
+* Felix Steindorff
+* Hamish Mackenzie
+* James Scholes
+* Jayson Smith
+* Jonathan Rodriguez
+* Jonathan Schuster
+* Keao Wright
+* Pratik Patel
+* Roberto Perez
+* Sean Randall
+* Timothy Wynn
+* Tyler Rodick
+
+## Lista zmian
+
+### Wersja 0.8.5
+* Dodano obsługę stron w książkach EPUB.
+* Dodano obsługę zaszyfrowanych dokumentów Microsoft Office. Obecnie obsługiwane są starsze dokumenty Word, nowoczesne dokumenty Word i nowoczesne prezentacje PowerPoint; obsługa starszych prezentacji PowerPoint jest planowana.
+* Dodano obsługę starszych dokumentów Microsoft Word (*.doc)!
+* Dodano obsługę starszych prezentacji PowerPoint (*.ppt)!
+* Dodano obsługę książek MOBI i AZW3!
+* Dodano obsługę tagowanych plików PDF!
+* Dodano skrót Ctrl+Q do zakończenia aplikacji.
+* Dodano obsługę spakowanych książek z Bookshare (zarówno DAISY, jak i Word)!
+* Tekst alternatywny osadzonych obrazów powinien być teraz poprawnie pokazywany.
+* Dokumenty CHM prawidłowo obsługują teraz nawigację po odnośnikach wewnętrznych.
+* Naprawiono odtwarzanie dźwięków zakładek na początku akapitu zamiast w pozycji zakładki.
+* Naprawiono przesunięcie o 1 przy poleceniu Przejdź do strony.
+* Naprawiono brak możliwości zamknięcia dialogu Otwórz jako klawiszem Escape.
+* Naprawiono niewyświetlanie menu kontekstowego czytnika po kliknięciu prawym przyciskiem myszy albo użyciu klawisza Aplikacje.
+* Naprawiono sytuację, w której podczas otwierania dokumentów z wiersza poleceń fokus czasami trafiał do niewłaściwego dokumentu.
+* Pliki PDF zawierające wyłącznie obrazy są ponownie wykrywane i aplikacja informuje o ich istnieniu.
+* Można teraz nawigować po obrazach i rysunkach odpowiednio za pomocą `G`/`Shift+G` oraz `F`/`Shift+F`.
+* Paperback respektuje teraz ustawienie ciemnego trybu aplikacji.
+* Usunięto obsługę DAISY XML, ponieważ nie jest już potrzebna.
+* W drzewie Spisu treści przywrócono natywną nawigację Win32 po pierwszych literach.
+* Dialog błędu wczytywania pokazuje teraz bardziej szczegółowe komunikaty.
+* Widok WWW otwiera się teraz znacznie szybciej i płynniej.
+
+### Wersja 0.8.2
+* Dodano obsługę stron w dokumentach RTF!
+* Naprawiono błąd, przez który otwarcie Widoku WWW w plikach EPUB zawierających odnośniki zewnętrzne automatycznie je aktywowało.
+* Naprawiono błąd, przez który parser RTF w rzadkich przypadkach nie dodawał spacji między słowami.
+* Naprawiono dzielenie akapitów na wiele krótkich wierszy w niektórych dokumentach PDF.
+* Dokumenty PDF mają teraz podstawową obsługę nawigacji po odnośnikach i nagłówkach!
+* Tabulatory i znaki końca wiersza w RTF są teraz renderowane dokładnie tak, jak występują w dokumencie.
+* Przywrócono sprawdzoną bibliotekę pdfium do parsowania plików PDF, dzięki czemu renderowanie PDF jest ponownie znacznie bardziej niezawodne.
+
+### Wersja 0.8.1
+* Dodano skrót Ctrl+Shift+T do ponownego otwarcia ostatnio zamkniętego dokumentu.
+* Dialog Wszystkie dokumenty obsługuje teraz wybór wielu dokumentów do jednoczesnego otwarcia.
+* Naprawiono kilka błędów w parserze RTF.
+* Naprawiono uszkadzanie ścieżek plików zawierających znaki spoza ASCII (na przykład bośniackie š, č, ć, ž) przy otwieraniu pliku przez drugą instancję Paperbacka.
+* Naprawiono odczytywanie tekstu z PDF w niewłaściwej kolejności oraz błędne odstępy wokół słów pisanych wielkimi literami.
+* Naprawiono powolne wczytywanie dużych dokumentów.
+* Naprawiono lokalizację przycisków Tak/Nie w dialogach potwierdzenia.
+
+### Wersja 0.8.0
+* Dodano tłumaczenia na japoński, chiński uproszczony i wietnamski!
+* Dodano automatyczny aktualizator, który zastępuje obecnie zainstalowaną wersję Paperbacka, zamiast tylko pobierać nową wersję!
+* Dodano opcjonalną informację dźwiękową przy dotarciu do zakładki lub notatki. Dziękujemy Andre Louisowi za dźwięki!
+* Dodano obsługę dokumentów RTF!
+* Dodano obsługę dokumentów DAISY XML.
+* Dodano obsługę płaskich plików tekstowych OpenDocument!
+* Dodano obsługę płaskich prezentacji OpenDocument!
+* Dodano obsługę separatorów z użyciem `S` i `Shift+S`.
+* Każde przesunięcie o więcej niż 300 znaków jest teraz automatycznie dodawane do historii nawigacji.
+* Naprawiono przywracanie okna Paperbacka z zasobnika systemowego.
+* Naprawiono pokazywanie surowego tekstu zamiast wyrenderowanego HTML w Widoku WWW dla dokumentów Markdown.
+* Naprawiono nieprawidłowe renderowanie tabel w plikach Markdown.
+* Pliki PDF zawierające wyłącznie obrazy wyświetlają teraz ostrzeżenie przy próbie wczytania.
+* Podczas sprawdzania aktualizacji można teraz szukać nowych wersji deweloperskich zamiast tylko wydań stabilnych.
+* Poprawnie osadzono informacje o wersji w pliku wykonywalnym Paperbacka.
+* Podzielono dialog Opcje na karty, aby ułatwić używanie i nawigację.
+* Przejście na bibliotekę Hayro do parsowania PDF zwiększyło niezawodność i szybkość oraz zmniejszyło liczbę bibliotek DLL.
+* Cała aplikacja została przepisana w Rust. Nowy kod jest bezpieczniejszy, szybciej wczytuje dokumenty i łatwiej go utrzymywać oraz rozwijać.
+* Menu kontekstowe kontrolki tekstu z treścią dokumentu zawiera teraz działania specyficzne dla czytnika, zamiast ogólnych pozycji takich jak wytnij i wklej.
+
+### Wersja 0.7.0
+* Dodano obsługę tabel w dokumentach opartych na HTML i XHTML! Między tabelami można przechodzić za pomocą `T` i `Shift+T`, a po naciśnięciu `Enter` można wyświetlić tabelę w Widoku WWW.
+* Dodano podstawową funkcję renderowania WWW! Naciśnij `Ctrl+Shift+V`, aby otworzyć bieżącą sekcję dokumentu w Widoku WWW; jest to przydatne przy treściach takich jak złożone formatowanie lub przykłady kodu.
+* Dodano rosyjskie tłumaczenie. Dziękujemy Ruslanowi Gulmagomedovowi!
+* Dodano przycisk Wyczyść wszystko w dialogu Wszystkie dokumenty.
+* Kontroler aktualizacji pokazuje teraz informacje o wydaniu, gdy dostępna jest nowa wersja.
+* Naprawiono przywracanie okna z zasobnika systemowego.
+* Naprawiono tłumaczenia przycisków Tak/Nie w dialogach potwierdzenia.
+* Naprawiono wczytywanie konfiguracji podczas uruchamiania jako administrator.
+* Naprawiono obsługę komentarzy w dokumentach XML i HTML.
+* Naprawiono parsowanie Spisu treści w książkach EPUB 2.
+* Naprawiono przechodzenie do następnego elementu o tej samej pierwszej literze w Spisie treści.
+* Naprawiono nieprawidłowe ukrywanie dialogu Znajdź podczas używania przycisków następne/poprzednie.
+* Naprawiono sytuacje, w których Spis treści w dokumentach EPUB czasami przenosił do niewłaściwego elementu.
+* Naprawiono różne problemy z obsługą białych znaków w XML, HTML i znacznikach pre.
+* Naprawiono przesunięcie o jeden odnośnik podczas nawigacji po odnośnikach.
+* Naprawiono problem z nadmiarowymi białymi znakami na końcach wierszy w niektórych książkach.
+* Naprawiono różne problemy parsera.
+* Pozycje menu związane z zakładkami oraz Lista elementów są teraz prawidłowo wyłączone, gdy żaden dokument nie jest otwarty.
+* Usprawniono obsługę list w różnych formatach dokumentów.
+* Usprawniono proces pracy nad tłumaczeniami dla współtwórców.
+* Wprowadzono wiele wewnętrznych refaktoryzacji, przenosząc większość logiki aplikacji z C++ do Rusta, aby poprawić wydajność i łatwość utrzymania.
+
+### Wersja 0.6.1
+* Dodano obsługę plików PDF chronionych hasłem!
+* Dodano bardzo prostą funkcję przechodzenia do poprzedniej/następnej pozycji. Jeśli naciśniesz `Enter` na odnośniku wewnętrznym i kursor zostanie przeniesiony, ta pozycja zostanie zapamiętana i będzie można do niej wracać za pomocą `Alt+Left`/`Alt+Right`.
+* Dodano Listę elementów! Obecnie pokazuje tylko drzewo wszystkich nagłówków w dokumencie albo listę odnośników, ale w przyszłości planowane jest jej rozszerzenie.
+* Dodano opcję uruchamiania Paperbacka w zmaksymalizowanym oknie domyślnie.
+* Naprawiono nieprawidłowe działanie odnośników w niektórych dokumentach EPUB.
+* Naprawiono parsowanie Spisu treści EPUB zawierającego ścieżki względne.
+* Naprawiono brak tytułu lub autora w niektórych dokumentach EPUB.
+* Naprawiono nieprawidłowe wyświetlanie tytułów niektórych rozdziałów EPUB w dialogu Spis treści.
+* Naprawiono brak możliwości aktywowania przycisków OK/Anuluj w dialogu Spis treści za pomocą spacji.
+* Ulepszono obsługę nagłówków w dokumentach Word.
+* Teraz otrzymasz informację głosową, jeśli lista ostatnich dokumentów jest pusta, gdy próbujesz otworzyć dialog.
+
+### Wersja 0.6.0
+* Do dialogu Opcje dodano nową opcję pokazywania menu Przejdź w dużo bardziej kompaktowej formie. Jest ona domyślnie włączona.
+* Dodano opcję zawijania nawigacji po elementach strukturalnych.
+* Do menu Narzędzia dodano opcję otwierania folderu zawierającego aktualnie aktywny dokument.
+* Dodano prosty, ale skuteczny system aktualizacji.
+* Dodano podstawowy Wyłącznik czasowy dostępny skrótem `Ctrl+Shift+S`.
+* Dodano obsługę parsowania e-booków FB2!
+* Dodano obsługę parsowania prezentacji OpenDocument!
+* Dodano obsługę parsowania plików tekstowych OpenDocument!
+* Zakładki mogą teraz obejmować cały wiersz albo tylko wskazany tekst. Jeśli podczas dodawania zakładki nic nie jest zaznaczone, działanie pozostaje takie jak przed wersją 0.6 i zakładka obejmuje cały wiersz. Jeśli zaznaczysz tekst, w zakładce znajdzie się tylko ten tekst.
+* Zakładki mogą teraz mieć opcjonalne notatki tekstowe. Między zakładkami z notatkami można przechodzić klawiszami `N` i `Shift+N`, a dialog zakładek można otwierać z widokiem wszystkich zakładek, tylko notatek albo tylko zakładek bez notatek za pomocą osobnych skrótów.
+* Zakładki w dialogu zakładek nie mają już irytującego prefiksu "zakładka x".
+* Książki EPUB zawierające treść HTML udającą XML są teraz obsługiwane poprawnie.
+* Naprawiono wczytywanie dużych dokumentów Markdown.
+* Naprawiono aktywowanie przycisku OK po naciśnięciu spacji w widoku drzewa Spisu treści.
+* Naprawiono obsługę białych znaków na początku znaczników pre w dokumentach HTML i XHTML.
+* Naprawiono sytuacje, w których kontrolka tekstu czasami nie odzyskiwała fokusu po powrocie do okna Paperbacka.
+* Naprawiono brak aktualizacji wartości suwaka przez pole tekstowe w dialogu Przejdź do procentu.
+* Naprawiono renderowanie własnych identyfikatorów HTML w dokumentach Markdown.
+* HTML wewnątrz bloków kodu Markdown jest teraz renderowany poprawnie.
+* Jeśli książka jest wczytywana przez parametr wiersza poleceń, gdy działa już istniejąca instancja Paperbacka, nie pojawi się już błąd, jeśli wczytywanie dokumentu trwa dłużej niż 5 sekund.
+* Jeśli Paperback działa jako administrator, konfiguracja jest teraz poprawnie wczytywana i zapisywana.
+* Można teraz usunąć zakładkę bezpośrednio z dialogu zakładek.
+* Można teraz importować i eksportować zakładki oraz pozycję czytania dla konkretnego dokumentu. Wygenerowany plik otrzymuje nazwę dokumentu z rozszerzeniem `.paperback`. Jeśli taki plik zostanie znaleziony w tym samym katalogu podczas wczytywania dokumentu, zostanie wczytany automatycznie. W przeciwnym razie można go zaimportować ręcznie z menu Narzędzia.
+* Odnośniki wewnątrz dokumentów są teraz w pełni obsługiwane. Użyj `K` i `Shift+K`, aby przechodzić po nich do przodu i do tyłu, a `Enter`, aby otworzyć albo aktywować odnośnik.
+* Wprowadzono wiele wewnętrznych refaktoryzacji, dzięki którym aplikacja jest szybsza, a plik binarny mniejszy.
+* Treść Markdown jest teraz wstępnie przetwarzana do zgodności z CommonMark przed renderowaniem.
+* Nawigacja po listach i ich elementach jest teraz w pełni obsługiwana. Użyj `L` i `Shift+L`, aby przechodzić po listach, oraz `I` i `Shift+I`, aby przechodzić po elementach listy.
+* `Numpad Delete` działa teraz przy usuwaniu dokumentów z paska kart, tak samo jak zwykły `Delete`.
+* Paperback może teraz opcjonalnie minimalizować się do zasobnika systemowego. Ta opcja jest domyślnie wyłączona, ale po jej włączeniu minimalizacja z menu systemowego przenosi Paperback do zasobnika, skąd można go przywrócić kliknięciem utworzonej ikony.
+* Paperback jest teraz w pełni tłumaczalny! Lista obsługiwanych języków jest obecnie dość krótka, ale stale rośnie.
+* Paperback ma teraz oficjalną stronę: [paperback.dev](https://paperback.dev)!
+* Dokumenty PPTX pokazują teraz podstawowy Spis treści zawierający wszystkie slajdy.
+* W dialogu Informacje o dokumencie pokazywana jest teraz pełna ścieżka do otwartego dokumentu.
+* Instalator zawiera teraz opcję wyświetlenia pliku readme w przeglądarce po instalacji.
+* Lista ostatnich dokumentów została znacznie rozszerzona. Zamiast pokazywać tylko 10 ostatnio otwartych dokumentów, pokazuje teraz konfigurowalną liczbę dokumentów, a pozostałe dokumenty kiedykolwiek otwarte są dostępne w małym dialogu.
+* Wprowadzono różne drobne ulepszenia parserów, między innymi dodanie pustego wiersza między slajdami w prezentacjach PPTX, naprawienie obsługi nowych wierszy wewnątrz akapitów w dokumentach Word oraz dodanie punktorów do elementów listy.
+
+### Wersja 0.5.0
+* Dodano obsługę dokumentów Microsoft Word!
+* Dodano obsługę prezentacji PowerPoint!
+* Naprawiono brak wyłączania niektórych pozycji menu, gdy żaden dokument nie jest otwarty.
+* Naprawiono orientację suwaka Przejdź do procentu.
+* Naprawiono Spis treści w książkach EPUB ze ścieżkami plików kodowanymi jako URL i/lub identyfikatorami fragmentów.
+* Naprawiono nietypowe usuwanie białych znaków z nagłówków XHTML.
+* Naprawiono obsługę białych znaków wewnątrz zagnieżdżonych znaczników pre w dokumentach HTML.
+* Dokumenty HTML i Markdown obsługują teraz funkcję Spisu treści. Po wczytaniu dokumentu HTML/Markdown Paperback zbuduje własny Spis treści na podstawie struktury nagłówków w dokumencie i pokaże go w dialogu `Ctrl+T`.
+* Dokumenty HTML mają teraz tytuł ustawiony w znaczniku title, jeśli taki istnieje. W przeciwnym razie nadal używana jest nazwa pliku bez rozszerzenia.
+* Zamiast UniversalSpeech używany jest teraz live region do zgłaszania mowy. Dzięki temu wraz z programem nie są już dostarczane biblioteki DLL czytników ekranu, a obsługiwanych jest więcej czytników, na przykład Microsoft Narrator.
+* Zmieniono bibliotekę ZIP, aby umożliwić otwieranie szerszego zakresu książek EPUB.
+* Dialog pytający, czy chcesz otworzyć dokument jako zwykły tekst, został całkowicie przebudowany i pozwala teraz otworzyć dokument jako zwykły tekst, HTML albo Markdown.
+* Dialog Przejdź do procentu zawiera teraz pole tekstowe pozwalające ręcznie wpisać procent, do którego chcesz przejść.
+* Parser HTML rozpoznaje teraz `dd`, `dt` i `dl` jako elementy list.
+* Spis treści w książkach EPUB jest ponownie zachowywany dokładnie.
+* Podczas usuwania pustych wierszy uwzględniana jest teraz nierozdzielająca spacja Unicode.
+* Program nie pyta już, jak otworzyć nierozpoznany plik przy każdym jego wczytaniu, a tylko za pierwszym razem.
+
+### Wersja 0.4.1
+* Dodano opcjonalną ikonę w menu Start w instalatorze.
+* Spis treści powinien być teraz w kilku przypadkach czytelniejszy; na przykład jeśli element podrzędny i nadrzędny mają ten sam tekst w tej samej pozycji, zobaczysz tylko element nadrzędny.
+* Naprawiono Spis treści w niektórych dokumentach CHM.
+* Naprawiono Spis treści w książkach EPUB 3 ze ścieżkami bezwzględnymi.
+* Dokumenty CHM powinny teraz pokazywać tytuł ustawiony w pliku metadanych.
+
+### Wersja 0.4.0
+* Dodano obsługę plików CHM!
+* Dodano obsługę zakładek! Możesz mieć dowolną liczbę zakładek w dowolnej liczbie dokumentów. Do przodu i do tyłu przechodzisz po nich klawiszami `B` i `Shift+B`, ustawiasz je skrótem `Ctrl+Shift+B`, a dialog przejścia do konkretnej zakładki otwierasz skrótem `Ctrl+B`.
+* Dodano instalator obok przenośnego pliku ZIP! Instalator zainstaluje Paperbacka w katalogu Program Files i automatycznie skonfiguruje skojarzenia plików.
+* Pliki tekstowe z BOM powinny być teraz poprawnie dekodowane, a BOM nie będzie już pokazywany na początku tekstu.
+* Dodano znacznie więcej informacji do paska stanu. Pokazuje on teraz bieżący wiersz, znak i procent czytania.
+* Komentarze HTML oraz zawartość znaczników script i style nie są już pokazywane w wyjściu tekstowym.
+* Jeśli w wierszu poleceń podasz ścieżkę względną do Paperbacka, zostanie ona teraz poprawnie rozwiązana.
+* Przechodzenie procentowe jest teraz obsługiwane przez osobny dialog oparty na suwaku, dostępny skrótem `Ctrl+Shift+G`.
+* Dokumenty bez znanych tytułów lub autorów mają teraz zawsze wartość domyślną.
+* Logika zapisywania pozycji jest teraz dużo inteligentniejsza i zapisuje na dysk tylko wtedy, gdy jest to naprawdę potrzebne.
+* Dokument, który był aktywny podczas zamykania Paperbacka, jest teraz zapamiętywany między uruchomieniami aplikacji.
+* Dane wejściowe w dialogach Przejdź do wiersza i Przejdź do strony są teraz bardziej rygorystycznie oczyszczane.
+* Naprawiono nawigację po Spisie treści w książkach EPUB 3 ze ścieżkami względnymi w manifestach.
+
+### Wersja 0.3.0
+* Naprawiono Spis treści w książkach EPUB z manifestami kodowanymi jako URL.
+* Naprawiono nawigację po nagłówkach w dokumentach HTML zawierających wielobajtowe znaki Unicode.
+* Naprawiono wysokie użycie CPU w dokumentach z długimi tytułami spowodowane regresją w wxWidgets.
+* Naprawiono wczytywanie plików tekstowych UTF-8.
+* Naprawiono umieszczanie kursora w niewłaściwej pozycji przez zagnieżdżone elementy Spisu treści w książkach EPUB.
+* Naprawiono awarię przy zamykaniu aplikacji w niektórych przypadkach.
+* Dodano pole wyboru w dialogu Opcje do włączania lub wyłączania zawijania wierszy!
+* Można teraz wspierać rozwój Paperbacka darowizną, przez nową pozycję Wesprzyj w menu Pomoc albo przez odnośnik sponsorowania projektu na dole głównej strony repozytorium GitHub.
+* Dokumenty Markdown mają teraz zawsze tytuł, a Paperback powinien być w stanie wczytać praktycznie każdy plik Markdown.
+* Dokumenty PDF mają teraz zawsze tytuł, nawet jeśli brakuje go w metadanych.
+* Zmieniono bibliotekę PDF na tę używaną w Chromium, co daje znacznie bardziej niezawodne parsowanie PDF.
+* W danym momencie może działać tylko jedna instancja Paperbacka. Uruchomienie `paperback.exe` z nazwą pliku, gdy program już działa, otworzy ten dokument w istniejącej instancji.
+* Możesz teraz nacisnąć `Delete` na dokumencie w kontrolce kart, aby go zamknąć.
+
+### Wersja 0.2.1
+* Dodano całkowitą liczbę stron do etykiety strony w dialogu Przejdź do strony.
+* Zezwolono na przechodzenie klawiszem Tab od treści dokumentu do listy otwartych dokumentów.
+* Naprawiono sporadyczne otwieranie ostatnich dokumentów przez skróty nagłówków, jeśli było ich wystarczająco dużo.
+* Paperback usuwa teraz zbędne miękkie dywizy z wyjścia tekstowego.
+* Naprawiono sytuacje, w których nawigacja po nagłówkach czasami ustawiała kursor na niewłaściwym znaku.
+
+### Wersja 0.2.0
+* Dodano obsługę dokumentów Markdown!
+* Dodano obsługę dokumentów PDF, w tym możliwość nawigacji między stronami!
+* Dodano skróty do nawigacji po nagłówkach w treści HTML, w tym w książkach EPUB i dokumentach Markdown. Skróty te zaprojektowano tak, aby działały podobnie do czytnika ekranu.
+* Naprawiono wczytywanie książek EPUB z nazwami plików kodowanymi jako URL w manifestach.
+* Naprawiono wczytywanie książek EPUB 3 z osadzonym XHTML.
+* Komunikat jest teraz wypowiadany, jeśli dokument nie obsługuje Spisu treści lub sekcji; wcześniej pozycje menu były po prostu wyłączane.
+* Dodano menu Ostatnie dokumenty! Obecnie przechowuje 10 ostatnio otwartych dokumentów, a naciśnięcie `Enter` na jednym z nich otwiera go do czytania.
+* Całkowicie przepisano dialog Znajdź, dzięki czemu jest znacznie prostszy w użyciu, a jednocześnie dodano historię ostatnich 25 wyszukiwań i obsługę wyrażeń regularnych!
+* Poprzednio otwarte dokumenty są teraz zapamiętywane między uruchomieniami aplikacji. Można to skonfigurować przez nową pozycję Opcje w menu Narzędzia.
+* Dodano `Shift+F1`, aby otwierać plik readme bezpośrednio w Paperbacku.
+
+### Wersja 0.1.0
+* Pierwsze wydanie.

--- a/doc/readme.md
+++ b/doc/readme.md
@@ -124,9 +124,12 @@ To learn how to contribute, please read our [Translation Guide](translating.md).
 
 * Bosnian
 * Czech
+* Finnish
 * French
 * German
 * Japanese
+* Polish
+* Portuguese (Brazil)
 * Russian
 * Simplified Chinese
 * Serbian

--- a/po/pl.po
+++ b/po/pl.po
@@ -1,0 +1,1331 @@
+# Polish translation for Paperback.
+# Copyright (C) 2026 Quin Gillespie
+# This file is distributed under the same license as the paperback package.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: paperback 0.8.5\n"
+"Report-Msgid-Bugs-To: https://github.com/trypsynth/paperback/issues\n"
+"POT-Creation-Date: 2026-06-03 18:57+0530\n"
+"PO-Revision-Date: 2026-06-08 13:45+0200\n"
+"Last-Translator: Michał Dziwisz <michal@dziwisz.net>\n"
+"Language-Team: Polish\n"
+"Language: pl\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=(n==1 ? 0 : n%10>=2 && n%10<=4 && (n%100<12 || n%100>14) ? 1 : 2);\n"
+
+msgid "Failed to create IPC server"
+msgstr "Nie udało się utworzyć serwera IPC"
+
+msgid "Warning"
+msgstr "Ostrzeżenie"
+
+msgid "An accessible, lightweight, fast ebook and document reader"
+msgstr "Dostępny, lekki i szybki czytnik e-booków i dokumentów"
+
+msgid "expanded"
+msgstr "rozwinięte"
+
+msgid "collapsed"
+msgstr "zwinięte"
+
+msgid "All Documents"
+msgstr "Wszystkie dokumenty"
+
+msgid "&search"
+msgstr "&Szukaj"
+
+msgid "&Yes"
+msgstr "&Tak"
+
+msgid "&No"
+msgstr "&Nie"
+
+msgid "File Name"
+msgstr "Nazwa pliku"
+
+msgid "Status"
+msgstr "Status"
+
+msgid "Path"
+msgstr "Ścieżka"
+
+msgid "&Open"
+msgstr "&Otwórz"
+
+msgid "&Remove"
+msgstr "&Usuń"
+
+msgid "&Clear All"
+msgstr "&Wyczyść wszystko"
+
+msgid "Close"
+msgstr "Zamknij"
+
+msgid ""
+"Are you sure you want to remove this document from the list? This will also "
+"remove its reading position."
+msgstr ""
+"Czy na pewno chcesz usunąć ten dokument z listy? Spowoduje to też usunięcie "
+"jego pozycji czytania."
+
+msgid ""
+"Are you sure you want to remove these {} documents from the list? This will "
+"also remove their reading positions."
+msgstr ""
+"Czy na pewno chcesz usunąć te dokumenty ({}) z listy? Spowoduje to też "
+"usunięcie ich pozycji czytania."
+
+msgid "Confirm"
+msgstr "Potwierdzenie"
+
+msgid ""
+"Are you sure you want to remove all documents from the list? This will also "
+"remove all reading positions and bookmarks."
+msgstr ""
+"Czy na pewno chcesz usunąć wszystkie dokumenty z listy? Spowoduje to też "
+"usunięcie wszystkich pozycji czytania i zakładek."
+
+msgid "Open"
+msgstr "Otwórz"
+
+msgid "Closed"
+msgstr "Zamknięty"
+
+msgid "Missing"
+msgstr "Brakujący"
+
+msgid "Jump to Bookmark"
+msgstr "Przejdź do zakładki"
+
+msgid "&Filter:"
+msgstr "&Filtr:"
+
+msgid "All"
+msgstr "Wszystko"
+
+msgid "Bookmarks"
+msgstr "Zakładki"
+
+msgid "Notes"
+msgstr "Notatki"
+
+msgid "&Edit Note"
+msgstr "&Edytuj notatkę"
+
+msgid "&Delete"
+msgstr "&Usuń"
+
+msgid "&Jump"
+msgstr "&Przejdź"
+
+msgid "&Cancel"
+msgstr "&Anuluj"
+
+msgid "blank"
+msgstr "puste"
+
+msgid "Please select a bookmark to jump to."
+msgstr "Wybierz zakładkę, do której chcesz przejść."
+
+msgid "Error"
+msgstr "Błąd"
+
+msgid "Bookmark Note"
+msgstr "Notatka zakładki"
+
+msgid "Edit bookmark note:"
+msgstr "Edytuj notatkę zakładki:"
+
+msgid "Document Info"
+msgstr "Informacje o dokumencie"
+
+msgid "Path:"
+msgstr "Ścieżka:"
+
+msgid "Title:"
+msgstr "Tytuł:"
+
+msgid "Author:"
+msgstr "Autor:"
+
+msgid "Words:"
+msgstr "Słowa:"
+
+msgid "Lines:"
+msgstr "Wiersze:"
+
+msgid "Characters:"
+msgstr "Znaki:"
+
+msgid "Characters (excluding spaces):"
+msgstr "Znaki bez spacji:"
+
+msgid "Elements"
+msgstr "Elementy"
+
+msgid "OK"
+msgstr "OK"
+
+msgid "Cancel"
+msgstr "Anuluj"
+
+msgid "Headings"
+msgstr "Nagłówki"
+
+msgid "Links"
+msgstr "Odnośniki"
+
+msgid "Untitled"
+msgstr "Bez tytułu"
+
+msgid "&View:"
+msgstr "&Widok:"
+
+msgid "Root"
+msgstr "Początek"
+
+msgid "Go to Line"
+msgstr "Przejdź do wiersza"
+
+msgid "&Line number:"
+msgstr "Numer &wiersza:"
+
+msgid "Go to page"
+msgstr "Przejdź do strony"
+
+#, c-format
+msgid "Go to page (%d/%d):"
+msgstr "Przejdź do strony (%d/%d):"
+
+msgid "Go to Percent"
+msgstr "Przejdź do procentu"
+
+msgid "&Percent"
+msgstr "&Procent"
+
+msgid "P&ercent:"
+msgstr "Pro&cent:"
+
+msgid "Open As"
+msgstr "Otwórz jako"
+
+msgid ""
+"No suitable parser was found for {}.\n"
+"How would you like to open this file?"
+msgstr ""
+"Nie znaleziono odpowiedniego parsera dla {}.\n"
+"Jak chcesz otworzyć ten plik?"
+
+msgid "Open &as:"
+msgstr "Otwórz &jako:"
+
+msgid "Plain Text"
+msgstr "Zwykły tekst"
+
+msgid "HTML"
+msgstr "HTML"
+
+msgid "Markdown"
+msgstr "Markdown"
+
+msgid "Options"
+msgstr "Opcje"
+
+msgid "&Restore previously opened documents on startup"
+msgstr "&Przywracaj poprzednio otwarte dokumenty przy uruchomieniu"
+
+msgid "&Word wrap"
+msgstr "&Zawijanie wierszy"
+
+msgid "&Minimize to system tray"
+msgstr "&Minimalizuj do zasobnika systemowego"
+
+msgid "&Start maximized"
+msgstr "&Uruchamiaj w zmaksymalizowanym oknie"
+
+msgid "Show compact &go menu"
+msgstr "Pokaż kompaktowe menu &Przejdź"
+
+msgid "&Wrap navigation"
+msgstr "Zawijaj &nawigację"
+
+msgid "Play &sounds on bookmarks and notes"
+msgstr "Odtwarzaj &dźwięki przy zakładkach i notatkach"
+
+msgid "Check for &updates on startup"
+msgstr "Sprawdzaj &aktualizacje przy uruchomieniu"
+
+msgid "Customize &Window Hotkey..."
+msgstr "Dostosuj &skrót okna..."
+
+msgid "&Reading speed (words per minute):"
+msgstr "&Szybkość czytania (słowa na minutę):"
+
+msgid "Number of &recent documents to show:"
+msgstr "Liczba &ostatnich dokumentów do pokazania:"
+
+msgid "&Language:"
+msgstr "&Język:"
+
+msgid "Update Channel:"
+msgstr "Kanał aktualizacji:"
+
+msgid "Stable"
+msgstr "Stabilny"
+
+msgid "Dev"
+msgstr "Deweloperski"
+
+msgid "Font"
+msgstr "Czcionka"
+
+msgid "Choose &Font..."
+msgstr "Wybierz &czcionkę..."
+
+msgid "&Reset to Default Font"
+msgstr "&Przywróć domyślną czcionkę"
+
+msgid "Background Color"
+msgstr "Kolor tła"
+
+msgid "Choose &Background Color..."
+msgstr "Wybierz kolor &tła..."
+
+msgid "Reset to &Default Background"
+msgstr "Przywróć &domyślne tło"
+
+msgid "&Line spacing:"
+msgstr "&Odstęp między wierszami:"
+
+msgid "Normal"
+msgstr "Normalny"
+
+msgid "1.5\\u{00d7}"
+msgstr "1,5\\u{00d7}"
+
+msgid "Double"
+msgstr "Podwójny"
+
+msgid "&Paragraph spacing:"
+msgstr "Odstęp między &akapitami:"
+
+msgid "Relaxed"
+msgstr "Luźny"
+
+msgid "Wide"
+msgstr "Szeroki"
+
+msgid "L&etter spacing:"
+msgstr "Odstęp między &literami:"
+
+msgid "Very Wide"
+msgstr "Bardzo szeroki"
+
+msgid "Text &alignment:"
+msgstr "&Wyrównanie tekstu:"
+
+msgid "Left"
+msgstr "Do lewej"
+
+msgid "Center"
+msgstr "Do środka"
+
+msgid "Right"
+msgstr "Do prawej"
+
+msgid "Justify"
+msgstr "Wyjustuj"
+
+msgid "General"
+msgstr "Ogólne"
+
+msgid "Reading"
+msgstr "Czytanie"
+
+msgid "Readability"
+msgstr "Czytelność"
+
+msgid "Background: Default"
+msgstr "Tło: domyślne"
+
+msgid "Font: Default"
+msgstr "Czcionka: domyślna"
+
+msgid "Default"
+msgstr "Domyślne"
+
+msgid "Bold"
+msgstr "Pogrubienie"
+
+msgid "Italic"
+msgstr "Kursywa"
+
+msgid "Underlined"
+msgstr "Podkreślenie"
+
+msgid "Strikethrough"
+msgstr "Przekreślenie"
+
+msgid "Window Hotkey"
+msgstr "Skrót okna"
+
+msgid "&Ctrl"
+msgstr "&Ctrl"
+
+msgid "&Alt"
+msgstr "&Alt"
+
+msgid "&Shift"
+msgstr "&Shift"
+
+msgid "&Win"
+msgstr "&Win"
+
+msgid "&Key:"
+msgstr "&Klawisz:"
+
+msgid "Space"
+msgstr "Spacja"
+
+msgid "Sleep Timer"
+msgstr "Wyłącznik czasowy"
+
+msgid "&Minutes:"
+msgstr "&Minuty:"
+
+msgid "Table of Contents"
+msgstr "Spis treści"
+
+msgid "Please select a section from the table of contents."
+msgstr "Wybierz sekcję ze spisu treści."
+
+msgid "No Selection"
+msgstr "Brak wyboru"
+
+msgid "View Note"
+msgstr "Wyświetl notatkę"
+
+msgid "1 hour"
+msgstr "1 godzina"
+
+msgid "hours"
+msgstr "godz."
+
+msgid "1 minute"
+msgstr "1 minuta"
+
+msgid "minutes"
+msgstr "min"
+
+msgid "1 second"
+msgstr "1 sekunda"
+
+msgid "seconds"
+msgstr "s"
+
+msgid "Estimated reading time: {}"
+msgstr "Szacowany czas czytania: {}"
+
+msgid "This document contains {} words."
+msgstr "Ten dokument zawiera {} słów."
+
+msgid "Word Count"
+msgstr "Liczba słów"
+
+msgid "File not found: {}"
+msgstr "Nie znaleziono pliku: {}"
+
+msgid ""
+"A .paperback file was found for this document. Would you like to import it?"
+msgstr "Znaleziono plik .paperback dla tego dokumentu. Czy chcesz go zaimportować?"
+
+msgid "Import document data"
+msgstr "Importuj dane dokumentu"
+
+msgid "Password is required."
+msgstr "Hasło jest wymagane."
+
+msgid "Navigated to internal link."
+msgstr "Przejście do odnośnika wewnętrznego."
+
+msgid "Table View"
+msgstr "Widok tabeli"
+
+msgid "Ready"
+msgstr "Gotowe"
+
+msgid "&Password:"
+msgstr "&Hasło:"
+
+msgid "Document Password"
+msgstr "Hasło dokumentu"
+
+msgid "Failed to load document."
+msgstr "Nie udało się wczytać dokumentu."
+
+msgid "Create &bookmark"
+msgstr "Utwórz &zakładkę"
+
+msgid "Create bookmark"
+msgstr "Utwórz zakładkę"
+
+msgid "Bookmark with &note"
+msgstr "Zakładka z &notatką"
+
+msgid "Create bookmark with note"
+msgstr "Utwórz zakładkę z notatką"
+
+msgid "&Find"
+msgstr "&Znajdź"
+
+msgid "Find text"
+msgstr "Znajdź tekst"
+
+msgid "Find &next"
+msgstr "Znajdź &następne"
+
+msgid "Find next match"
+msgstr "Znajdź następne dopasowanie"
+
+msgid "Find &previous"
+msgstr "Znajdź &poprzednie"
+
+msgid "Find previous match"
+msgstr "Znajdź poprzednie dopasowanie"
+
+msgid "Go to &page"
+msgstr "Przejdź do &strony"
+
+msgid "Go to &line"
+msgstr "Przejdź do &wiersza"
+
+msgid "Go to line"
+msgstr "Przejdź do wiersza"
+
+msgid "Go to &percent"
+msgstr "Przejdź do &procentu"
+
+msgid "Go to percent"
+msgstr "Przejdź do procentu"
+
+msgid "Find"
+msgstr "Znajdź"
+
+msgid "Find &what:"
+msgstr "Znajdź &tekst:"
+
+msgid "&Match case"
+msgstr "Uwzględniaj &wielkość liter"
+
+msgid "Match &whole word"
+msgstr "Dopasuj &całe słowo"
+
+msgid "Use &regular expressions"
+msgstr "Użyj wyrażeń &regularnych"
+
+msgid "Find &Previous"
+msgstr "Znajdź &poprzednie"
+
+msgid "Find &Next"
+msgstr "Znajdź &następne"
+
+msgid "Not found."
+msgstr "Nie znaleziono."
+
+msgid "No more results. Wrapping search."
+msgstr "Nie ma więcej wyników. Zawijanie wyszukiwania."
+
+msgid "Failed to open containing folder."
+msgstr "Nie udało się otworzyć folderu zawierającego dokument."
+
+msgid ""
+"readme.html not found. Please ensure the application was built properly."
+msgstr "Nie znaleziono readme.html. Upewnij się, że aplikacja została poprawnie zbudowana."
+
+msgid "Failed to launch default browser."
+msgstr "Nie udało się uruchomić domyślnej przeglądarki."
+
+msgid "Failed to open donation page in browser."
+msgstr "Nie udało się otworzyć strony wsparcia w przeglądarce."
+
+msgid "Unsupported format selected."
+msgstr "Wybrano nieobsługiwany format."
+
+msgid "Paperback"
+msgstr "Paperback"
+
+msgid "Paperback - {}"
+msgstr "Paperback - {}"
+
+msgid "{} chars"
+msgstr "{} znaków"
+
+msgid "Open Document"
+msgstr "Otwórz dokument"
+
+msgid "No pages."
+msgstr "Brak stron."
+
+msgid "document"
+msgstr "dokument"
+
+msgid "Plain text files (*.txt)|*.txt|All files (*.*)|*.*"
+msgstr "Pliki tekstowe (*.txt)|*.txt|Wszystkie pliki (*.*)|*.*"
+
+msgid "Export document to plain text"
+msgstr "Eksportuj dokument do zwykłego tekstu"
+
+msgid "Failed to export document."
+msgstr "Nie udało się wyeksportować dokumentu."
+
+msgid "HTML files (*.html)|*.html|All files (*.*)|*.*"
+msgstr "Pliki HTML (*.html)|*.html|Wszystkie pliki (*.*)|*.*"
+
+msgid "Export document to HTML"
+msgstr "Eksportuj dokument do HTML"
+
+msgid "Markdown files (*.md)|*.md|All files (*.*)|*.*"
+msgstr "Pliki Markdown (*.md)|*.md|Wszystkie pliki (*.*)|*.*"
+
+msgid "Export document to Markdown"
+msgstr "Eksportuj dokument do Markdown"
+
+msgid "Paperback files (*.paperback)|*.paperback"
+msgstr "Pliki Paperback (*.paperback)|*.paperback"
+
+msgid "Export notes and bookmarks"
+msgstr "Eksportuj zakładki i notatki"
+
+msgid "Notes and bookmarks exported successfully."
+msgstr "Zakładki i notatki zostały wyeksportowane."
+
+msgid "Export Successful"
+msgstr "Eksport zakończony"
+
+msgid "Import notes and bookmarks"
+msgstr "Importuj zakładki i notatki"
+
+msgid "Notes and bookmarks imported successfully."
+msgstr "Zakładki i notatki zostały zaimportowane."
+
+msgid "Import Successful"
+msgstr "Import zakończony"
+
+msgid "No table of contents."
+msgstr "Brak spisu treści."
+
+msgid "Web View"
+msgstr "Widok WWW"
+
+msgid "Could not determine content to display in Web View."
+msgstr "Nie udało się określić treści do pokazania w Widoku WWW."
+
+msgid "Sleep timer cancelled."
+msgstr "Wyłącznik czasowy anulowany."
+
+msgid "Sleep timer set for 1 minute."
+msgstr "Wyłącznik czasowy ustawiony na 1 minutę."
+
+#, c-format
+msgid "Sleep timer set for %d minutes."
+msgstr "Wyłącznik czasowy ustawiony na %d min."
+
+msgid "No recent documents."
+msgstr "Brak ostatnich dokumentów."
+
+msgid "Previous Section\t["
+msgstr "Poprzednia sekcja\t["
+
+msgid "Go to previous section"
+msgstr "Przejdź do poprzedniej sekcji"
+
+msgid "Next Section\t]"
+msgstr "Następna sekcja\t]"
+
+msgid "Go to next section"
+msgstr "Przejdź do następnej sekcji"
+
+msgid "Go to &Page\tCtrl+P"
+msgstr "Przejdź do &strony\tCtrl+P"
+
+msgid "Previous Pa&ge\tShift+P"
+msgstr "Poprzednia stro&na\tShift+P"
+
+msgid "Next Pag&e\tP"
+msgstr "Następna str&ona\tP"
+
+msgid "Previous Lin&k\tShift+K"
+msgstr "Poprzedni odnośni&k\tShift+K"
+
+msgid "Next Lin&k\tK"
+msgstr "Następny odnośni&k\tK"
+
+msgid "Previous Ima&ge\tShift+G"
+msgstr "Poprzedni &obraz\tShift+G"
+
+msgid "Next Ima&ge\tG"
+msgstr "Następny &obraz\tG"
+
+msgid "Previous Figu&re\tShift+F"
+msgstr "Poprzedni &rysunek\tShift+F"
+
+msgid "Next Figu&re\tF"
+msgstr "Następny &rysunek\tF"
+
+msgid "Previous &Table\tShift+T"
+msgstr "Poprzednia &tabela\tShift+T"
+
+msgid "Next &Table\tT"
+msgstr "Następna &tabela\tT"
+
+msgid "Previous Se&parator\tShift+S"
+msgstr "Poprzedni se&parator\tShift+S"
+
+msgid "Next Se&parator\tS"
+msgstr "Następny se&parator\tS"
+
+msgid "Previous L&ist\tShift+L"
+msgstr "Poprzednia &lista\tShift+L"
+
+msgid "Next L&ist\tL"
+msgstr "Następna &lista\tL"
+
+msgid "Previous List &Item\tShift+I"
+msgstr "Poprzedni element l&isty\tShift+I"
+
+msgid "Next List I&tem\tI"
+msgstr "Następny element lis&ty\tI"
+
+msgid "Next Heading Level 1\t1"
+msgstr "Następny nagłówek poziomu 1\t1"
+
+msgid "Previous Heading Level &2\tShift+2"
+msgstr "Poprzedni nagłówek poziomu &2\tShift+2"
+
+msgid "Next Heading Level 2\t2"
+msgstr "Następny nagłówek poziomu 2\t2"
+
+msgid "Previous Heading Level &3\tShift+3"
+msgstr "Poprzedni nagłówek poziomu &3\tShift+3"
+
+msgid "Next Heading Level 3\t3"
+msgstr "Następny nagłówek poziomu 3\t3"
+
+msgid "Previous Heading Level &4\tShift+4"
+msgstr "Poprzedni nagłówek poziomu &4\tShift+4"
+
+msgid "Next Heading Level 4\t4"
+msgstr "Następny nagłówek poziomu 4\t4"
+
+msgid "Previous Heading Level &5\tShift+5"
+msgstr "Poprzedni nagłówek poziomu &5\tShift+5"
+
+msgid "Next Heading Level 5\t5"
+msgstr "Następny nagłówek poziomu 5\t5"
+
+msgid "Previous Heading Level &6\tShift+6"
+msgstr "Poprzedni nagłówek poziomu &6\tShift+6"
+
+msgid "Next Heading Level 6\t6"
+msgstr "Następny nagłówek poziomu 6\t6"
+
+msgid "&Previous Heading\tShift+H"
+msgstr "&Poprzedni nagłówek\tShift+H"
+
+msgid "Go to previous heading"
+msgstr "Przejdź do poprzedniego nagłówka"
+
+msgid "&Next Heading\tH"
+msgstr "&Następny nagłówek\tH"
+
+msgid "Go to next heading"
+msgstr "Przejdź do następnego nagłówka"
+
+msgid "Previous Heading Level &1\tShift+1"
+msgstr "Poprzedni nagłówek poziomu &1\tShift+1"
+
+msgid "&Previous Bookmark\tShift+B"
+msgstr "&Poprzednia zakładka\tShift+B"
+
+msgid "Go to previous bookmark"
+msgstr "Przejdź do poprzedniej zakładki"
+
+msgid "&Next Bookmark\tB"
+msgstr "&Następna zakładka\tB"
+
+msgid "Go to next bookmark"
+msgstr "Przejdź do następnej zakładki"
+
+msgid "Previous &Note\tShift+N"
+msgstr "Poprzednia &notatka\tShift+N"
+
+msgid "Go to previous note"
+msgstr "Przejdź do poprzedniej notatki"
+
+msgid "Next N&ote\tN"
+msgstr "Następna n&otatka\tN"
+
+msgid "Go to next note"
+msgstr "Przejdź do następnej notatki"
+
+msgid "Jump to &All...\tCtrl+B"
+msgstr "Przejdź do &wszystkich...\tCtrl+B"
+
+msgid "Show all bookmarks and notes"
+msgstr "Pokaż wszystkie zakładki i notatki"
+
+msgid "Jump to &Bookmarks Only...\tCtrl+Alt+B"
+msgstr "Przejdź tylko do &zakładek...\tCtrl+Alt+B"
+
+msgid "Show bookmarks only"
+msgstr "Pokaż tylko zakładki"
+
+msgid "Jump to Notes &Only...\tCtrl+Alt+M"
+msgstr "Przejdź tylko do n&otatek...\tCtrl+Alt+M"
+
+msgid "Show notes only"
+msgstr "Pokaż tylko notatki"
+
+msgid "&View Note Text\tRawCtrl+Shift+W"
+msgstr "&Wyświetl tekst notatki\tRawCtrl+Shift+W"
+
+msgid "&View Note Text\tCtrl+Shift+W"
+msgstr "&Wyświetl tekst notatki\tCtrl+Shift+W"
+
+msgid "View the note at current position"
+msgstr "Wyświetl notatkę w bieżącej pozycji"
+
+msgid "&File"
+msgstr "&Plik"
+
+msgid "&Go"
+msgstr "&Przejdź"
+
+msgid "&Tools"
+msgstr "&Narzędzia"
+
+msgid "&Help"
+msgstr "Pomo&c"
+
+msgid "&Open...\tCtrl+O"
+msgstr "&Otwórz...\tCtrl+O"
+
+msgid "Open a document"
+msgstr "Otwórz dokument"
+
+msgid "&Close\tCtrl+W"
+msgstr "&Zamknij\tCtrl+W"
+
+msgid "&Close\tCtrl+F4"
+msgstr "&Zamknij\tCtrl+F4"
+
+msgid "Close the current document"
+msgstr "Zamknij bieżący dokument"
+
+msgid "Close &All\tCtrl+Shift+W"
+msgstr "Zamknij &wszystkie\tCtrl+Shift+W"
+
+msgid "Close &All\tCtrl+Shift+F4"
+msgstr "Zamknij &wszystkie\tCtrl+Shift+F4"
+
+msgid "Close all documents"
+msgstr "Zamknij wszystkie dokumenty"
+
+msgid "Reopen &Last Closed\tCtrl+Shift+T"
+msgstr "Otwórz ponownie &ostatnio zamknięty\tCtrl+Shift+T"
+
+msgid "Reopen the last closed document"
+msgstr "Otwórz ponownie ostatnio zamknięty dokument"
+
+msgid "&Recent Documents"
+msgstr "&Ostatnie dokumenty"
+
+msgid "Open a recent document"
+msgstr "Otwórz ostatni dokument"
+
+msgid "E&xit\tCtrl+Q"
+msgstr "Za&kończ\tCtrl+Q"
+
+msgid "Exit the application"
+msgstr "Zakończ aplikację"
+
+msgid "&Find...\tCtrl+F"
+msgstr "&Znajdź...\tCtrl+F"
+
+msgid "Find text in the document"
+msgstr "Znajdź tekst w dokumencie"
+
+msgid "Find &Next\tF3"
+msgstr "Znajdź &następne\tF3"
+
+msgid "Find next occurrence"
+msgstr "Znajdź następne wystąpienie"
+
+msgid "Find &Previous\tShift+F3"
+msgstr "Znajdź &poprzednie\tShift+F3"
+
+msgid "Find previous occurrence"
+msgstr "Znajdź poprzednie wystąpienie"
+
+msgid "Go to &line...\tCtrl+G"
+msgstr "Przejdź do &wiersza...\tCtrl+G"
+
+msgid "Go to a specific line"
+msgstr "Przejdź do określonego wiersza"
+
+msgid "Go to &percent...\tCtrl+Shift+G"
+msgstr "Przejdź do &procentu...\tCtrl+Shift+G"
+
+msgid "Go to a percentage of the document"
+msgstr "Przejdź do procentowej pozycji dokumentu"
+
+msgid "Go &Back\tAlt+Left"
+msgstr "W&stecz\tAlt+Left"
+
+msgid "Go back in history"
+msgstr "Przejdź wstecz w historii"
+
+msgid "Go &Forward\tAlt+Right"
+msgstr "D&o przodu\tAlt+Right"
+
+msgid "Go forward in history"
+msgstr "Przejdź do przodu w historii"
+
+msgid "&Sections"
+msgstr "&Sekcje"
+
+msgid "Navigate by sections"
+msgstr "Nawiguj po sekcjach"
+
+msgid "&Headings"
+msgstr "&Nagłówki"
+
+msgid "Navigate by headings"
+msgstr "Nawiguj po nagłówkach"
+
+msgid "&Pages"
+msgstr "S&trony"
+
+msgid "Navigate by pages"
+msgstr "Nawiguj po stronach"
+
+msgid "&Bookmarks"
+msgstr "&Zakładki"
+
+msgid "Navigate by bookmarks"
+msgstr "Nawiguj po zakładkach"
+
+msgid "&Links"
+msgstr "&Odnośniki"
+
+msgid "Navigate by links"
+msgstr "Nawiguj po odnośnikach"
+
+msgid "&Images"
+msgstr "&Obrazy"
+
+msgid "Navigate by images"
+msgstr "Nawiguj po obrazach"
+
+msgid "&Figures"
+msgstr "&Rysunki"
+
+msgid "Navigate by figures"
+msgstr "Nawiguj po rysunkach"
+
+msgid "&Tables"
+msgstr "&Tabele"
+
+msgid "Navigate by tables"
+msgstr "Nawiguj po tabelach"
+
+msgid "&Separators"
+msgstr "Se&paratory"
+
+msgid "Navigate by separators"
+msgstr "Nawiguj po separatorach"
+
+msgid "&Lists"
+msgstr "&Listy"
+
+msgid "Navigate by lists"
+msgstr "Nawiguj po listach"
+
+msgid "&Import Document Data...\tCtrl+Shift+I"
+msgstr "&Importuj dane dokumentu...\tCtrl+Shift+I"
+
+msgid "Import bookmarks and position"
+msgstr "Importuj zakładki i pozycję"
+
+msgid "&Export Document Data...\tCtrl+Shift+E"
+msgstr "&Eksportuj dane dokumentu...\tCtrl+Shift+E"
+
+msgid "Export bookmarks and position"
+msgstr "Eksportuj zakładki i pozycję"
+
+msgid "Export to &Plain Text...\tCtrl+E"
+msgstr "Eksportuj do &zwykłego tekstu...\tCtrl+E"
+
+msgid "Export document as plain text"
+msgstr "Eksportuj dokument jako zwykły tekst"
+
+msgid "Export to &HTML..."
+msgstr "Eksportuj do &HTML..."
+
+msgid "Export document as HTML"
+msgstr "Eksportuj dokument jako HTML"
+
+msgid "Export to &Markdown..."
+msgstr "Eksportuj do &Markdown..."
+
+msgid "Export document as Markdown"
+msgstr "Eksportuj dokument jako Markdown"
+
+msgid "&Word Count\tRawCtrl+W"
+msgstr "&Liczba słów\tRawCtrl+W"
+
+msgid "&Word Count\tCtrl+W"
+msgstr "&Liczba słów\tCtrl+W"
+
+msgid "Show word count"
+msgstr "Pokaż liczbę słów"
+
+msgid "Document &Info\tCtrl+I"
+msgstr "&Informacje o dokumencie\tCtrl+I"
+
+msgid "Show document information"
+msgstr "Pokaż informacje o dokumencie"
+
+msgid "&Table of Contents\tCtrl+T"
+msgstr "&Spis treści\tCtrl+T"
+
+msgid "Show table of contents"
+msgstr "Pokaż spis treści"
+
+msgid "&Elements List...\tF7"
+msgstr "Lista &elementów...\tF7"
+
+msgid "Show elements list"
+msgstr "Pokaż listę elementów"
+
+msgid "Open &Containing Folder\tCtrl+Shift+C"
+msgstr "Otwórz folder &zawierający\tCtrl+Shift+C"
+
+msgid "Open folder containing the document"
+msgstr "Otwórz folder zawierający dokument"
+
+msgid "Open in &Web View\tCtrl+Shift+V"
+msgstr "Otwórz w &Widoku WWW\tCtrl+Shift+V"
+
+msgid "Open document in web view"
+msgstr "Otwórz dokument w Widoku WWW"
+
+msgid "I&mport/Export"
+msgstr "I&mport/eksport"
+
+msgid "Import and export options"
+msgstr "Opcje importu i eksportu"
+
+msgid "Toggle &Bookmark\tCtrl+Shift+B"
+msgstr "Przełącz &zakładkę\tCtrl+Shift+B"
+
+msgid "Bookmark with &Note\tCtrl+Shift+N"
+msgstr "Zakładka z &notatką\tCtrl+Shift+N"
+
+msgid "&Options\tCtrl+,"
+msgstr "&Opcje\tCtrl+,"
+
+msgid "&Sleep Timer...\tCtrl+Shift+S"
+msgstr "&Wyłącznik czasowy...\tCtrl+Shift+S"
+
+msgid "&About Paperback\tCtrl+F1"
+msgstr "&O programie Paperback\tCtrl+F1"
+
+msgid "About this application"
+msgstr "Informacje o tej aplikacji"
+
+msgid "View Help in &Browser\tF1"
+msgstr "Wyświetl pomoc w &przeglądarce\tF1"
+
+msgid "View help in default browser"
+msgstr "Wyświetl pomoc w domyślnej przeglądarce"
+
+msgid "View Help in &Paperback\tShift+F1"
+msgstr "Wyświetl pomoc w &Paperbacku\tShift+F1"
+
+msgid "View help in Paperback"
+msgstr "Wyświetl pomoc w Paperbacku"
+
+msgid "Check for &Updates\tCtrl+Shift+U"
+msgstr "Sprawdź &aktualizacje\tCtrl+Shift+U"
+
+msgid "Check for updates"
+msgstr "Sprawdź aktualizacje"
+
+msgid "&Donate\tCtrl+D"
+msgstr "&Wesprzyj\tCtrl+D"
+
+msgid "Support Paperback development"
+msgstr "Wesprzyj rozwój Paperbacka"
+
+msgid "(No recent documents)"
+msgstr "(Brak ostatnich dokumentów)"
+
+msgid "Show All...\tCtrl+R"
+msgstr "Pokaż wszystko...\tCtrl+R"
+
+msgid "No sections."
+msgstr "Brak sekcji."
+
+msgid "No next section"
+msgstr "Brak następnej sekcji"
+
+msgid "No previous section"
+msgstr "Brak poprzedniej sekcji"
+
+#, c-format
+msgid "No headings at level %d."
+msgstr "Brak nagłówków poziomu %d."
+
+#, c-format
+msgid "No next heading at level %d."
+msgstr "Brak następnego nagłówka poziomu %d."
+
+#, c-format
+msgid "No previous heading at level %d."
+msgstr "Brak poprzedniego nagłówka poziomu %d."
+
+msgid "No headings."
+msgstr "Brak nagłówków."
+
+msgid "No next heading."
+msgstr "Brak następnego nagłówka."
+
+msgid "No previous heading."
+msgstr "Brak poprzedniego nagłówka."
+
+msgid "No next page."
+msgstr "Brak następnej strony."
+
+msgid "No previous page."
+msgstr "Brak poprzedniej strony."
+
+msgid "No links."
+msgstr "Brak odnośników."
+
+msgid "No next link."
+msgstr "Brak następnego odnośnika."
+
+msgid "No previous link."
+msgstr "Brak poprzedniego odnośnika."
+
+msgid "No lists."
+msgstr "Brak list."
+
+msgid "No next list."
+msgstr "Brak następnej listy."
+
+msgid "No previous list."
+msgstr "Brak poprzedniej listy."
+
+msgid "No list items."
+msgstr "Brak elementów listy."
+
+msgid "No next list item."
+msgstr "Brak następnego elementu listy."
+
+msgid "No previous list item."
+msgstr "Brak poprzedniego elementu listy."
+
+msgid "No tables."
+msgstr "Brak tabel."
+
+msgid "No next table."
+msgstr "Brak następnej tabeli."
+
+msgid "No previous table."
+msgstr "Brak poprzedniej tabeli."
+
+msgid "No separators."
+msgstr "Brak separatorów."
+
+msgid "No next separator."
+msgstr "Brak następnego separatora."
+
+msgid "No previous separator."
+msgstr "Brak poprzedniego separatora."
+
+msgid "No images."
+msgstr "Brak obrazów."
+
+msgid "No next image."
+msgstr "Brak następnego obrazu."
+
+msgid "No previous image."
+msgstr "Brak poprzedniego obrazu."
+
+msgid "No figures."
+msgstr "Brak rysunków."
+
+msgid "No next figure."
+msgstr "Brak następnego rysunku."
+
+msgid "No previous figure."
+msgstr "Brak poprzedniego rysunku."
+
+msgid "Wrapping to start. "
+msgstr "Zawijanie do początku. "
+
+msgid "Wrapping to end. "
+msgstr "Zawijanie do końca. "
+
+#, c-format
+msgid "%s Heading level %d"
+msgstr "%s Nagłówek poziomu %d"
+
+#, c-format
+msgid "Page %d: %s"
+msgstr "Strona %d: %s"
+
+msgid " link"
+msgstr " odnośnik"
+
+msgid "Navigated to next position."
+msgstr "Przejście do następnej pozycji."
+
+msgid "Navigated to previous position."
+msgstr "Przejście do poprzedniej pozycji."
+
+msgid "No next position."
+msgstr "Brak następnej pozycji."
+
+msgid "No previous position."
+msgstr "Brak poprzedniej pozycji."
+
+#, c-format
+msgid "%s - Bookmark %d"
+msgstr "%s - Zakładka %d"
+
+msgid "No notes."
+msgstr "Brak notatek."
+
+msgid "No bookmarks."
+msgstr "Brak zakładek."
+
+msgid "No next note."
+msgstr "Brak następnej notatki."
+
+msgid "No next bookmark."
+msgstr "Brak następnej zakładki."
+
+msgid "No previous note."
+msgstr "Brak poprzedniej notatki."
+
+msgid "No previous bookmark."
+msgstr "Brak poprzedniej zakładki."
+
+msgid "Bookmark."
+msgstr "Zakładka."
+
+msgid "Bookmark removed."
+msgstr "Zakładka usunięta."
+
+msgid "Bookmark added."
+msgstr "Zakładka dodana."
+
+msgid "Enter bookmark note:"
+msgstr "Wpisz notatkę zakładki:"
+
+msgid "Bookmark saved."
+msgstr "Zakładka zapisana."
+
+msgid "No note at the current position."
+msgstr "Brak notatki w bieżącej pozycji."
+
+msgid "Line"
+msgstr "Wiersz"
+
+msgid "Character"
+msgstr "Znak"
+
+msgid "Sleep timer"
+msgstr "Wyłącznik czasowy"
+
+msgid "&Restore"
+msgstr "&Przywróć"
+
+msgid "Restore Paperback"
+msgstr "Przywróć Paperback"
+
+msgid "E&xit"
+msgstr "Za&kończ"
+
+msgid "Exit Paperback"
+msgstr "Zakończ Paperback"
+
+#, c-format
+msgid "Update to %s"
+msgstr "Zaktualizuj do %s"
+
+#, c-format
+msgid "A new version of %s is available. Here's what's new:"
+msgstr "Dostępna jest nowa wersja %s. Oto zmiany:"
+
+msgid "No release notes provided."
+msgstr "Nie podano informacji o wydaniu."
+
+#, c-format
+msgid "%s Update"
+msgstr "Aktualizacja %s"
+
+msgid "Downloading update..."
+msgstr "Pobieranie aktualizacji..."
+
+msgid "No updates available."
+msgstr "Brak dostępnych aktualizacji."
+
+#, c-format
+msgid "No updates available. Latest version: %s"
+msgstr "Brak dostępnych aktualizacji. Najnowsza wersja: %s"
+
+msgid "Info"
+msgstr "Informacja"
+
+#, c-format
+msgid ""
+"Security verification failed. The update might have been tampered with: %s"
+msgstr ""
+"Weryfikacja bezpieczeństwa nie powiodła się. Aktualizacja mogła zostać "
+"zmodyfikowana: %s"
+
+msgid "Security Error"
+msgstr "Błąd bezpieczeństwa"
+
+msgid "Update failed"
+msgstr "Aktualizacja nie powiodła się"
+
+#, c-format
+msgid ""
+"Update downloaded to: %s\n"
+"Please install it manually."
+msgstr ""
+"Aktualizacja została pobrana do: %s\n"
+"Zainstaluj ją ręcznie."
+
+msgid "Update Ready"
+msgstr "Aktualizacja gotowa"
+
+msgid "Failed to get current exe path"
+msgstr "Nie udało się pobrać bieżącej ścieżki pliku exe"
+
+msgid "Failed to launch installer script"
+msgstr "Nie udało się uruchomić skryptu instalatora"
+
+msgid "Failed to launch update script"
+msgstr "Nie udało się uruchomić skryptu aktualizacji"
+
+msgid "Unknown update file format."
+msgstr "Nieznany format pliku aktualizacji."

--- a/web/index.md
+++ b/web/index.md
@@ -48,6 +48,7 @@ Paperback is translated into multiple languages by contributors around the world
 - French
 - German
 - Japanese
+- Polish
 - Portuguese (Brazil)
 - Russian
 - Serbian


### PR DESCRIPTION
## Summary
- Add Polish gettext translations for the Paperback UI in `po/pl.po`.
- Add Polish user documentation in `doc/readme-pl.md` with terminology aligned to the UI translation.
- Update language lists to include Polish and keep the bundled documentation list in sync with existing translations.

## Why
This adds Polish as a supported Paperback language for both the application interface and user-facing documentation.

## How to validate
- `msgfmt --check --verbose -o /tmp/paperback-pl.mo po/pl.po`
- `msgcmp --use-fuzzy po/pl.po po/paperback.pot`
- `pandoc doc/readme-pl.md -o /tmp/readme-pl.html`
- `git diff --check`

## Screenshots / GIF
Not included; this is a translation and documentation update.

## Risk / rollout notes
- No compiled `.mo` files are committed; translations should be compiled by the existing build process.
- Polish terminology is kept consistent between the UI and documentation, including `Wyłącznik czasowy`, `Spis treści`, `Lista elementów`, and `Widok WWW`.