### PR TITLE
Count selected words in the Word Count dialog

### DIFF
--- a/crates/paperback/src/ui/dialogs/word_count.rs
+++ b/crates/paperback/src/ui/dialogs/word_count.rs
@@ -30,8 +30,9 @@ fn format_reading_time(word_count: usize, wpm: i32) -> String {
 	template.replace("{}", &time_str)
 }
 
-pub fn show_word_count_dialog(parent: &Frame, word_count: usize, reading_speed_wpm: i32) {
-	let words_template = t("This document contains {} words.");
+pub fn show_word_count_dialog(parent: &Frame, word_count: usize, reading_speed_wpm: i32, is_selection: bool) {
+	let words_template =
+		if is_selection { t("The selection contains {} words.") } else { t("This document contains {} words.") };
 	let mut msg = words_template.replace("{}", &word_count.to_string());
 	let reading_time = format_reading_time(word_count, reading_speed_wpm);
 	if !reading_time.is_empty() {

--- a/crates/paperback/src/ui/main_window.rs
+++ b/crates/paperback/src/ui/main_window.rs
@@ -1208,9 +1208,14 @@ impl MainWindow {
 						return;
 					};
 					if let Some(tab) = dm_ref.active_tab() {
-						let word_count = tab.session.stats().word_count;
+						let selection = tab.text_ctrl.get_string_selection();
+						let (word_count, is_selection) = if selection.trim().is_empty() {
+							(tab.session.stats().word_count, false)
+						} else {
+							(paperback_core::document::DocumentStats::from_text(&selection).word_count, true)
+						};
 						let wpm = config.lock().unwrap().get_app_int("reading_speed_wpm", 150);
-						dialogs::show_word_count_dialog(&frame_copy, word_count, wpm);
+						dialogs::show_word_count_dialog(&frame_copy, word_count, wpm, is_selection);
 					}
 				}
 				menu_ids::DOCUMENT_INFO => {


### PR DESCRIPTION
Today I needed a way to count the number of Words in a certain paragraph in a PDF document. I had to copy the words to a Word document to do so, therefore I thought it made sense to have this directly in Paperback.

## Changes

- `main_window.rs` — the `WORD_COUNT` handler reads the active tab''s selection via
  `text_ctrl.get_string_selection()`. If non-blank, it counts the selection with
  `DocumentStats::from_text` (same whitespace rules as the document count); otherwise
  it falls back to the precomputed document stats.
- `word_count.rs` — `show_word_count_dialog` takes an `is_selection` flag and picks
  the message template accordingly. Estimated reading time scales with the reported
  count automatically.
- New translatable string: `"The selection contains {} words."`.

## Behavior

- No selection → "This document contains N words." (unchanged).
- Selection → "The selection contains M words." with reading time scaled to M.
- Whitespace-only selection → falls back to the full document count.