### PR TITLE
feat: open web view at current reading position

### DIFF
--- a/crates/paperback-core/src/parser/markdown.rs
+++ b/crates/paperback-core/src/parser/markdown.rs
@@ -1,7 +1,7 @@
 use std::fs;
 
 use anyhow::{Context, Result};
-use pulldown_cmark::{Options, Parser as MarkdownParserImpl, html::push_html};
+use pulldown_cmark::{Event, Options, Parser as MarkdownParserImpl, Tag, html::push_html};
 
 use crate::{
 	document::{Document, DocumentBuffer, ParserContext, ParserFlags},
@@ -13,7 +13,62 @@ use crate::{
 	util::encoding::convert_to_utf8,
 };
 
+/// Converts Markdown to HTML with an empty `<span id="pb-block-N"></span>` before each block.
+///
+/// The anchors produce no text but give every block a stable id, so a position
+/// in the converted text can be mapped back to a `#fragment` when the document
+/// is shown in a web view.
+#[must_use]
+pub fn markdown_to_html(markdown_text: &str) -> String {
+	let mut options = Options::empty();
+	options.insert(Options::ENABLE_TABLES);
+	let parser = MarkdownParserImpl::new_ext(markdown_text, options);
+	let mut block_counter = 0usize;
+	let events = parser.flat_map(|event| {
+		let anchor = match &event {
+			Event::Start(Tag::Paragraph | Tag::Heading { .. } | Tag::Item | Tag::BlockQuote(_) | Tag::CodeBlock(_)) => {
+				block_counter += 1;
+				Some(Event::Html(format!("<span id=\"pb-block-{block_counter}\"></span>").into()))
+			}
+			_ => None,
+		};
+		anchor.into_iter().chain(std::iter::once(event))
+	});
+	let mut html_content = String::new();
+	push_html(&mut html_content, events);
+	html_content
+}
+
 pub struct MarkdownParser;
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn markdown_to_html_injects_block_anchors() {
+		let html = markdown_to_html("# Title\n\nFirst paragraph.\n\nSecond paragraph.\n");
+		let anchor_2 = html.find(r#"<span id="pb-block-2"></span>"#).expect("second anchor present");
+		let anchor_3 = html.find(r#"<span id="pb-block-3"></span>"#).expect("third anchor present");
+		let first_para = html.find("<p>First paragraph.</p>").expect("first paragraph present");
+		let second_para = html.find("<p>Second paragraph.</p>").expect("second paragraph present");
+		assert!(html.contains(r#"<span id="pb-block-1"></span>"#), "got: {html}");
+		assert!(anchor_2 < first_para && first_para < anchor_3 && anchor_3 < second_para, "got: {html}");
+	}
+
+	#[test]
+	fn markdown_block_anchors_reach_id_positions_without_changing_text() {
+		let source = "# Title\n\nFirst paragraph.\n\nSecond paragraph.\n";
+		let html = markdown_to_html(source);
+		let mut converter = HtmlToText::new();
+		assert!(converter.convert(&html, HtmlSourceMode::Markdown));
+		let text = converter.get_text();
+		let ids = converter.get_id_positions();
+		assert_eq!(ids.get("pb-block-1"), Some(&text.find("Title").unwrap()), "ids: {ids:?} text: {text:?}");
+		assert_eq!(ids.get("pb-block-3"), Some(&text.find("Second").unwrap()), "ids: {ids:?} text: {text:?}");
+		assert!(!text.contains("pb-block"), "anchors must not leak into text: {text:?}");
+	}
+}
 
 impl Parser for MarkdownParser {
 	fn name(&self) -> &'static str {
@@ -32,11 +87,7 @@ impl Parser for MarkdownParser {
 		let bytes = fs::read(&context.file_path)
 			.with_context(|| format!("Failed to open Markdown file '{}'", context.file_path))?;
 		let markdown_content = convert_to_utf8(&bytes);
-		let mut options = Options::empty();
-		options.insert(Options::ENABLE_TABLES);
-		let parser = MarkdownParserImpl::new_ext(&markdown_content, options);
-		let mut html_content = String::new();
-		push_html(&mut html_content, parser);
+		let html_content = markdown_to_html(&markdown_content);
 		let mut converter = HtmlToText::new();
 		if !converter.convert(&html_content, HtmlSourceMode::Markdown) {
 			anyhow::bail!("Failed to convert Markdown to text: {}", context.file_path);

--- a/crates/paperback-core/src/parser/xml_to_text.rs
+++ b/crates/paperback-core/src/parser/xml_to_text.rs
@@ -37,6 +37,8 @@ pub struct XmlToText {
 	lists: Vec<ListInfo>,
 	list_items: Vec<ListItemInfo>,
 	section_offsets: Vec<usize>,
+	position_watch: Option<usize>,
+	watched_byte_offset: Option<usize>,
 	in_body: bool,
 	preserve_whitespace_depth: usize,
 	list_level: i32,
@@ -66,6 +68,18 @@ impl XmlToText {
 	#[must_use]
 	pub fn get_text(&self) -> String {
 		self.lines.join("\n")
+	}
+
+	/// Returns the source byte offset of the start tag of the element nearest
+	/// at-or-before `target_position` (a character position in the converted text),
+	/// suitable as an insertion point for a navigation anchor.
+	pub fn find_anchor_byte_offset(&mut self, xml_content: &str, target_position: usize) -> Option<usize> {
+		self.position_watch = Some(target_position);
+		self.watched_byte_offset = None;
+		let converted = self.convert(xml_content);
+		self.position_watch = None;
+		let result = self.watched_byte_offset.take();
+		if converted { result } else { None }
 	}
 
 	#[must_use]
@@ -145,6 +159,11 @@ impl XmlToText {
 				let tag_name = node.tag_name().name();
 				if Self::is_ignored_element(tag_name) {
 					return;
+				}
+				if let Some(target) = self.position_watch
+					&& self.in_body && self.get_current_text_position() <= target
+				{
+					self.watched_byte_offset = Some(node.range().start);
 				}
 				let skip_children = self.handle_element_opening_xml(tag_name, node);
 				self.handle_heading_xml(tag_name, node);
@@ -566,6 +585,19 @@ impl XmlToText {
 	}
 }
 
+/// Inserts an empty `<span id="{anchor_id}"></span>` into `xml_content`.
+///
+/// The span is placed before the element nearest at-or-before `target_position`
+/// (a character position in the converted text). Returns `None` when the
+/// content is not valid XML.
+#[must_use]
+pub fn inject_anchor_at_position(xml_content: &str, target_position: usize, anchor_id: &str) -> Option<String> {
+	let byte_offset = XmlToText::new().find_anchor_byte_offset(xml_content, target_position)?;
+	let mut result = xml_content.to_string();
+	result.insert_str(byte_offset, &format!("<span id=\"{anchor_id}\"></span>"));
+	Some(result)
+}
+
 impl crate::parser::ConverterOutput for XmlToText {
 	fn get_headings(&self) -> &[HeadingInfo] {
 		&self.headings
@@ -692,6 +724,52 @@ mod tests {
 		let mut converter = XmlToText::new();
 		assert!(converter.convert(xml));
 		assert_eq!(converter.get_tables().len(), 1);
+	}
+
+	#[test]
+	fn find_anchor_byte_offset_locates_block_containing_position() {
+		let xml = "<root><body><p>First paragraph.</p><p>Second paragraph.</p></body></root>";
+		// Text output: "First paragraph.\nSecond paragraph." — second paragraph starts at 17.
+		let mut converter = XmlToText::new();
+		let offset = converter.find_anchor_byte_offset(xml, 20).expect("offset for position in second paragraph");
+		assert!(xml[offset..].starts_with("<p>Second"), "got offset {offset}: {}", &xml[offset..]);
+		let offset = converter.find_anchor_byte_offset(xml, 5).expect("offset for position in first paragraph");
+		assert!(xml[offset..].starts_with("<p>First"), "got offset {offset}: {}", &xml[offset..]);
+	}
+
+	#[test]
+	fn find_anchor_byte_offset_at_position_zero_uses_first_body_element() {
+		let xml = "<root><head><title>T</title></head><body><p>First.</p></body></root>";
+		let mut converter = XmlToText::new();
+		let offset = converter.find_anchor_byte_offset(xml, 0).expect("offset at start");
+		assert!(xml[offset..].starts_with("<p>First."), "got offset {offset}: {}", &xml[offset..]);
+	}
+
+	#[test]
+	fn find_anchor_byte_offset_picks_nearest_inline_element() {
+		let xml = "<root><body><p>Start <em>middle</em> end of line</p></body></root>";
+		// Position inside " end of line" — nearest preceding element start is <em>.
+		let mut converter = XmlToText::new();
+		let offset = converter.find_anchor_byte_offset(xml, 16).expect("offset for position after em");
+		assert!(xml[offset..].starts_with("<em>"), "got offset {offset}: {}", &xml[offset..]);
+	}
+
+	#[test]
+	fn find_anchor_byte_offset_returns_none_for_invalid_xml() {
+		let mut converter = XmlToText::new();
+		assert_eq!(converter.find_anchor_byte_offset("<p>broken", 0), None);
+	}
+
+	#[test]
+	fn inject_anchor_at_position_inserts_span_before_block() {
+		let xml = "<root><body><p>First paragraph.</p><p>Second paragraph.</p></body></root>";
+		let result = inject_anchor_at_position(xml, 20, "reading-pos").expect("injection succeeds");
+		assert!(result.contains(r#"</p><span id="reading-pos"></span><p>Second paragraph.</p>"#), "got: {result}");
+	}
+
+	#[test]
+	fn inject_anchor_at_position_returns_none_for_invalid_xml() {
+		assert_eq!(inject_anchor_at_position("<p>broken", 0, "reading-pos"), None);
 	}
 
 	#[test]

--- a/crates/paperback-core/src/reader_core.rs
+++ b/crates/paperback-core/src/reader_core.rs
@@ -417,6 +417,42 @@ fn find_fragment_offset(doc: &DocumentHandle, fragment: &str, scoped_path: Optio
 	doc.document().id_positions.get(fragment).copied()
 }
 
+/// Percent-encodes an element id for use as a URL `#fragment`.
+#[must_use]
+pub fn encode_url_fragment(id: &str) -> String {
+	const FRAGMENT_ENCODE_SET: &percent_encoding::AsciiSet =
+		&percent_encoding::CONTROLS.add(b' ').add(b'"').add(b'<').add(b'>').add(b'`').add(b'#').add(b'%');
+	percent_encoding::utf8_percent_encode(id, FRAGMENT_ENCODE_SET).to_string()
+}
+
+/// Finds the id of the element closest at-or-before `position`, suitable as a URL
+/// fragment when opening the current section in a web view.
+///
+/// For multi-section documents (epub) only ids scoped to the current section
+/// (stored as `"{path}#{id}"` keys) are considered; for single-file documents
+/// bare id keys are used instead.
+#[must_use]
+pub fn nearest_fragment_before(doc: &DocumentHandle, position: usize) -> Option<String> {
+	let id_positions = &doc.document().id_positions;
+	current_section_path(doc, position).map_or_else(
+		|| {
+			id_positions
+				.iter()
+				.filter(|&(key, &offset)| offset <= position && !key.contains('#'))
+				.max_by_key(|&(_, &offset)| offset)
+				.map(|(key, _)| key.clone())
+		},
+		|path| {
+			let prefix = format!("{path}#");
+			id_positions
+				.iter()
+				.filter(|&(key, &offset)| offset <= position && key.starts_with(&prefix))
+				.max_by_key(|&(_, &offset)| offset)
+				.map(|(key, _)| key[prefix.len()..].to_string())
+		},
+	)
+}
+
 fn find_manifest_id_for_path(doc: &DocumentHandle, path: &str) -> Option<String> {
 	doc.document().manifest_items.iter().find_map(|(id, p)| if p == path { Some(id.clone()) } else { None })
 }
@@ -702,5 +738,74 @@ mod tests {
 		let doc = sample_link_doc_handle();
 		let result = resolve_link(&doc, "missing.xhtml#none", 0);
 		assert!(!result.found);
+	}
+
+	fn sample_reading_pos_doc_handle() -> DocumentHandle {
+		let mut buffer = DocumentBuffer::with_content("x".repeat(220));
+		buffer.add_marker(Marker::new(MarkerType::SectionBreak, 0));
+		buffer.add_marker(Marker::new(MarkerType::SectionBreak, 100));
+		let mut manifest_items = HashMap::new();
+		manifest_items.insert("id1".to_string(), "chapter1.xhtml".to_string());
+		manifest_items.insert("id2".to_string(), "chapter2.xhtml".to_string());
+		let mut id_positions = HashMap::new();
+		id_positions.insert("chapter1.xhtml#intro".to_string(), 10);
+		id_positions.insert("chapter1.xhtml#mid".to_string(), 50);
+		id_positions.insert("chapter2.xhtml#target".to_string(), 120);
+		// Bare duplicate as inserted by the epub parser alongside the scoped key.
+		id_positions.insert("intro".to_string(), 10);
+		let mut doc = Document::new();
+		doc.set_buffer(buffer);
+		doc.spine_items = vec!["id1".to_string(), "id2".to_string()];
+		doc.manifest_items = manifest_items;
+		doc.id_positions = id_positions;
+		DocumentHandle::new(doc)
+	}
+
+	fn sample_single_file_doc_handle() -> DocumentHandle {
+		let mut id_positions = HashMap::new();
+		id_positions.insert("top".to_string(), 10);
+		id_positions.insert("middle".to_string(), 50);
+		id_positions.insert("some.xhtml#scoped".to_string(), 40);
+		let mut doc = Document::new();
+		doc.set_buffer(DocumentBuffer::with_content("x".repeat(220)));
+		doc.id_positions = id_positions;
+		DocumentHandle::new(doc)
+	}
+
+	#[test]
+	fn nearest_fragment_picks_latest_id_at_or_before_position() {
+		let doc = sample_reading_pos_doc_handle();
+		assert_eq!(nearest_fragment_before(&doc, 60), Some("mid".to_string()));
+		assert_eq!(nearest_fragment_before(&doc, 30), Some("intro".to_string()));
+		assert_eq!(nearest_fragment_before(&doc, 120), Some("target".to_string()));
+	}
+
+	#[test]
+	fn nearest_fragment_returns_none_before_first_id_in_section() {
+		let doc = sample_reading_pos_doc_handle();
+		assert_eq!(nearest_fragment_before(&doc, 5), None);
+	}
+
+	#[test]
+	fn nearest_fragment_ignores_ids_from_other_sections_and_bare_duplicates() {
+		let doc = sample_reading_pos_doc_handle();
+		// Position 110 is in chapter2 before its first id; chapter1 ids and the
+		// bare "intro" duplicate must not match.
+		assert_eq!(nearest_fragment_before(&doc, 110), None);
+	}
+
+	#[test]
+	fn encode_url_fragment_escapes_unsafe_characters() {
+		assert_eq!(encode_url_fragment("plain-id_1"), "plain-id_1");
+		assert_eq!(encode_url_fragment("with space"), "with%20space");
+		assert_eq!(encode_url_fragment("a#b%c"), "a%23b%25c");
+	}
+
+	#[test]
+	fn nearest_fragment_uses_bare_ids_for_single_file_documents() {
+		let doc = sample_single_file_doc_handle();
+		assert_eq!(nearest_fragment_before(&doc, 60), Some("middle".to_string()));
+		assert_eq!(nearest_fragment_before(&doc, 45), Some("top".to_string()));
+		assert_eq!(nearest_fragment_before(&doc, 5), None);
 	}
 }

--- a/crates/paperback-core/src/session.rs
+++ b/crates/paperback-core/src/session.rs
@@ -5,7 +5,6 @@ use std::{
 };
 
 use base64::Engine;
-use pulldown_cmark::{Options as MdOptions, Parser as MdParser, html::push_html as md_push_html};
 use zip::ZipArchive;
 
 use crate::{
@@ -13,8 +12,8 @@ use crate::{
 	document::{self, DocumentHandle, MarkerType, ParserContext, ParserFlags},
 	parser,
 	reader_core::{
-		SearchOptions, bookmark_navigate, history_go_next, history_go_previous, reader_navigate,
-		reader_search_with_wrap, record_history_position, resolve_link,
+		SearchOptions, bookmark_navigate, encode_url_fragment, history_go_next, history_go_previous,
+		nearest_fragment_before, reader_navigate, reader_search_with_wrap, record_history_position, resolve_link,
 	},
 	types::{self as ffi, NavDirection, NavTarget},
 	util::{encoding::convert_to_utf8, zip as zip_utils},
@@ -36,6 +35,12 @@ pub struct SearchResultFfi {
 	pub found: bool,
 	pub wrapped: bool,
 	pub position: i64,
+}
+
+#[derive(Debug, Clone)]
+pub struct WebviewTarget {
+	pub path: String,
+	pub fragment: Option<String>,
 }
 
 #[derive(Debug, Clone, Copy, Default)]
@@ -868,7 +873,7 @@ impl DocumentSession {
 	}
 
 	#[must_use]
-	pub fn webview_target_path(&self, position: i64, temp_dir: &str) -> Option<String> {
+	pub fn webview_target_path(&self, position: i64, temp_dir: &str) -> Option<WebviewTarget> {
 		let section_path = self.get_current_section_path(position).filter(|path| !path.is_empty());
 		if let Some(section_path) = section_path {
 			let digest = crate::config::compute_document_hash(&self.file_path);
@@ -879,13 +884,14 @@ impl DocumentSession {
 				let output_path = doc_temp_dir.join(file_name);
 				let output_str = output_path.to_string_lossy().to_string();
 				if self.extract_resource(&section_path, &output_str).ok() == Some(true) {
-					return Some(output_str);
+					let fragment = self.inject_reading_anchor(position, &output_str);
+					return Some(WebviewTarget { path: output_str, fragment });
 				}
 			}
 		}
 		let ext = Path::new(&self.file_path).extension().map(|ext| ext.to_string_lossy().to_ascii_lowercase());
 		match ext.as_deref() {
-			Some("html" | "htm" | "xhtml") => Some(self.file_path.clone()),
+			Some("html" | "htm" | "xhtml") => Some(WebviewTarget { path: self.file_path.clone(), fragment: None }),
 			Some("md" | "markdown") => {
 				let digest = crate::config::compute_document_hash(&self.file_path);
 				let hash = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(digest);
@@ -894,15 +900,14 @@ impl DocumentSession {
 					let html_path = doc_temp_dir.join("document.html");
 					if let Ok(bytes) = fs::read(&self.file_path) {
 						let markdown_text = convert_to_utf8(&bytes);
-						let mut opts = MdOptions::empty();
-						opts.insert(MdOptions::ENABLE_TABLES);
-						let md_parser = MdParser::new_ext(&markdown_text, opts);
-						let mut html_body = String::new();
-						md_push_html(&mut html_body, md_parser);
+						let html_body = parser::markdown::markdown_to_html(&markdown_text);
 						let full_html =
 							format!("<html><head><meta charset=\"utf-8\"></head><body>{html_body}</body></html>");
 						if fs::write(&html_path, full_html.as_bytes()).is_ok() {
-							return Some(html_path.to_string_lossy().to_string());
+							return Some(WebviewTarget {
+								path: html_path.to_string_lossy().to_string(),
+								fragment: None,
+							});
 						}
 					}
 				}
@@ -910,6 +915,28 @@ impl DocumentSession {
 			}
 			_ => None,
 		}
+	}
+
+	/// Inserts an empty anchor element at the current reading position into the
+	/// extracted section file and returns its id, for use as a URL `#fragment`.
+	fn inject_reading_anchor(&self, position: i64, file_path: &str) -> Option<String> {
+		const READING_POS_ANCHOR_ID: &str = "paperback-reading-pos";
+		let pos = usize::try_from(position.max(0)).unwrap_or(0);
+		let section_index = self.handle.current_marker_index(pos, MarkerType::SectionBreak)?;
+		let section_start = self.handle.document().buffer.markers.get(section_index)?.position;
+		let relative = pos.checked_sub(section_start)?;
+		let content = convert_to_utf8(&fs::read(file_path).ok()?);
+		let injected = parser::xml_to_text::inject_anchor_at_position(&content, relative, READING_POS_ANCHOR_ID)?;
+		fs::write(file_path, injected.as_bytes()).ok()?;
+		Some(READING_POS_ANCHOR_ID.to_string())
+	}
+
+	/// Returns the id of the element closest at-or-before `position` in the current
+	/// section, for use as a `#fragment` when opening the section in a web view.
+	#[must_use]
+	pub fn webview_fragment_for_position(&self, position: i64) -> Option<String> {
+		let pos = usize::try_from(position.max(0)).unwrap_or(0);
+		nearest_fragment_before(&self.handle, pos).map(|id| encode_url_fragment(&id))
 	}
 
 	/// # Errors
@@ -1492,7 +1519,7 @@ mod tests {
 			parser_flags: ParserFlags::NONE,
 			last_stable_position: None,
 		};
-		assert_eq!(session.webview_target_path(0, "C:\\temp").as_deref(), None);
+		assert!(session.webview_target_path(0, "C:\\temp").is_none());
 	}
 
 	#[test]

--- a/crates/paperback/src/ui/main_window.rs
+++ b/crates/paperback/src/ui/main_window.rs
@@ -1233,8 +1233,14 @@ impl MainWindow {
 					};
 					let current_pos = tab.text_ctrl.get_insertion_point();
 					let temp_dir = env::temp_dir().to_string_lossy().to_string();
-					if let Some(target_path) = tab.session.webview_target_path(current_pos, &temp_dir) {
-						let url = format!("file:///{}", target_path.replace('\\', "/"));
+					if let Some(target) = tab.session.webview_target_path(current_pos, &temp_dir) {
+						let mut url = format!("file:///{}", target.path.replace('\\', "/"));
+						let fragment =
+							target.fragment.or_else(|| tab.session.webview_fragment_for_position(current_pos));
+						if let Some(fragment) = fragment {
+							url.push('#');
+							url.push_str(&fragment);
+						}
 						dialogs::show_web_view_dialog(
 							&frame_copy,
 							&t("Web View"),


### PR DESCRIPTION
Web view (Ctrl+Shift+V) previously always opened at the top of the section. Append a #fragment to the file URL so the web view and with it the screen reader virtual buffer, jumps to the reading position.

- epub: inject <span id="paperback-reading-pos"> into the extracted section before the element nearest the cursor, located by replaying the XmlToText conversion (roxmltree source byte ranges)
- markdown: emit <span id="pb-block-N"> anchors per block in a shared markdown_to_html used by both parser and web view, resolved via nearest-id lookup
- fallback for HTML files and non-XML epub sections: nearest existing id at-or-before the cursor from document id_positions