### PR TITLE
feat(ui): add Word Wrap toggle menu item with Ctrl+Alt+W shortcut

### DIFF
--- a/crates/paperback/src/ui/main_window.rs
+++ b/crates/paperback/src/ui/main_window.rs
@@ -894,6 +894,26 @@ impl MainWindow {
 				menu_ids::BOOKMARK_WITH_NOTE => {
 					navigation::handle_bookmark_with_note(&frame_copy, &dm, &config, live_region_label);
 				}
+				menu_ids::TOGGLE_WORD_WRAP => {
+					let new_state = {
+						let cfg = config.lock().unwrap();
+						let v = !cfg.get_app_bool("word_wrap", false);
+						cfg.set_app_bool("word_wrap", v);
+						cfg.flush();
+						v
+					};
+					{
+						let dm_for_wrap = Rc::clone(&dm);
+						let mut dm_ref = dm.lock().unwrap();
+						dm_ref.apply_word_wrap(&dm_for_wrap, new_state);
+					}
+					if let Some(menu_bar) = frame_copy.get_menu_bar() {
+						menu_bar.check_item(menu_ids::TOGGLE_WORD_WRAP, new_state);
+					}
+					let msg = if new_state { t("Word wrap on.") } else { t("Word wrap off.") };
+					live_region::announce(live_region_label, &msg);
+					dm.lock().unwrap().restore_focus();
+				}
 				menu_ids::VIEW_NOTE_TEXT => {
 					navigation::handle_view_note_text(&frame_copy, &dm, &config);
 				}

--- a/crates/paperback/src/ui/menu.rs
+++ b/crates/paperback/src/ui/menu.rs
@@ -85,6 +85,8 @@ const DOCUMENT_DEPENDENT_IDS: &[i32] = &[
 	// Bookmark tools
 	menu_ids::TOGGLE_BOOKMARK,
 	menu_ids::BOOKMARK_WITH_NOTE,
+	// View toggles
+	menu_ids::TOGGLE_WORD_WRAP,
 ];
 
 /// Enable or disable all document-dependent menu items.
@@ -380,7 +382,7 @@ pub fn create_menu_bar(config: &ConfigManager) -> MenuBar {
 	let file_menu = create_file_menu(config);
 	let compact_go_menu = config.get_app_bool("compact_go_menu", true);
 	let go_menu = create_go_menu(compact_go_menu);
-	let tools_menu = create_tools_menu();
+	let tools_menu = create_tools_menu(config);
 	let help_menu = create_help_menu();
 	let file_label = t("&File");
 	let go_label = t("&Go");
@@ -522,7 +524,7 @@ pub fn create_go_menu(compact: bool) -> Menu {
 	menu
 }
 
-pub fn create_tools_menu() -> Menu {
+pub fn create_tools_menu(config: &ConfigManager) -> Menu {
 	let import_label = t("&Import Document Data...\tCtrl+Shift+I");
 	let import_help = t("Import bookmarks and position");
 	let export_label = t("&Export Document Data...\tCtrl+Shift+E");
@@ -574,6 +576,11 @@ pub fn create_tools_menu() -> Menu {
 	let bookmark_note_label = t("Bookmark with &Note\tCtrl+Shift+N");
 	menu.append(menu_ids::TOGGLE_BOOKMARK, &toggle_bookmark_label, "", ItemKind::Normal);
 	menu.append(menu_ids::BOOKMARK_WITH_NOTE, &bookmark_note_label, "", ItemKind::Normal);
+	menu.append_separator();
+	let word_wrap_label = t("Word w&rap\tCtrl+Alt+W");
+	let word_wrap_help = t("Toggle word wrap");
+	menu.append(menu_ids::TOGGLE_WORD_WRAP, &word_wrap_label, &word_wrap_help, ItemKind::Check);
+	menu.check_item(menu_ids::TOGGLE_WORD_WRAP, config.get_app_bool("word_wrap", false));
 	menu.append_separator();
 	let options_label = t("&Options\tCtrl+,");
 	let sleep_label = t("&Sleep Timer...\tCtrl+Shift+S");

--- a/crates/paperback/src/ui/menu.rs
+++ b/crates/paperback/src/ui/menu.rs
@@ -85,8 +85,6 @@ const DOCUMENT_DEPENDENT_IDS: &[i32] = &[
 	// Bookmark tools
 	menu_ids::TOGGLE_BOOKMARK,
 	menu_ids::BOOKMARK_WITH_NOTE,
-	// View toggles
-	menu_ids::TOGGLE_WORD_WRAP,
 ];
 
 /// Enable or disable all document-dependent menu items.

--- a/crates/paperback/src/ui/menu_ids.rs
+++ b/crates/paperback/src/ui/menu_ids.rs
@@ -79,6 +79,9 @@ seq_ids!(BASE + 420 => TOGGLE_BOOKMARK, BOOKMARK_WITH_NOTE);
 // Tools menu: Settings (BASE + 430..439)
 seq_ids!(BASE + 430 => OPTIONS, SLEEP_TIMER);
 
+// Tools menu: View toggles (BASE + 440..449)
+seq_ids!(BASE + 440 => TOGGLE_WORD_WRAP);
+
 // Help menu (BASE + 500..599)
 seq_ids!(BASE + 500 => VIEW_HELP_BROWSER, VIEW_HELP_PAPERBACK, CHECK_FOR_UPDATES, DONATE);
 

--- a/doc/readme.md
+++ b/doc/readme.md
@@ -99,6 +99,7 @@ Paperback is designed for keyboard-first and screen reader-first use. Here are t
 * `Ctrl+E`: Export the current document to plain text.
 * `Ctrl+Shift+B`: Toggle bookmark at the current selection/cursor.
 * `Ctrl+Shift+N`: Add or edit bookmark note at the current selection/cursor.
+* `Ctrl+Alt+W`: Toggle word wrap.
 * `Ctrl+,`: Open options.
 * `Ctrl+Shift+S`: Toggle sleep timer.
 


### PR DESCRIPTION
## Summary

Adds a checkable **Word wrap** item to the Tools menu, bound to `Ctrl+Alt+W`, so word wrap can be toggled while reading — no need to open the Options dialog. The Options-dialog checkbox and this menu item stay in sync via the shared `word_wrap` config, and both can be changed with or without a document open.

## Changes

- **`menu_ids.rs`** — new `TOGGLE_WORD_WRAP` ID (Tools view-toggles range, BASE+440).
- **`menu.rs`** — `create_tools_menu` now takes `&ConfigManager`; appends a checkable item (`Word w&rap\tCtrl+Alt+W`) with its initial check state read from config.
- **`main_window.rs`** — `on_menu` handler: flip + persist `word_wrap`, rebuild open docs via `apply_word_wrap`, sync the menu check state, announce to screen readers, then restore focus to the text control.
- **`doc/readme.md`** — documented `Ctrl+Alt+W` in the keyboard-shortcuts list.

## Notes

- **Shortcut choice:** `Ctrl+Alt+W` keeps the W (wrap) mnemonic — plain `Ctrl+W` (Word Count) and `Ctrl+Shift+W` (View Note Text) are taken — and matches the existing `Ctrl+Alt+B` / `Ctrl+Alt+M` convention. No macOS-specific arm, mirroring those.

## Testing

- Toggle `Ctrl+Alt+W` while reading: text rewraps, caret/scroll preserved, focus stays in the document, screen reader announces "Word wrap on/off".
- Persists across restart; Options -> Readability checkbox reflects the current state.
- Works with no document open (config flips, no-op on zero tabs).