### PR TITLE
Fall back to plain text extraction for falsely-tagged PDFs

### DIFF
--- a/crates/paperback-core/src/parser/pdf.rs
+++ b/crates/paperback-core/src/parser/pdf.rs
@@ -10,6 +10,13 @@ use crate::{
 	util::text::{collapse_whitespace, display_len, trim_string},
 };
 
+/// Minimum fraction of visible text glyphs that must be associated with a
+/// marked-content ID for the tagged-extraction path to be trusted. Some PDFs
+/// advertise a structure tree while leaving their text essentially untagged
+/// (no MCIDs, or wrapped only in `/Artifact` marks); below this threshold the
+/// structure tree is treated as unreliable and plain extraction is used instead.
+const MIN_MCID_COVERAGE: f64 = 0.5;
+
 pub struct PdfParser;
 
 impl Parser for PdfParser {
@@ -61,6 +68,8 @@ impl Parser for PdfParser {
 				let child_count = struct_tree.count_children();
 				if child_count > 0 {
 					let mut mcid_to_text: HashMap<i32, String> = HashMap::new();
+					let mut real_char_count: usize = 0;
+					let mut mcid_char_count: usize = 0;
 					if let Ok(char_count) = text_page.char_count() {
 						let mut current_mcid = -1;
 						let mut current_text = String::new();
@@ -77,6 +86,12 @@ impl Parser for PdfParser {
 										char_mcid = obj.get_marked_content_id();
 									}
 								}
+								if !is_generated && !ch.is_whitespace() {
+									real_char_count += 1;
+									if char_mcid >= 0 {
+										mcid_char_count += 1;
+									}
+								}
 								if char_mcid >= 0 && char_mcid != current_mcid {
 									if current_mcid >= 0 && !current_text.is_empty() {
 										mcid_to_text.entry(current_mcid).or_default().push_str(&current_text);
@@ -91,23 +106,27 @@ impl Parser for PdfParser {
 							mcid_to_text.entry(current_mcid).or_default().push_str(&current_text);
 						}
 					}
-					let mut current_block = String::new();
-					for i in 0..child_count {
-						if let Ok(child) = struct_tree.child(i) {
-							process_struct_element(
-								&child,
-								&mcid_to_text,
-								&mut buffer,
-								&mut page_display_text,
-								&mut current_block,
-								&mut current_lines_info,
-								&mut flat_toc_items,
-							);
+					let coverage =
+						if real_char_count > 0 { mcid_char_count as f64 / real_char_count as f64 } else { 1.0 };
+					if coverage >= MIN_MCID_COVERAGE {
+						let mut current_block = String::new();
+						for i in 0..child_count {
+							if let Ok(child) = struct_tree.child(i) {
+								process_struct_element(
+									&child,
+									&mcid_to_text,
+									&mut buffer,
+									&mut page_display_text,
+									&mut current_block,
+									&mut current_lines_info,
+									&mut flat_toc_items,
+								);
+							}
 						}
+						flush_block(&mut current_block, &mut buffer, &mut page_display_text, &mut current_lines_info);
+						tags_processed = true;
+						any_tags_processed = true;
 					}
-					flush_block(&mut current_block, &mut buffer, &mut page_display_text, &mut current_lines_info);
-					tags_processed = true;
-					any_tags_processed = true;
 				}
 			}
 			if !tags_processed {


### PR DESCRIPTION
### Problem

Some PDFs advertise a structure tree (`/MarkInfo /Marked true` together with a `StructTreeRoot`) but leave their actual text essentially untagged. The individual glyphs carry no marked-content ID (MCID), or they are wrapped only in `/Artifact` marks rather than real structure elements.

The PDF parser currently switches to its tagged-extraction path as soon as a page''s structure tree has any children. That path can only emit text that is linked to the structure tree through an MCID, so when a file is tagged in name only, almost all of its text is silently discarded.

I ran into this with a 28-page document where the difference is dramatic:

| Extractor | Characters |
|-----------|-----------|
| PDFium raw text | 46,896 |
| Paperback (before this change) | ~10,000 |
| **Paperback (after this change)** | **45,952** |

Digging into the file, only 169 of roughly 38,000 visible glyphs actually carried an MCID. The structure tree was present, but it was linked to virtually none of the page text, so the tagged path had almost nothing to work with.

### Fix

This change adds a per-page MCID **coverage** check. While the parser builds its `mcid -> text` map, it also counts how many visible glyphs are MCID-linked versus the total. It only trusts the structure tree when coverage is at least `MIN_MCID_COVERAGE` (0.5); otherwise the page falls through to the existing plain text extraction path.

In practice this coverage value is strongly bimodal: a properly tagged PDF sits around 0.9-1.0 (only artifacts such as running headers stay untagged), while a falsely-tagged one sits near 0.0 (this file measured 0.004). The threshold of 0.5 sits in the wide empty gap between those two regimes, so there is plenty of margin.

### Why this approach

I considered two alternatives and settled on the coverage check for a few reasons:

- **No extra work.** The counters piggyback on the per-character loop that already runs to build the MCID map, so there is no second pass over the page.
- **No rollback.** The decision is made before anything is written to the document buffer. Alternatives such as "extract via tags, then redo if the result is too short" or "run both paths and keep the longer one" would require unwinding buffer contents, markers, and TOC entries mid-stream, which is far more invasive.
- **It measures the real defect.** Coverage directly reflects whether the text is genuinely tagged. A length-based heuristic would be misleading, because proper tagging deliberately omits artifacts, so plain extraction is often *longer* than tagged extraction on a well-made PDF - and a "keep the longer output" rule would wrongly discard good structure.
- **It preserves structure where it is real.** Legitimately tagged PDFs keep their correct reading order, tables, headings, and lists.

### Testing

- `cargo test -p paperback-core` passes (303 tests).
- Verified the reported file directly: extracted character count went from roughly 10,000 to 45,952, matching PDFium''s raw text output minus collapsed whitespace.

### Known limitation (follow-up)

In a *mixed* document - where some pages are well-tagged and others are routed to the fallback - headings detected on the fallback pages will not appear in the table of contents, because the heading-detection branch is gated on `any_tags_processed` (`pdf.rs:282`). The text itself is still fully recovered; only the TOC entries for those pages are missing. This does not affect all-fallback files like the one reported here, so I''ve left it for a separate patch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)