### PR TITLE
feat(tables): render tables inline toggle (#535)

### DIFF
--- a/crates/paperback-core/src/config.rs
+++ b/crates/paperback-core/src/config.rs
@@ -122,6 +122,8 @@ pub struct AppSettings {
 	pub restore_previous_documents: bool,
 	#[serde(default)]
 	pub word_wrap: bool,
+	#[serde(default = "default_true")]
+	pub render_tables_inline: bool,
 	#[serde(default)]
 	pub navigation_wrap: bool,
 	#[serde(default)]
@@ -174,6 +176,7 @@ impl Default for AppSettings {
 		Self {
 			restore_previous_documents: true,
 			word_wrap: false,
+			render_tables_inline: true,
 			navigation_wrap: false,
 			find_match_case: false,
 			find_whole_word: false,
@@ -412,6 +415,7 @@ impl ConfigManager {
 		match key {
 			"restore_previous_documents" => data.app.restore_previous_documents,
 			"word_wrap" => data.app.word_wrap,
+			"render_tables_inline" => data.app.render_tables_inline,
 			"navigation_wrap" => data.app.navigation_wrap,
 			"find_match_case" => data.app.find_match_case,
 			"find_whole_word" => data.app.find_whole_word,
@@ -459,6 +463,7 @@ impl ConfigManager {
 			match key {
 				"restore_previous_documents" => data.app.restore_previous_documents = value,
 				"word_wrap" => data.app.word_wrap = value,
+				"render_tables_inline" => data.app.render_tables_inline = value,
 				"navigation_wrap" => data.app.navigation_wrap = value,
 				"find_match_case" => data.app.find_match_case = value,
 				"find_whole_word" => data.app.find_whole_word = value,
@@ -1106,5 +1111,16 @@ mod tests {
 		let a = config.get_doc_key("book-a.epub");
 		let b = config.get_doc_key("book-b.epub");
 		assert_ne!(a, b);
+	}
+
+	#[test]
+	fn render_tables_inline_round_trips() {
+		let mut config = ConfigManager::new();
+		config.initialized = true;
+		assert!(config.get_app_bool("render_tables_inline", true));
+		config.set_app_bool("render_tables_inline", false);
+		assert!(!config.get_app_bool("render_tables_inline", true));
+		config.set_app_bool("render_tables_inline", true);
+		assert!(config.get_app_bool("render_tables_inline", true));
 	}
 }

--- a/crates/paperback-core/src/document.rs
+++ b/crates/paperback-core/src/document.rs
@@ -532,12 +532,15 @@ pub struct ParserContext {
 	pub file_path: String,
 	pub password: Option<String>,
 	pub forced_extension: Option<String>,
+	/// When `true`, parsers emit each table's full tab-separated rendering inline; when `false`,
+	/// they emit a `"[Table]: <first row>"` placeholder. Threaded into each parser at parse time.
+	pub render_tables_inline: bool,
 }
 
 impl ParserContext {
 	#[must_use]
 	pub const fn new(file_path: String) -> Self {
-		Self { file_path, password: None, forced_extension: None }
+		Self { file_path, password: None, forced_extension: None, render_tables_inline: true }
 	}
 
 	#[must_use]
@@ -549,6 +552,12 @@ impl ParserContext {
 	#[must_use]
 	pub fn with_forced_extension(mut self, extension: String) -> Self {
 		self.forced_extension = Some(extension);
+		self
+	}
+
+	#[must_use]
+	pub const fn with_render_tables_inline(mut self, value: bool) -> Self {
+		self.render_tables_inline = value;
 		self
 	}
 }

--- a/crates/paperback-core/src/paperback.udl
+++ b/crates/paperback-core/src/paperback.udl
@@ -105,7 +105,7 @@ dictionary LinkListFfi {
 
 interface DocumentSession {
 	[Name=new_ffi, Throws=DocumentError]
-	constructor(string file_path, string password, string forced_extension);
+	constructor(string file_path, string password, string forced_extension, boolean render_tables_inline);
 
 	string title();
 	string author();

--- a/crates/paperback-core/src/parser.rs
+++ b/crates/paperback-core/src/parser.rs
@@ -25,6 +25,7 @@ pub mod odt;
 pub mod pdf;
 pub mod powerpoint;
 pub mod rtf;
+pub mod table_text;
 pub mod text;
 pub mod util;
 pub mod word;
@@ -530,5 +531,33 @@ mod tests {
 	fn file_filter_string_contains_text_files_group_name() {
 		let filter = build_file_filter_string();
 		assert!(filter.contains("Text Files ("));
+	}
+	/// `add_tables_separators_lists` sets the Table marker's `length` to `table.length`
+	/// (display units) and offsets it by the base offset.
+	#[test]
+	fn add_tables_separators_lists_sets_table_marker_length() {
+		let converter = MockConverter {
+			headings: vec![],
+			links: vec![],
+			images: vec![],
+			figures: vec![],
+			tables: vec![TableInfo {
+				offset: 10,
+				text: "T".to_string(),
+				html_content: "<table/>".to_string(),
+				length: 7, // display-unit field — must appear as marker length
+			}],
+			separators: vec![],
+			lists: vec![],
+			list_items: vec![],
+		};
+		let mut buffer = DocumentBuffer::new();
+		let base_offset = 100usize;
+		add_converter_markers(&mut buffer, &converter, base_offset);
+
+		let table_marker = buffer.markers.iter().find(|m| m.mtype == MarkerType::Table).expect("Table marker");
+		assert_eq!(table_marker.position, base_offset + 10, "position = offset + table.offset");
+		assert_eq!(table_marker.length, 7, "marker length must equal table length, not byte length");
+		assert_eq!(table_marker.reference, "<table/>", "marker reference must be the table HTML");
 	}
 }

--- a/crates/paperback-core/src/parser/chm.rs
+++ b/crates/paperback-core/src/parser/chm.rs
@@ -63,7 +63,7 @@ impl Parser for ChmParser {
 				continue;
 			}
 			let utf8_content = convert_to_utf8(&content_bytes);
-			let mut converter = HtmlToText::new();
+			let mut converter = HtmlToText::with_render_tables_inline(context.render_tables_inline);
 			if !converter.convert(&utf8_content, HtmlSourceMode::NativeHtml) {
 				continue;
 			}

--- a/crates/paperback-core/src/parser/daisy.rs
+++ b/crates/paperback-core/src/parser/daisy.rs
@@ -93,7 +93,7 @@ impl Parser for DaisyParser {
 									e.context("Failed to read XML file from zip")
 								}
 							})?;
-					let mut converter = XmlToText::new();
+					let mut converter = XmlToText::with_render_tables_inline(context.render_tables_inline);
 					if converter.convert(&xml_content) {
 						buffer = DocumentBuffer::with_content(converter.get_text());
 						add_converter_markers(&mut buffer, &converter, 0);
@@ -156,7 +156,7 @@ impl Parser for DaisyParser {
 						combined_html.push_str("\n\n");
 					}
 				}
-				let mut converter = HtmlToText::new();
+				let mut converter = HtmlToText::with_render_tables_inline(context.render_tables_inline);
 				if converter.convert(&combined_html, HtmlSourceMode::NativeHtml) {
 					buffer = DocumentBuffer::with_content(converter.get_text());
 					add_converter_markers(&mut buffer, &converter, 0);
@@ -186,7 +186,7 @@ impl Parser for DaisyParser {
 			let xml_full_path = base_dir.join(&dtbook_path);
 			let xml_content = std::fs::read_to_string(&xml_full_path)
 				.with_context(|| format!("Failed to read DTBook XML file at {}", xml_full_path.display()))?;
-			let mut converter = XmlToText::new();
+			let mut converter = XmlToText::with_render_tables_inline(context.render_tables_inline);
 			if converter.convert(&xml_content) {
 				buffer = DocumentBuffer::with_content(converter.get_text());
 				add_converter_markers(&mut buffer, &converter, 0);

--- a/crates/paperback-core/src/parser/epub.rs
+++ b/crates/paperback-core/src/parser/epub.rs
@@ -123,7 +123,7 @@ impl Parser for EpubParser {
 			.find(|n| n.node_type() == NodeType::Element && n.tag_name().name() == "package")
 			.ok_or_else(|| anyhow::anyhow!("OPF package element missing"))?;
 		let (manifest, spine, nav_path, ncx_path, metadata) = parse_package(package_node, &opf_dir);
-		let mut conversion = convert_spine_items(&mut archive, &manifest, &spine);
+		let mut conversion = convert_spine_items(&mut archive, &manifest, &spine, context.render_tables_inline);
 		if conversion.sections.is_empty() {
 			let reason = if conversion.conversion_errors.is_empty() {
 				String::from("no readable spine items")
@@ -170,6 +170,7 @@ fn convert_spine_items<R: Read + Seek>(
 	archive: &mut ZipArchive<R>,
 	manifest: &HashMap<String, ManifestItem>,
 	spine: &[String],
+	render_tables_inline: bool,
 ) -> SpineConversionResult {
 	let mut buffer = DocumentBuffer::new();
 	let mut id_positions = HashMap::new();
@@ -194,7 +195,7 @@ fn convert_spine_items<R: Read + Seek>(
 				.with_text(section_label)
 				.with_reference(item.path.clone()),
 		);
-		match convert_section(&section_data) {
+		match convert_section(&section_data, render_tables_inline) {
 			Ok(section) => {
 				for (id, relative) in &section.id_positions {
 					let absolute = section_start + relative;
@@ -336,8 +337,8 @@ fn parse_package(package: Node<'_, '_>, opf_dir: &Path) -> PackageParts {
 	(manifest, spine, nav_path, ncx_path, PackageMetadata { title, author })
 }
 
-fn convert_section(content: &str) -> Result<SectionContent> {
-	let mut xml_converter = XmlToText::new();
+fn convert_section(content: &str, render_tables_inline: bool) -> Result<SectionContent> {
+	let mut xml_converter = XmlToText::with_render_tables_inline(render_tables_inline);
 	if xml_converter.convert(content) {
 		return Ok(SectionContent {
 			text: xml_converter.get_text(),
@@ -352,7 +353,7 @@ fn convert_section(content: &str) -> Result<SectionContent> {
 			id_positions: xml_converter.get_id_positions().clone(),
 		});
 	}
-	let mut html_converter = HtmlToText::new();
+	let mut html_converter = HtmlToText::with_render_tables_inline(render_tables_inline);
 	if html_converter.convert(content, HtmlSourceMode::NativeHtml) {
 		return Ok(SectionContent {
 			text: html_converter.get_text(),

--- a/crates/paperback-core/src/parser/fb2.rs
+++ b/crates/paperback-core/src/parser/fb2.rs
@@ -40,7 +40,7 @@ impl Parser for Fb2Parser {
 			let (title, author) = extract_metadata(&xml_content);
 			(xml_content, (title, author))
 		});
-		let mut converter = XmlToText::new();
+		let mut converter = XmlToText::with_render_tables_inline(context.render_tables_inline);
 		if !converter.convert(&xml_content) {
 			anyhow::bail!("Failed to convert FB2 XML to text");
 		}

--- a/crates/paperback-core/src/parser/html.rs
+++ b/crates/paperback-core/src/parser/html.rs
@@ -34,7 +34,7 @@ impl Parser for HtmlParser {
 			anyhow::bail!("HTML file is empty: {}", context.file_path);
 		}
 		let html_content = convert_to_utf8(&bytes);
-		let mut converter = HtmlToText::new();
+		let mut converter = HtmlToText::with_render_tables_inline(context.render_tables_inline);
 		if !converter.convert(&html_content, HtmlSourceMode::NativeHtml) {
 			anyhow::bail!("Failed to convert HTML to text: {}", context.file_path);
 		}

--- a/crates/paperback-core/src/parser/html_to_text.rs
+++ b/crates/paperback-core/src/parser/html_to_text.rs
@@ -256,8 +256,7 @@ impl HtmlToText {
 	/// length so position tracking stays correct. Used for table rows whose tab separators and empty
 	/// cells must not be mangled by `add_line`.
 	fn push_finalized_line(&mut self, line: String) {
-		self.cached_char_length += display_len(&line) + 1; // +1 for the line's newline
-		self.lines.push(line);
+		crate::parser::table_text::push_finalized_line(&mut self.lines, &mut self.cached_char_length, line);
 	}
 
 	fn handle_element_opening(&mut self, tag_name: &str, node: NodeRef<'_, Node>, document: &Html) {

--- a/crates/paperback-core/src/parser/html_to_text.rs
+++ b/crates/paperback-core/src/parser/html_to_text.rs
@@ -65,6 +65,9 @@ pub struct HtmlToText {
 	link_start_pos: usize,
 	source_mode: HtmlSourceMode,
 	cached_char_length: usize,
+	/// When `true`, tables are emitted as their full tab-separated rendering; otherwise as a
+	/// `"[Table]: <first row>"` placeholder. A config flag, not parse state: it survives `clear()`.
+	render_tables_inline: bool,
 }
 
 impl HtmlToText {
@@ -93,7 +96,16 @@ impl HtmlToText {
 			link_start_pos: 0,
 			source_mode: HtmlSourceMode::NativeHtml,
 			cached_char_length: 0,
+			render_tables_inline: false,
 		}
+	}
+
+	/// Like [`new`](Self::new) but sets whether tables are rendered inline (full TSV) or as a
+	/// placeholder. Threaded from the owning parser's `ParserContext`; preserved across
+	/// `convert`/`clear`.
+	#[must_use]
+	pub fn with_render_tables_inline(render_tables_inline: bool) -> Self {
+		Self { render_tables_inline, ..Self::new() }
 	}
 
 	pub fn convert(&mut self, html_content: &str, mode: HtmlSourceMode) -> bool {
@@ -222,65 +234,30 @@ impl HtmlToText {
 	fn handle_table(&mut self, node: NodeRef<'_, Node>, document: &Html) {
 		self.finalize_current_line();
 		let table_html = Self::serialize_node(node, document);
-		let start_lines_count = self.lines.len();
 		let start_offset = self.get_current_text_position();
-		let mut table_caption = String::new();
-		for child in node.children() {
-			if let Node::Element(element) = child.value()
-				&& element.name() == "caption"
-			{
-				table_caption = Self::collect_text(child).trim().to_string();
-				break;
-			}
+		// Emit the table's on-screen text via the shared helper instead of recursing children to
+		// emit one cell per line. The helper output may contain tabs and span multiple lines; push
+		// each line verbatim so tab separators and empty cells survive whitespace collapsing.
+		let render = crate::parser::table_text::table_render_bundle(&table_html, self.render_tables_inline);
+		for line in render.lines {
+			self.push_finalized_line(line);
 		}
-		if table_caption.is_empty() {
-			for child in node.children() {
-				if let Node::Element(element) = child.value() {
-					let name = element.name();
-					if name == "tr" {
-						table_caption = Self::collect_text(child).trim().to_string();
-						break;
-					} else if matches!(name, "thead" | "tbody" | "tfoot") {
-						for subchild in child.children() {
-							if let Node::Element(subelem) = subchild.value()
-								&& subelem.name() == "tr"
-							{
-								table_caption = Self::collect_text(subchild).trim().to_string();
-								break;
-							}
-						}
-						if !table_caption.is_empty() {
-							break;
-						}
-					}
-				}
-			}
-		}
-		for child in node.children() {
-			self.process_node(child, document);
-		}
-		self.finalize_current_line();
-		let mut table_text = String::new();
-		for (i, line) in self.lines.iter().enumerate().skip(start_lines_count) {
-			if i > start_lines_count {
-				table_text.push('\n');
-			}
-			table_text.push_str(line);
-		}
-		if table_text.trim().is_empty() {
-			table_text = "table".to_string();
-			self.current_line.push_str(&table_text);
-			self.finalize_current_line();
-		}
-		if table_caption.trim().is_empty() {
-			table_caption = "table".to_string();
-		}
+		let table_caption = render.caption;
+		let display_length = render.display_length;
 		self.tables.push(TableInfo {
 			offset: start_offset,
 			text: table_caption,
 			html_content: table_html,
-			length: table_text.len(),
+			length: display_length,
 		});
+	}
+
+	/// Push a line to the output verbatim (no whitespace collapsing/trimming), updating the cached
+	/// length so position tracking stays correct. Used for table rows whose tab separators and empty
+	/// cells must not be mangled by `add_line`.
+	fn push_finalized_line(&mut self, line: String) {
+		self.cached_char_length += display_len(&line) + 1; // +1 for the line's newline
+		self.lines.push(line);
 	}
 
 	fn handle_element_opening(&mut self, tag_name: &str, node: NodeRef<'_, Node>, document: &Html) {
@@ -644,10 +621,10 @@ impl crate::parser::ConverterOutput for HtmlToText {
 	fn get_links(&self) -> &[LinkInfo] {
 		&self.links
 	}
-	fn get_images(&self) -> &[crate::types::ImageInfo] {
+	fn get_images(&self) -> &[ImageInfo] {
 		&self.images
 	}
-	fn get_figures(&self) -> &[crate::types::ImageInfo] {
+	fn get_figures(&self) -> &[ImageInfo] {
 		&self.figures
 	}
 	fn get_tables(&self) -> &[TableInfo] {
@@ -669,6 +646,54 @@ mod tests {
 	use rstest::rstest;
 
 	use super::*;
+
+	/// End-to-end: the HtmlToText converter emits each table's on-screen text at parse time, and a
+	/// heading that follows the table is offset by the emitted display extent. Verified in both
+	/// modes: OFF (placeholder) and ON (full TSV). The fixture has an "Intro" paragraph before the
+	/// table (so the table offset is non-zero) and an `<h2>` after it.
+	#[rstest]
+	#[case(false)]
+	#[case(true)]
+	fn html_converter_emits_table_inline_or_placeholder(#[case] inline: bool) {
+		let html = concat!(
+			"<html><body>",
+			"<p>Intro</p>",
+			"<table><tr><td>A</td><td>B</td></tr></table>",
+			"<h2>After heading</h2>",
+			"</body></html>"
+		);
+
+		let mut converter = HtmlToText::with_render_tables_inline(inline);
+		assert!(converter.convert(html, HtmlSourceMode::NativeHtml));
+
+		let tables = converter.get_tables();
+		assert_eq!(tables.len(), 1);
+		assert_eq!(tables[0].offset, 6, "table follows 'Intro\n' (6 display units)");
+
+		let table_line = if inline { "A\tB" } else { "[Table]: A B" };
+		let expected_text = format!("Intro\n{table_line}\nAfter heading");
+		assert_eq!(converter.get_text(), expected_text, "table emitted as {table_line:?}");
+
+		// display_length equals the emitted display extent (the table line plus its newline).
+		let expected_display_length = display_len(table_line) + 1;
+		assert_eq!(tables[0].length, expected_display_length);
+
+		// The heading marker that follows the table sits right after the emitted table span.
+		let headings = converter.get_headings();
+		assert_eq!(headings.len(), 1);
+		assert_eq!(
+			headings[0].offset,
+			tables[0].offset + expected_display_length,
+			"h2 immediately follows the emitted table span"
+		);
+
+		// Through the real marker path, the Table marker's length matches the emitted extent.
+		let mut buffer = crate::document::DocumentBuffer::with_content(converter.get_text());
+		crate::parser::add_converter_markers(&mut buffer, &converter, 0);
+		let table_marker =
+			buffer.markers.iter().find(|m| m.mtype == crate::document::MarkerType::Table).expect("Table marker");
+		assert_eq!(table_marker.length, expected_display_length);
+	}
 
 	#[test]
 	fn test_title_and_text() {
@@ -785,5 +810,47 @@ mod tests {
 		assert_eq!(converter.get_title(), "Second");
 		assert_eq!(converter.get_text(), "Two");
 		assert!(converter.get_headings().is_empty());
+	}
+
+	#[test]
+	fn html_table_display_length_is_display_extent_not_byte_length() {
+		let html = concat!(
+			"<html><body><p>Intro</p>",
+			"<table><tr><td>A</td><td>\u{1D11E}</td></tr></table>",
+			"</body></html>"
+		);
+		let mut converter = HtmlToText::with_render_tables_inline(true);
+		assert!(converter.convert(html, HtmlSourceMode::NativeHtml));
+		let tables = converter.get_tables();
+		assert_eq!(tables.len(), 1, "expected exactly one table");
+		let table = &tables[0];
+		assert_eq!(table.offset, 6, "table starts after 'Intro\n'");
+		assert_eq!(table.length, 5, "length must be the display extent (5 display units), not byte length (6)");
+	}
+
+	#[test]
+	fn html_two_tables_offsets_are_cumulative() {
+		let html = concat!(
+			"<html><body>",
+			"<table><tr><td>X</td></tr></table>",
+			"<table><tr><td>Y</td></tr></table>",
+			"</body></html>"
+		);
+		let mut converter = HtmlToText::new();
+		assert!(converter.convert(html, HtmlSourceMode::NativeHtml));
+		let tables = converter.get_tables();
+		assert_eq!(tables.len(), 2, "expected two tables");
+
+		let t1_offset = tables[0].offset;
+		let t1_display_length = tables[0].length;
+		let t2_offset = tables[1].offset;
+
+		assert_eq!(t1_offset, 0, "first table starts at 0");
+		assert!(t1_display_length > 0, "first table has non-zero display_length");
+		assert_eq!(
+			t2_offset,
+			t1_offset + t1_display_length,
+			"second table offset must equal first offset + first display_length"
+		);
 	}
 }

--- a/crates/paperback-core/src/parser/markdown.rs
+++ b/crates/paperback-core/src/parser/markdown.rs
@@ -123,7 +123,7 @@ impl Parser for MarkdownParser {
 			.with_context(|| format!("Failed to open Markdown file '{}'", context.file_path))?;
 		let markdown_content = convert_to_utf8(&bytes);
 		let html_content = markdown_to_html(&markdown_content);
-		let mut converter = HtmlToText::new();
+		let mut converter = HtmlToText::with_render_tables_inline(context.render_tables_inline);
 		if !converter.convert(&html_content, HtmlSourceMode::Markdown) {
 			anyhow::bail!("Failed to convert Markdown to text: {}", context.file_path);
 		}

--- a/crates/paperback-core/src/parser/mobi.rs
+++ b/crates/paperback-core/src/parser/mobi.rs
@@ -247,7 +247,7 @@ impl Parser for MobiParser {
 		// Old-style Mobipocket files use <font size="N"> instead of <h1>-<h6>.
 		// Rewrite them so the heading-based TOC builder can pick them up.
 		text = rewrite_font_size_headings(&text);
-		let mut html_converter = HtmlToText::new();
+		let mut html_converter = HtmlToText::with_render_tables_inline(context.render_tables_inline);
 		html_converter.convert(&text, HtmlSourceMode::NativeHtml);
 		if document_title.trim().is_empty() {
 			document_title = extract_title_from_path(&context.file_path);

--- a/crates/paperback-core/src/parser/odt.rs
+++ b/crates/paperback-core/src/parser/odt.rs
@@ -42,7 +42,7 @@ impl Parser for OdtParser {
 		let xml_doc = XmlDocument::parse(&content_str).context("Invalid ODT content.xml")?;
 		let mut buffer = DocumentBuffer::new();
 		let mut id_positions = HashMap::new();
-		traverse(xml_doc.root(), &mut buffer, &mut id_positions);
+		traverse(xml_doc.root(), &mut buffer, &mut id_positions, context.render_tables_inline);
 		let title = extract_title_from_path(&context.file_path);
 		let toc_items = build_toc_from_buffer(&buffer);
 		let mut document = Document::new().with_title(title);
@@ -74,7 +74,7 @@ impl Parser for FodtParser {
 		let xml_doc = XmlDocument::parse(&content_str).context("Invalid FODT document")?;
 		let mut buffer = DocumentBuffer::new();
 		let mut id_positions = HashMap::new();
-		traverse(xml_doc.root(), &mut buffer, &mut id_positions);
+		traverse(xml_doc.root(), &mut buffer, &mut id_positions, context.render_tables_inline);
 		let title = extract_title_from_path(&context.file_path);
 		let toc_items = build_toc_from_buffer(&buffer);
 		let mut document = Document::new().with_title(title);
@@ -85,7 +85,12 @@ impl Parser for FodtParser {
 	}
 }
 
-fn traverse(node: Node, buffer: &mut DocumentBuffer, id_positions: &mut HashMap<String, usize>) {
+fn traverse(
+	node: Node,
+	buffer: &mut DocumentBuffer,
+	id_positions: &mut HashMap<String, usize>,
+	render_tables_inline: bool,
+) {
 	if node.node_type() == NodeType::Element {
 		let tag_name = node.tag_name().name();
 		if tag_name == "h" {
@@ -101,7 +106,7 @@ fn traverse(node: Node, buffer: &mut DocumentBuffer, id_positions: &mut HashMap<
 			return; // Don't traverse children, we already got the text
 		}
 		if tag_name == "p" {
-			traverse_children(node, buffer, id_positions);
+			traverse_children(node, buffer, id_positions, render_tables_inline);
 			buffer.append("\n");
 			return;
 		}
@@ -124,7 +129,7 @@ fn traverse(node: Node, buffer: &mut DocumentBuffer, id_positions: &mut HashMap<
 			id_positions.insert(id.to_string(), buffer.current_position());
 		}
 		if tag_name == "table" {
-			process_table(node, buffer, id_positions);
+			process_table(node, buffer, render_tables_inline);
 			return;
 		}
 	} else if node.node_type() == NodeType::Text {
@@ -133,59 +138,112 @@ fn traverse(node: Node, buffer: &mut DocumentBuffer, id_positions: &mut HashMap<
 		}
 		return;
 	}
-	traverse_children(node, buffer, id_positions);
+	traverse_children(node, buffer, id_positions, render_tables_inline);
 }
 
-fn traverse_children(node: Node, buffer: &mut DocumentBuffer, id_positions: &mut HashMap<String, usize>) {
+fn traverse_children(
+	node: Node,
+	buffer: &mut DocumentBuffer,
+	id_positions: &mut HashMap<String, usize>,
+	render_tables_inline: bool,
+) {
 	for child in node.children() {
-		traverse(child, buffer, id_positions);
+		traverse(child, buffer, id_positions, render_tables_inline);
 	}
 }
 
-fn process_table(node: Node, buffer: &mut DocumentBuffer, id_positions: &mut HashMap<String, usize>) {
+fn process_table(node: Node, buffer: &mut DocumentBuffer, render_tables_inline: bool) {
 	let table_start = buffer.current_position();
 	let mut html_content = String::from("<table border=\"1\">");
 	let mut table_caption = String::new();
 	let mut found_first_row = false;
+	let mut has_content = false;
+	// Build the table HTML and caption from the XML nodes directly. Cell text is collected via
+	// `collect_element_text` (operating on the XML tree), NOT by slicing the display buffer — the
+	// display buffer is indexed in display units, so slicing it with those offsets as byte indices
+	// mis-sliced (and could panic) on non-ASCII cell content.
 	for child in node.children() {
 		if child.is_element() && child.tag_name().name() == "table-row" {
-			if !found_first_row {
-				for cell in child.children() {
-					if cell.is_element() && cell.tag_name().name() == "table-cell" {
-						let cell_text = collect_element_text(cell);
-						table_caption.push_str(&cell_text);
-						table_caption.push(' ');
-					}
-				}
-				found_first_row = true;
-			}
 			html_content.push_str("<tr>");
 			for cell in child.children() {
 				if cell.is_element() && cell.tag_name().name() == "table-cell" {
+					let cell_text = collect_element_text(cell);
+					if !cell_text.trim().is_empty() {
+						has_content = true;
+					}
+					if !found_first_row {
+						table_caption.push_str(cell_text.trim());
+						table_caption.push(' ');
+					}
 					html_content.push_str("<td>");
-					let cell_start = buffer.current_position();
-					traverse_children(cell, buffer, id_positions);
-					let cell_end = buffer.current_position();
-					let cell_text = &buffer.content[cell_start..cell_end];
 					html_content.push_str(&cell_text.replace('\n', "<br/>"));
 					html_content.push_str("</td>");
-					buffer.append(" ");
 				}
 			}
 			html_content.push_str("</tr>");
-			buffer.append("\n");
+			found_first_row = true;
 		}
 	}
 	html_content.push_str("</table>");
-	let table_end = buffer.current_position();
-	let table_text = buffer.content[table_start..table_end].to_string();
-	if !table_text.trim().is_empty() {
-		let marker_text = if table_caption.trim().is_empty() { "table".to_string() } else { table_caption };
-		buffer.add_marker(
-			Marker::new(MarkerType::Table, table_start)
-				.with_text(marker_text)
-				.with_reference(html_content)
-				.with_length(table_text.len()),
-		);
+	if !has_content {
+		return;
+	}
+	let marker_text =
+		if table_caption.trim().is_empty() { "table".to_string() } else { table_caption.trim().to_string() };
+	let display_text = crate::parser::table_text::html_table_to_display(&html_content, render_tables_inline);
+	buffer.append(&display_text);
+	buffer.append("\n");
+	let display_len = buffer.current_position() - table_start;
+	buffer.add_marker(
+		Marker::new(MarkerType::Table, table_start)
+			.with_text(marker_text)
+			.with_reference(html_content)
+			.with_length(display_len),
+	);
+}
+
+#[cfg(test)]
+mod tests {
+	use std::collections::HashMap;
+
+	use roxmltree::Document as XmlDocument;
+
+	use super::traverse;
+	use crate::{
+		document::{DocumentBuffer, MarkerType},
+		util::text::display_len,
+	};
+
+	/// OFF mode: an ODT table emits a `"[Table]: <first row>"` placeholder. The second cell holds a
+	/// non-ASCII character (U+1D11E, G Clef, non-BMP) to prove the cell-text extraction no longer
+	/// mis-slices the display buffer with display-unit offsets as byte indices.
+	#[test]
+	fn odt_table_emits_placeholder_when_off() {
+		let xml = "<document><table><table-row><table-cell>Kop</table-cell><table-cell>\u{1D11E}</table-cell></table-row></table></document>";
+		let xml_doc = XmlDocument::parse(xml).expect("valid xml");
+		let mut buffer = DocumentBuffer::new();
+		let mut id_positions = HashMap::new();
+		traverse(xml_doc.root(), &mut buffer, &mut id_positions, false);
+
+		assert_eq!(buffer.content, "[Table]: Kop \u{1D11E}\n");
+		let table_marker = buffer.markers.iter().find(|m| m.mtype == MarkerType::Table).expect("Table marker");
+		assert_eq!(table_marker.position, 0, "marker starts at buffer start");
+		assert_eq!(table_marker.length, display_len("[Table]: Kop \u{1D11E}") + 1, "marker length in display units");
+		assert_eq!(table_marker.text, "Kop \u{1D11E}", "marker keeps the first-row caption");
+		assert!(table_marker.reference.contains("<table"), "marker reference is the table HTML");
+	}
+
+	/// ON mode: the same ODT table emits the full TSV instead of the placeholder.
+	#[test]
+	fn odt_table_emits_tsv_when_inline() {
+		let xml = "<document><table><table-row><table-cell>Kop</table-cell><table-cell>\u{1D11E}</table-cell></table-row></table></document>";
+		let xml_doc = XmlDocument::parse(xml).expect("valid xml");
+		let mut buffer = DocumentBuffer::new();
+		let mut id_positions = HashMap::new();
+		traverse(xml_doc.root(), &mut buffer, &mut id_positions, true);
+
+		assert_eq!(buffer.content, "Kop\t\u{1D11E}\n");
+		let table_marker = buffer.markers.iter().find(|m| m.mtype == MarkerType::Table).expect("Table marker");
+		assert_eq!(table_marker.length, display_len("Kop\t\u{1D11E}") + 1, "marker length spans the TSV");
 	}
 }

--- a/crates/paperback-core/src/parser/odt.rs
+++ b/crates/paperback-core/src/parser/odt.rs
@@ -129,7 +129,7 @@ fn traverse(
 			id_positions.insert(id.to_string(), buffer.current_position());
 		}
 		if tag_name == "table" {
-			process_table(node, buffer, render_tables_inline);
+			process_table(node, buffer, id_positions, render_tables_inline);
 			return;
 		}
 	} else if node.node_type() == NodeType::Text {
@@ -152,8 +152,23 @@ fn traverse_children(
 	}
 }
 
-fn process_table(node: Node, buffer: &mut DocumentBuffer, render_tables_inline: bool) {
+fn process_table(
+	node: Node,
+	buffer: &mut DocumentBuffer,
+	id_positions: &mut HashMap<String, usize>,
+	render_tables_inline: bool,
+) {
 	let table_start = buffer.current_position();
+	// The table collapses to a placeholder/TSV, so cells have no individual display offset. Register
+	// every anchor `id` nested inside the table at the table's start position; internal links to a
+	// bookmark/footnote/cross-ref target inside a cell then navigate to the table.
+	for descendant in node.descendants() {
+		if descendant.is_element()
+			&& let Some(id) = descendant.attribute("id")
+		{
+			id_positions.insert(id.to_string(), table_start);
+		}
+	}
 	let mut html_content = String::from("<table border=\"1\">");
 	let mut table_caption = String::new();
 	let mut found_first_row = false;
@@ -231,6 +246,26 @@ mod tests {
 		assert_eq!(table_marker.length, display_len("[Table]: Kop \u{1D11E}") + 1, "marker length in display units");
 		assert_eq!(table_marker.text, "Kop \u{1D11E}", "marker keeps the first-row caption");
 		assert!(table_marker.reference.contains("<table"), "marker reference is the table HTML");
+	}
+
+	/// An `id` attribute on an element nested inside a table cell must be registered in
+	/// `id_positions` at the table's start position, so internal links to that anchor navigate to
+	/// the table. Holds in both OFF and ON modes (registration happens before the cells collapse).
+	#[test]
+	fn odt_table_cell_id_registered_at_table_start() {
+		let xml = "<document><p>before</p><table><table-row><table-cell><span id=\"anchor1\">Kop</span></table-cell></table-row></table></document>";
+		let xml_doc = XmlDocument::parse(xml).expect("valid xml");
+		for inline in [false, true] {
+			let mut buffer = DocumentBuffer::new();
+			let mut id_positions = HashMap::new();
+			traverse(xml_doc.root(), &mut buffer, &mut id_positions, inline);
+			let table_marker = buffer.markers.iter().find(|m| m.mtype == MarkerType::Table).expect("Table marker");
+			assert_eq!(
+				id_positions.get("anchor1"),
+				Some(&table_marker.position),
+				"in-cell anchor id maps to the table start (inline={inline})"
+			);
+		}
 	}
 
 	/// ON mode: the same ODT table emits the full TSV instead of the placeholder.

--- a/crates/paperback-core/src/parser/pdf.rs
+++ b/crates/paperback-core/src/parser/pdf.rs
@@ -824,12 +824,15 @@ fn append_pdf_table_to_buffer(
 	render_tables_inline: bool,
 ) {
 	let display_text = crate::parser::table_text::html_table_to_display(&html, render_tables_inline);
-	for line in display_text.split('\n') {
+	// `display_lines_and_length` guards the empty case (an empty inline table) by returning no
+	// lines, where a raw `split('\n')` would yield one `""` and emit a spurious blank line.
+	let (lines, _) = crate::parser::table_text::display_lines_and_length(&display_text);
+	for line in lines {
 		let line_pos = buffer.current_position();
-		current_lines_info.push((line_pos, line.to_string()));
-		buffer.append(line);
+		current_lines_info.push((line_pos, line.clone()));
+		buffer.append(&line);
 		buffer.append("\n");
-		page_display_text.push_str(line);
+		page_display_text.push_str(&line);
 		page_display_text.push('\n');
 	}
 	let display_len = buffer.current_position() - pos;
@@ -917,5 +920,23 @@ mod tests {
 		let expected_len = display_len("Kop\t\u{1D11E}\na\tb\n");
 		let table_marker = buffer.markers.iter().find(|m| m.mtype == MarkerType::Table).expect("Table marker present");
 		assert_eq!(table_marker.length, expected_len, "marker length spans all emitted rows");
+	}
+
+	/// An empty inline table must emit no line at all (a raw `split('\n')` would emit one spurious
+	/// blank line). The buffer stays empty and the Table marker has zero length.
+	#[test]
+	fn pdf_table_helper_empty_inline_emits_no_line() {
+		let html = "<table border=\"1\">\n</table>\n".to_string();
+		let mut buffer = DocumentBuffer::new();
+		let pos = buffer.current_position();
+		let mut lines_info = Vec::new();
+		let mut page_text = String::new();
+		append_pdf_table_to_buffer(&mut buffer, html, pos, &mut lines_info, &mut page_text, true);
+
+		assert_eq!(buffer.content, "", "empty inline table appends nothing");
+		assert!(lines_info.is_empty(), "no lines recorded");
+		assert!(page_text.is_empty(), "no page display text");
+		let table_marker = buffer.markers.iter().find(|m| m.mtype == MarkerType::Table).expect("Table marker present");
+		assert_eq!(table_marker.length, 0, "zero-length marker for empty inline table");
 	}
 }

--- a/crates/paperback-core/src/parser/pdf.rs
+++ b/crates/paperback-core/src/parser/pdf.rs
@@ -33,6 +33,7 @@ impl Parser for PdfParser {
 	}
 
 	fn parse(&self, context: &ParserContext) -> Result<Document> {
+		let render_tables_inline = context.render_tables_inline;
 		let document =
 			PdfiumDocument::new_from_path(&context.file_path, context.password.as_deref()).map_err(map_load_error)?;
 		let mut buffer = DocumentBuffer::new();
@@ -118,6 +119,7 @@ impl Parser for PdfParser {
 									&mut current_block,
 									&mut current_lines_info,
 									&mut flat_toc_items,
+									render_tables_inline,
 								);
 							}
 						}
@@ -656,19 +658,14 @@ fn process_struct_element(
 	current_block: &mut String,
 	current_lines_info: &mut Vec<(usize, String)>,
 	toc_items: &mut Vec<(u32, TocItem)>,
+	render_tables_inline: bool,
 ) {
 	let elem_type = elem.element_type().unwrap_or_default();
 	if elem_type == "Table" {
 		flush_block(current_block, buffer, page_display_text, current_lines_info);
 		let html = build_html_table(elem, mcid_to_text);
 		let pos = buffer.current_position();
-		buffer.add_marker(Marker::new(MarkerType::Table, pos).with_reference(html));
-		let table_placeholder = "[Table]";
-		current_lines_info.push((pos, table_placeholder.to_string()));
-		buffer.append(table_placeholder);
-		buffer.append("\n");
-		page_display_text.push_str(table_placeholder);
-		page_display_text.push('\n');
+		append_pdf_table_to_buffer(buffer, html, pos, current_lines_info, page_display_text, render_tables_inline);
 		return;
 	}
 	let is_block = matches!(
@@ -700,6 +697,7 @@ fn process_struct_element(
 				current_block,
 				current_lines_info,
 				toc_items,
+				render_tables_inline,
 			);
 		} else if let Some(mcid) = elem.child_marked_content_id(i)
 			&& let Some(text) = mcid_to_text.get(&mcid)
@@ -811,9 +809,37 @@ fn html_escape(s: &str) -> String {
 	s.replace('&', "&amp;").replace('<', "&lt;").replace('>', "&gt;")
 }
 
+/// Append a PDF table's on-screen text to the buffer and add the Table marker. The text is produced
+/// by [`crate::parser::table_text::html_table_to_display`]: the full tab-separated rendering when
+/// `render_tables_inline` is set, otherwise a `"[Table]: <first row>"` placeholder. The helper
+/// output may span multiple lines (one per table row); each line is recorded as its own
+/// `current_lines_info` / `page_display_text` line, mirroring the rest of the PDF line tracking.
+/// Extracted from `process_struct_element` so the logic is unit-testable without live pdfium objects.
+fn append_pdf_table_to_buffer(
+	buffer: &mut DocumentBuffer,
+	html: String,
+	pos: usize,
+	current_lines_info: &mut Vec<(usize, String)>,
+	page_display_text: &mut String,
+	render_tables_inline: bool,
+) {
+	let display_text = crate::parser::table_text::html_table_to_display(&html, render_tables_inline);
+	for line in display_text.split('\n') {
+		let line_pos = buffer.current_position();
+		current_lines_info.push((line_pos, line.to_string()));
+		buffer.append(line);
+		buffer.append("\n");
+		page_display_text.push_str(line);
+		page_display_text.push('\n');
+	}
+	let display_len = buffer.current_position() - pos;
+	buffer.add_marker(Marker::new(MarkerType::Table, pos).with_reference(html).with_length(display_len));
+}
+
 #[cfg(test)]
 mod tests {
-	use super::{join_paragraphs, sanitize_pdf_text};
+	use super::{append_pdf_table_to_buffer, join_paragraphs, sanitize_pdf_text};
+	use crate::document::{DocumentBuffer, MarkerType};
 
 	#[test]
 	fn sanitize_pdf_text_strips_control_chars_and_soft_hyphens() {
@@ -840,5 +866,56 @@ mod tests {
 		assert!(result[0].1);
 		assert_eq!(result[1].0, "This is the body text of the document.");
 		assert!(!result[1].1);
+	}
+
+	/// OFF mode: the PDF table helper emits a single `"[Table]: <first row>"` placeholder line and
+	/// the Table marker's length equals the emitted display extent. The HTML has a non-BMP char
+	/// (U+1D11E, G Clef) in a cell to lock display-unit math (it takes 2 UTF-16 units).
+	#[test]
+	fn pdf_table_helper_emits_placeholder_when_off() {
+		use crate::util::text::display_len;
+		let html = "<table border=\"1\">\n<tr>\n<td>Kop</td>\n<td>\u{1D11E}</td>\n</tr>\n</table>\n".to_string();
+		let mut buffer = DocumentBuffer::new();
+		let pos = buffer.current_position();
+		let mut lines_info = Vec::new();
+		let mut page_text = String::new();
+		append_pdf_table_to_buffer(&mut buffer, html.clone(), pos, &mut lines_info, &mut page_text, false);
+
+		// Placeholder: first row with tabs->spaces.
+		assert_eq!(buffer.content, "[Table]: Kop \u{1D11E}\n");
+		assert_eq!(lines_info.len(), 1, "placeholder is a single line");
+		assert!(lines_info[0].1.starts_with("[Table]: "));
+
+		// Table marker length equals the emitted display extent.
+		let placeholder_len = display_len("[Table]: Kop \u{1D11E}") + 1; // +1 for trailing newline
+		let table_marker = buffer.markers.iter().find(|m| m.mtype == MarkerType::Table).expect("Table marker present");
+		assert_eq!(table_marker.position, 0);
+		assert_eq!(table_marker.length, placeholder_len, "marker length in display units");
+		assert_eq!(table_marker.reference, html, "marker keeps the table HTML");
+	}
+
+	/// ON mode: the helper emits the full TSV; multi-row tables produce one line per row, and the
+	/// marker length spans all emitted lines.
+	#[test]
+	fn pdf_table_helper_emits_tsv_when_inline() {
+		use crate::util::text::display_len;
+		let html =
+			"<table border=\"1\">\n<tr>\n<td>Kop</td>\n<td>\u{1D11E}</td>\n</tr>\n<tr>\n<td>a</td>\n<td>b</td>\n</tr>\n</table>\n"
+				.to_string();
+		let mut buffer = DocumentBuffer::new();
+		let pos = buffer.current_position();
+		let mut lines_info = Vec::new();
+		let mut page_text = String::new();
+		append_pdf_table_to_buffer(&mut buffer, html.clone(), pos, &mut lines_info, &mut page_text, true);
+
+		// Two rows -> "Kop\t𝄞\na\tb\n".
+		assert_eq!(buffer.content, "Kop\t\u{1D11E}\na\tb\n");
+		assert_eq!(lines_info.len(), 2, "one line per table row");
+		assert_eq!(lines_info[0].1, "Kop\t\u{1D11E}");
+		assert_eq!(lines_info[1].1, "a\tb");
+
+		let expected_len = display_len("Kop\t\u{1D11E}\na\tb\n");
+		let table_marker = buffer.markers.iter().find(|m| m.mtype == MarkerType::Table).expect("Table marker present");
+		assert_eq!(table_marker.length, expected_len, "marker length spans all emitted rows");
 	}
 }

--- a/crates/paperback-core/src/parser/table_text.rs
+++ b/crates/paperback-core/src/parser/table_text.rs
@@ -1,0 +1,321 @@
+use scraper::{Html, Node};
+
+use crate::util::text::{collapse_whitespace, display_len, trim_string};
+
+/// `<table>…</table>` HTML -> tab-separated text: rows by '\n', cells (`<td>`/`<th>`) by '\t'.
+/// Cell text whitespace-collapsed + trimmed; internal '\t'/'\n' -> space; nested tables flattened.
+///
+/// Only the outermost table's grid structure is honored: rows and cells that belong to a nested
+/// `<table>` do not start new rows/cells, they are flattened into the enclosing cell's text.
+#[must_use]
+pub fn html_table_to_tsv(html: &str) -> String {
+	let fragment = Html::parse_fragment(html);
+	let Some(table) = find_first_table(fragment.tree.root()) else {
+		return String::new();
+	};
+	let mut rows: Vec<String> = Vec::new();
+	collect_rows(table, &mut rows);
+	rows.join("\n")
+}
+
+/// Produce the on-screen text for a table in the requested display mode (see `tsv_to_display`).
+#[must_use]
+pub fn html_table_to_display(html: &str, inline: bool) -> String {
+	tsv_to_display(&html_table_to_tsv(html), inline)
+}
+
+/// Render a tab-separated table body in the requested display mode.
+///
+/// - `inline == true`  -> the TSV unchanged.
+/// - `inline == false` -> a uniform placeholder `"[Table]: <first row>"`, where `<first row>` is
+///   the first row with tab separators replaced by single spaces. Empty TSV -> just `"[Table]"`.
+fn tsv_to_display(tsv: &str, inline: bool) -> String {
+	if inline {
+		return tsv.to_string();
+	}
+	let first_line = tsv.split('\n').next().unwrap_or("");
+	if first_line.is_empty() { "[Table]".to_string() } else { format!("[Table]: {}", first_line.replace('\t', " ")) }
+}
+
+#[must_use]
+pub fn table_caption_from_html(html: &str) -> Option<String> {
+	let fragment = Html::parse_fragment(html);
+	let table = find_first_table(fragment.tree.root())?;
+	if let Some(caption) = caption_element_text(table) {
+		return Some(caption);
+	}
+	// Reuse the already-parsed tree instead of calling html_table_to_tsv(html) again.
+	let mut rows: Vec<String> = Vec::new();
+	collect_rows(table, &mut rows);
+	let first_row = first_tsv_row_text(&rows.join("\n"));
+	if first_row.is_empty() { None } else { Some(first_row) }
+}
+
+/// Text of the table's explicit `<caption>` element, if present and non-empty.
+fn caption_element_text(table: ego_tree::NodeRef<'_, Node>) -> Option<String> {
+	for child in table.children() {
+		if let Node::Element(element) = child.value()
+			&& element.name() == "caption"
+		{
+			let caption = cell_text(child);
+			if !caption.is_empty() {
+				return Some(caption);
+			}
+		}
+	}
+	None
+}
+
+#[must_use]
+pub fn table_caption_from_tsv(tsv: &str) -> String {
+	let caption = first_tsv_row_text(tsv);
+	if caption.is_empty() { "table".to_string() } else { caption }
+}
+
+fn first_tsv_row_text(tsv: &str) -> String {
+	let first_line = tsv.split('\n').next().unwrap_or("").replace('\t', " ");
+	trim_string(&collapse_whitespace(&first_line))
+}
+
+pub struct TableRenderBundle {
+	pub caption: String,
+	pub lines: Vec<String>,
+	pub display_length: usize,
+}
+
+/// Split `display_text` into lines and compute the total display-unit length (each line's
+/// display width + 1 for its trailing newline).  Returns `(lines, display_length)`.
+#[must_use]
+pub fn display_lines_and_length(display_text: &str) -> (Vec<String>, usize) {
+	if display_text.is_empty() {
+		return (Vec::new(), 0);
+	}
+	let lines: Vec<String> = display_text.split('\n').map(str::to_string).collect();
+	let display_length = lines.iter().map(|line| display_len(line) + 1).sum();
+	(lines, display_length)
+}
+
+#[must_use]
+pub fn table_render_bundle(html: &str, inline: bool) -> TableRenderBundle {
+	// Parse the HTML once; derive TSV, caption, and display text from the same tree.
+	let fragment = Html::parse_fragment(html);
+	let (tsv, caption) = match find_first_table(fragment.tree.root()) {
+		Some(table) => {
+			let mut rows: Vec<String> = Vec::new();
+			collect_rows(table, &mut rows);
+			let tsv = rows.join("\n");
+			// Prefer an explicit <caption> element; fall back to the first TSV row.
+			let caption = caption_element_text(table).unwrap_or_else(|| table_caption_from_tsv(&tsv));
+			(tsv, caption)
+		}
+		None => (String::new(), table_caption_from_tsv("")),
+	};
+	let (lines, display_length) = display_lines_and_length(&tsv_to_display(&tsv, inline));
+	TableRenderBundle { caption, lines, display_length }
+}
+
+/// Find the first (outermost) `<table>` element in document order, descending through wrappers.
+fn find_first_table(node: ego_tree::NodeRef<'_, Node>) -> Option<ego_tree::NodeRef<'_, Node>> {
+	for child in node.children() {
+		if let Node::Element(element) = child.value() {
+			if element.name() == "table" {
+				return Some(child);
+			}
+			if let Some(found) = find_first_table(child) {
+				return Some(found);
+			}
+		}
+	}
+	None
+}
+
+/// Gather the rows of `table`, descending through grouping wrappers (`thead`/`tbody`/`tfoot`)
+/// to reach `<tr>` elements, but never descending into a nested table.
+fn collect_rows(node: ego_tree::NodeRef<'_, Node>, rows: &mut Vec<String>) {
+	for child in node.children() {
+		if let Node::Element(element) = child.value() {
+			match element.name() {
+				"tr" => rows.push(collect_row(child)),
+				// A nested table's rows belong to a cell, not this grid: skip them here.
+				"table" => {}
+				_ => collect_rows(child, rows),
+			}
+		}
+	}
+}
+
+/// Collect the cells of a single row, joined by tabs. Recurses through wrapper elements to find
+/// `<td>`/`<th>` but stops at nested tables (their cells are flattened into the parent cell text).
+fn collect_row(row: ego_tree::NodeRef<'_, Node>) -> String {
+	let mut cells: Vec<String> = Vec::new();
+	collect_cells(row, &mut cells);
+	cells.join("\t")
+}
+
+fn collect_cells(node: ego_tree::NodeRef<'_, Node>, cells: &mut Vec<String>) {
+	for child in node.children() {
+		if let Node::Element(element) = child.value() {
+			match element.name() {
+				"td" | "th" => cells.push(cell_text(child)),
+				// A nested table inside a row (but outside a cell) is not part of this grid.
+				"table" => {}
+				_ => collect_cells(child, cells),
+			}
+		}
+	}
+}
+
+/// Collect the flattened text of a single cell: descendant text nodes concatenated, with
+/// `<br>` rendered as a space, then whitespace-collapsed, trimmed, and any residual `\t`/`\n`
+/// replaced by a single space. Nested tables contribute only their text (no grid structure).
+fn cell_text(cell: ego_tree::NodeRef<'_, Node>) -> String {
+	let mut raw = String::new();
+	collect_cell_text(cell, &mut raw);
+	let collapsed = collapse_whitespace(&raw);
+	let trimmed = trim_string(&collapsed);
+	trimmed.replace(['\t', '\n'], " ")
+}
+
+fn collect_cell_text(node: ego_tree::NodeRef<'_, Node>, buffer: &mut String) {
+	match node.value() {
+		Node::Text(text) => buffer.push_str(&text.text),
+		Node::Element(element) => {
+			if element.name() == "br" {
+				buffer.push(' ');
+			}
+			for child in node.children() {
+				collect_cell_text(child, buffer);
+			}
+		}
+		_ => {}
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn two_by_two_table_is_tab_and_newline_separated() {
+		let html = "<table><tr><td>a</td><td>b</td></tr><tr><td>c</td><td>d</td></tr></table>";
+		assert_eq!(html_table_to_tsv(html), "a\tb\nc\td");
+	}
+
+	#[test]
+	fn header_row_cells_are_included() {
+		let html = "<table><tr><th>H1</th><th>H2</th></tr><tr><td>v1</td><td>v2</td></tr></table>";
+		assert_eq!(html_table_to_tsv(html), "H1\tH2\nv1\tv2");
+	}
+
+	#[test]
+	fn empty_cells_produce_empty_strings_between_tabs() {
+		let html = "<table><tr><td></td><td>b</td></tr></table>";
+		assert_eq!(html_table_to_tsv(html), "\tb");
+	}
+
+	#[test]
+	fn nested_table_is_flattened_to_text() {
+		let html = "<table><tr><td>outer<table><tr><td>inner</td></tr></table></td><td>x</td></tr></table>";
+		assert_eq!(html_table_to_tsv(html), "outerinner\tx");
+	}
+
+	#[test]
+	fn embedded_tab_and_newline_collapse_to_single_space() {
+		let html = "<table><tr><td>a\t\nb</td></tr></table>";
+		assert_eq!(html_table_to_tsv(html), "a b");
+	}
+
+	#[test]
+	fn entities_decoded_and_br_becomes_space() {
+		let html = "<table><tr><td>1 &lt; 2 &amp; 3<br/>line2</td></tr></table>";
+		assert_eq!(html_table_to_tsv(html), "1 < 2 & 3 line2");
+	}
+
+	#[test]
+	fn empty_table_yields_empty_string() {
+		assert_eq!(html_table_to_tsv("<table></table>"), "");
+	}
+
+	#[test]
+	fn html_table_to_display_inline_2x2_table() {
+		let html = "<table><tr><td>a</td><td>b</td></tr><tr><td>c</td><td>d</td></tr></table>";
+		assert_eq!(html_table_to_display(html, true), "a\tb\nc\td");
+	}
+
+	#[test]
+	fn html_table_to_display_placeholder_2x2_table() {
+		let html = "<table><tr><td>a</td><td>b</td></tr><tr><td>c</td><td>d</td></tr></table>";
+		assert_eq!(html_table_to_display(html, false), "[Table]: a b");
+	}
+
+	#[test]
+	fn html_table_to_display_placeholder_single_cell() {
+		let html = "<table><tr><td>x</td></tr></table>";
+		assert_eq!(html_table_to_display(html, false), "[Table]: x");
+	}
+
+	#[test]
+	fn html_table_to_display_placeholder_empty_table() {
+		let html = "<table></table>";
+		assert_eq!(html_table_to_display(html, false), "[Table]");
+	}
+
+	#[test]
+	fn html_table_to_display_inline_empty_table() {
+		let html = "<table></table>";
+		assert_eq!(html_table_to_display(html, true), "");
+	}
+
+	#[test]
+	fn html_table_to_display_placeholder_header_body_table() {
+		let html = "<table><tr><th>H1</th><th>H2</th></tr><tr><td>v1</td><td>v2</td></tr></table>";
+		assert_eq!(html_table_to_display(html, false), "[Table]: H1 H2");
+	}
+
+	#[test]
+	fn table_caption_prefers_caption_element() {
+		let html = "<table><caption>Cap</caption><tr><td>row</td></tr></table>";
+		assert_eq!(table_caption_from_html(html), Some("Cap".to_string()));
+	}
+
+	#[test]
+	fn table_caption_falls_back_to_first_row() {
+		let html = "<table><tr><td>a</td><td>b</td></tr><tr><td>c</td><td>d</td></tr></table>";
+		assert_eq!(table_caption_from_html(html), Some("a b".to_string()));
+	}
+
+	#[test]
+	fn table_caption_returns_none_for_empty_table() {
+		assert_eq!(table_caption_from_html("<table></table>"), None);
+	}
+
+	#[test]
+	fn table_lines_preserve_empty_rows_and_report_display_length() {
+		let (lines, display_length) = display_lines_and_length("a\tb\n\tc");
+		assert_eq!(lines, vec!["a\tb".to_string(), "\tc".to_string()]);
+		assert_eq!(display_length, 7);
+	}
+
+	#[test]
+	fn table_lines_handle_empty_display_text() {
+		let (lines, display_length) = display_lines_and_length("");
+		assert!(lines.is_empty());
+		assert_eq!(display_length, 0);
+	}
+
+	#[test]
+	fn table_render_bundle_includes_caption_lines_and_length() {
+		let bundle = table_render_bundle("<table><caption>Cap</caption><tr><td>a</td><td>b</td></tr></table>", true);
+		assert_eq!(bundle.caption, "Cap");
+		assert_eq!(bundle.lines, vec!["a\tb".to_string()]);
+		assert_eq!(bundle.display_length, 4);
+	}
+
+	#[test]
+	fn table_render_bundle_falls_back_to_default_caption() {
+		let bundle = table_render_bundle("<table></table>", true);
+		assert_eq!(bundle.caption, "table");
+		assert!(bundle.lines.is_empty());
+		assert_eq!(bundle.display_length, 0);
+	}
+}

--- a/crates/paperback-core/src/parser/table_text.rs
+++ b/crates/paperback-core/src/parser/table_text.rs
@@ -95,6 +95,15 @@ pub fn display_lines_and_length(display_text: &str) -> (Vec<String>, usize) {
 	(lines, display_length)
 }
 
+/// Push a line to a parser's output verbatim (no whitespace collapsing/trimming), updating its
+/// cached display length so position tracking stays correct. Shared by `HtmlToText` and `XmlToText`
+/// so the `+1` newline accounting can never diverge between the two. Used for table rows whose tab
+/// separators and empty cells must not be mangled.
+pub fn push_finalized_line(lines: &mut Vec<String>, cached_len: &mut usize, line: String) {
+	*cached_len += display_len(&line) + 1; // +1 for the line's newline
+	lines.push(line);
+}
+
 #[must_use]
 pub fn table_render_bundle(html: &str, inline: bool) -> TableRenderBundle {
 	// Parse the HTML once; derive TSV, caption, and display text from the same tree.

--- a/crates/paperback-core/src/parser/word.rs
+++ b/crates/paperback-core/src/parser/word.rs
@@ -61,13 +61,14 @@ impl Parser for WordParser {
 			},
 			|ext| ext.to_ascii_lowercase(),
 		);
+		let render_tables_inline = context.render_tables_inline;
 		if extension == "zip" {
-			return parse_word_zip(context);
+			return parse_word_zip(context, render_tables_inline);
 		}
 		if extension == "doc" {
 			match parse_legacy_doc(context) {
 				Ok(document) => return Ok(document),
-				Err(legacy_err) => match parse_ooxml_doc(context) {
+				Err(legacy_err) => match parse_ooxml_doc(context, render_tables_inline) {
 					Ok(document) => return Ok(document),
 					Err(ooxml_err) => {
 						if let Ok(document) = parse_text_like_doc(context) {
@@ -80,11 +81,11 @@ impl Parser for WordParser {
 				},
 			}
 		}
-		parse_ooxml_doc(context)
+		parse_ooxml_doc(context, render_tables_inline)
 	}
 }
 
-fn parse_word_zip(context: &ParserContext) -> Result<Document> {
+fn parse_word_zip(context: &ParserContext, render_tables_inline: bool) -> Result<Document> {
 	let file =
 		File::open(&context.file_path).with_context(|| format!("Failed to open ZIP file '{}'", context.file_path))?;
 	let mut archive = ZipArchive::new(BufReader::new(file))
@@ -117,8 +118,14 @@ fn parse_word_zip(context: &ParserContext) -> Result<Document> {
 		let mut inner_archive = ZipArchive::new(Cursor::new(inner_file_data))
 			.with_context(|| format!("Failed to parse inner DOCX '{docx_name}' as zip"))?;
 
-		parse_ooxml_from_archive(&mut inner_archive, &mut buffer, &mut id_positions, &mut headings)
-			.with_context(|| format!("Failed to parse DOCX contents of '{docx_name}'"))?;
+		parse_ooxml_from_archive(
+			&mut inner_archive,
+			&mut buffer,
+			&mut id_positions,
+			&mut headings,
+			render_tables_inline,
+		)
+		.with_context(|| format!("Failed to parse DOCX contents of '{docx_name}'"))?;
 	}
 
 	let title = extract_title_from_path(&context.file_path);
@@ -130,14 +137,14 @@ fn parse_word_zip(context: &ParserContext) -> Result<Document> {
 	Ok(document)
 }
 
-fn parse_ooxml_doc(context: &ParserContext) -> Result<Document> {
+fn parse_ooxml_doc(context: &ParserContext, render_tables_inline: bool) -> Result<Document> {
 	let bytes = load_ooxml_bytes(&context.file_path, context.password.as_deref())?;
 	let mut archive = ZipArchive::new(Cursor::new(bytes))
 		.with_context(|| format!("Failed to read DOCX as zip '{}'", context.file_path))?;
 	let mut buffer = DocumentBuffer::new();
 	let mut id_positions = HashMap::new();
 	let mut headings = Vec::new();
-	parse_ooxml_from_archive(&mut archive, &mut buffer, &mut id_positions, &mut headings)?;
+	parse_ooxml_from_archive(&mut archive, &mut buffer, &mut id_positions, &mut headings, render_tables_inline)?;
 	let title = extract_title_from_path(&context.file_path);
 	let toc_items = build_toc_from_buffer(&buffer);
 	let mut document = Document::new().with_title(title);
@@ -160,12 +167,13 @@ pub fn parse_ooxml_from_archive<R: std::io::Read + std::io::Seek>(
 	buffer: &mut DocumentBuffer,
 	id_positions: &mut HashMap<String, usize>,
 	headings: &mut Vec<HeadingInfo>,
+	render_tables_inline: bool,
 ) -> Result<()> {
 	let style_heading_map = build_style_heading_map(archive);
 	let rels = read_ooxml_relationships(archive, "word/_rels/document.xml.rels");
 	let doc_content = read_zip_entry_by_name(archive, "word/document.xml")?;
 	let doc_xml = XmlDocument::parse(&doc_content).context("Failed to parse word/document.xml")?;
-	traverse(doc_xml.root(), buffer, headings, id_positions, &rels, &style_heading_map);
+	traverse(doc_xml.root(), buffer, headings, id_positions, &rels, &style_heading_map, render_tables_inline);
 	Ok(())
 }
 
@@ -513,6 +521,7 @@ fn traverse(
 	id_positions: &mut HashMap<String, usize>,
 	rels: &HashMap<String, String>,
 	style_heading_map: &HashMap<String, i32>,
+	render_tables_inline: bool,
 ) {
 	if node.node_type() == NodeType::Element {
 		let tag_name = node.tag_name().name();
@@ -523,16 +532,21 @@ fn traverse(
 			process_paragraph(node, buffer, headings, id_positions, rels, style_heading_map);
 			return;
 		} else if tag_name == "tbl" {
-			process_table(node, buffer, rels);
+			process_table(node, buffer, rels, render_tables_inline);
 			return;
 		}
 	}
 	for child in node.children() {
-		traverse(child, buffer, headings, id_positions, rels, style_heading_map);
+		traverse(child, buffer, headings, id_positions, rels, style_heading_map, render_tables_inline);
 	}
 }
 
-fn process_table(element: Node, buffer: &mut DocumentBuffer, _rels: &HashMap<String, String>) {
+fn process_table(
+	element: Node,
+	buffer: &mut DocumentBuffer,
+	_rels: &HashMap<String, String>,
+	render_tables_inline: bool,
+) {
 	let table_start = buffer.current_position();
 	let mut html_content = String::from("<table border=\"1\">");
 	let mut table_caption = String::from("table: ");
@@ -569,13 +583,15 @@ fn process_table(element: Node, buffer: &mut DocumentBuffer, _rels: &HashMap<Str
 	}
 	html_content.push_str("</table>");
 	let final_caption = table_caption.trim().to_string();
-	buffer.append(&final_caption);
+	let display_text = crate::parser::table_text::html_table_to_display(&html_content, render_tables_inline);
+	buffer.append(&display_text);
 	buffer.append("\n");
+	let display_len = buffer.current_position() - table_start;
 	buffer.add_marker(
 		Marker::new(MarkerType::Table, table_start)
-			.with_text(final_caption.clone())
+			.with_text(final_caption)
 			.with_reference(html_content)
-			.with_length(final_caption.len()),
+			.with_length(display_len),
 	);
 }
 
@@ -840,7 +856,12 @@ pub fn try_decrypt_office_file(path: &str, password: Option<&str>) -> Result<Opt
 
 #[cfg(test)]
 mod tests {
-	use super::{looks_like_text_content, normalize_doc_text, parse_doc_clx, parse_doc_piece_table};
+	use std::collections::HashMap;
+
+	use roxmltree::Document as XmlDocument;
+
+	use super::{looks_like_text_content, normalize_doc_text, parse_doc_clx, parse_doc_piece_table, traverse};
+	use crate::document::{DocumentBuffer, MarkerType};
 
 	#[test]
 	fn parse_doc_piece_table_extracts_ansi_text() {
@@ -886,5 +907,45 @@ mod tests {
 	fn looks_like_text_content_detects_textual_data() {
 		assert!(looks_like_text_content("Manual Title\nLine 2\nLine 3"));
 		assert!(!looks_like_text_content("\u{0}\u{1}\u{2}\u{3}\u{4}\u{5}"));
+	}
+
+	/// Parse a Word table. The second cell contains U+1D11E (MUSICAL SYMBOL G CLEF, non-BMP,
+	/// UTF-16 width 2) to lock the display-unit arithmetic. OFF mode emits the placeholder; ON mode
+	/// emits the full TSV. In both cases the Table marker keeps the caption as text and its length
+	/// equals the emitted display extent.
+	#[test]
+	fn word_table_emits_placeholder_or_tsv_by_flag() {
+		use crate::util::text::display_len;
+		// Minimal OOXML XML: one table with one row, two cells.
+		let xml = r#"<document><body>
+			<tbl>
+				<tr>
+					<tc><p><r><t>Kop</t></r></p></tc>
+					<tc><p><r><t>&#x1D11E;</t></r></p></tc>
+				</tr>
+			</tbl>
+		</body></document>"#;
+		let xml_doc = XmlDocument::parse(xml).expect("valid xml");
+
+		// OFF: placeholder "[Table]: Kop 𝄞".
+		let mut buffer = DocumentBuffer::new();
+		let mut headings = Vec::new();
+		let mut id_positions = HashMap::new();
+		let rels = HashMap::new();
+		traverse(xml_doc.root(), &mut buffer, &mut headings, &mut id_positions, &rels, &HashMap::new(), false);
+		assert_eq!(buffer.content, "[Table]: Kop \u{1D11E}\n");
+		let table_marker = buffer.markers.iter().find(|m| m.mtype == MarkerType::Table).expect("Table marker");
+		assert_eq!(table_marker.text, "table: Kop \u{1D11E}", "marker keeps the caption text");
+		assert_eq!(table_marker.length, display_len("[Table]: Kop \u{1D11E}") + 1, "marker length in display units");
+		assert!(table_marker.reference.contains("<td>Kop</td>"), "marker reference is the table HTML");
+
+		// ON: full TSV "Kop\t𝄞".
+		let mut buffer = DocumentBuffer::new();
+		let mut headings = Vec::new();
+		let mut id_positions = HashMap::new();
+		traverse(xml_doc.root(), &mut buffer, &mut headings, &mut id_positions, &rels, &HashMap::new(), true);
+		assert_eq!(buffer.content, "Kop\t\u{1D11E}\n");
+		let table_marker = buffer.markers.iter().find(|m| m.mtype == MarkerType::Table).expect("Table marker");
+		assert_eq!(table_marker.length, display_len("Kop\t\u{1D11E}") + 1, "marker length spans the TSV");
 	}
 }

--- a/crates/paperback-core/src/parser/word.rs
+++ b/crates/paperback-core/src/parser/word.rs
@@ -549,8 +549,6 @@ fn process_table(
 ) {
 	let table_start = buffer.current_position();
 	let mut html_content = String::from("<table border=\"1\">");
-	let mut table_caption = String::from("table: ");
-	let mut first_row = true;
 	for child in element.children() {
 		if child.node_type() == NodeType::Element && child.tag_name().name() == "tr" {
 			html_content.push_str("<tr>");
@@ -568,21 +566,18 @@ fn process_table(
 							cell_text.push(' ');
 						}
 					}
-					let trimmed_cell = cell_text.trim();
-					html_content.push_str(trimmed_cell);
+					html_content.push_str(cell_text.trim());
 					html_content.push_str("</td>");
-					if first_row {
-						table_caption.push_str(trimmed_cell);
-						table_caption.push(' ');
-					}
 				}
 			}
 			html_content.push_str("</tr>");
-			first_row = false;
 		}
 	}
 	html_content.push_str("</table>");
-	let final_caption = table_caption.trim().to_string();
+	// Derive the caption the same way HTML/XML do (first-row text, no prefix) for consistent
+	// labels across formats; fall back to "table" for an empty table like `table_caption_from_tsv`.
+	let final_caption =
+		crate::parser::table_text::table_caption_from_html(&html_content).unwrap_or_else(|| "table".to_string());
 	let display_text = crate::parser::table_text::html_table_to_display(&html_content, render_tables_inline);
 	buffer.append(&display_text);
 	buffer.append("\n");
@@ -935,7 +930,7 @@ mod tests {
 		traverse(xml_doc.root(), &mut buffer, &mut headings, &mut id_positions, &rels, &HashMap::new(), false);
 		assert_eq!(buffer.content, "[Table]: Kop \u{1D11E}\n");
 		let table_marker = buffer.markers.iter().find(|m| m.mtype == MarkerType::Table).expect("Table marker");
-		assert_eq!(table_marker.text, "table: Kop \u{1D11E}", "marker keeps the caption text");
+		assert_eq!(table_marker.text, "Kop \u{1D11E}", "marker caption is the first-row text, no prefix");
 		assert_eq!(table_marker.length, display_len("[Table]: Kop \u{1D11E}") + 1, "marker length in display units");
 		assert!(table_marker.reference.contains("<td>Kop</td>"), "marker reference is the table HTML");
 

--- a/crates/paperback-core/src/parser/xml_to_text.rs
+++ b/crates/paperback-core/src/parser/xml_to_text.rs
@@ -48,12 +48,23 @@ pub struct XmlToText {
 	/// balanced with the start/close handlers so list lengths are set on the right entries.
 	open_lists: Vec<Option<usize>>,
 	cached_char_length: usize,
+	/// When `true`, tables are emitted as their full tab-separated rendering; otherwise as a
+	/// `"[Table]: <first row>"` placeholder. A config flag, not parse state: it survives `clear()`.
+	render_tables_inline: bool,
 }
 
 impl XmlToText {
 	#[must_use]
 	pub fn new() -> Self {
 		Self::default()
+	}
+
+	/// Like [`new`](Self::new) but sets whether tables are rendered inline (full TSV) or as a
+	/// placeholder. Threaded from the owning parser's `ParserContext`; preserved across
+	/// `convert`/`clear`.
+	#[must_use]
+	pub fn with_render_tables_inline(render_tables_inline: bool) -> Self {
+		Self { render_tables_inline, ..Self::default() }
 	}
 
 	pub fn convert(&mut self, xml_content: &str) -> bool {
@@ -285,61 +296,30 @@ impl XmlToText {
 	fn handle_table_xml(&mut self, node: Node<'_, '_>) {
 		self.finalize_current_line();
 		let table_xml = node.document().input_text()[node.range()].to_string();
-		let start_lines_count = self.lines.len();
 		let start_offset = self.get_current_text_position();
-		let mut table_caption = String::new();
-		for child in node.children() {
-			if child.is_element() && child.tag_name().name() == "caption" {
-				table_caption = collect_element_text(child).trim().to_string();
-				break;
-			}
+		// Emit the table's on-screen text via the shared helper instead of recursing children to
+		// emit one cell per line. The helper output may contain tabs and span multiple lines; push
+		// each line verbatim so tab separators and empty cells survive whitespace collapsing.
+		let render = crate::parser::table_text::table_render_bundle(&table_xml, self.render_tables_inline);
+		for line in render.lines {
+			self.push_finalized_line(line);
 		}
-		if table_caption.is_empty() {
-			for child in node.children() {
-				if child.is_element() {
-					let name = child.tag_name().name();
-					if name == "tr" {
-						table_caption = collect_element_text(child).trim().to_string();
-						break;
-					} else if matches!(name, "thead" | "tbody" | "tfoot") {
-						for subchild in child.children() {
-							if subchild.is_element() && subchild.tag_name().name() == "tr" {
-								table_caption = collect_element_text(subchild).trim().to_string();
-								break;
-							}
-						}
-						if !table_caption.is_empty() {
-							break;
-						}
-					}
-				}
-			}
-		}
-		for child in node.children() {
-			self.process_node(child);
-		}
-		self.finalize_current_line();
-		let mut table_text = String::new();
-		for (i, line) in self.lines.iter().enumerate().skip(start_lines_count) {
-			if i > start_lines_count {
-				table_text.push('\n');
-			}
-			table_text.push_str(line);
-		}
-		if table_text.trim().is_empty() {
-			table_text = "table".to_string();
-			self.current_line.push_str(&table_text);
-			self.finalize_current_line();
-		}
-		if table_caption.trim().is_empty() {
-			table_caption = "table".to_string();
-		}
+		let table_caption = render.caption;
+		let display_length = render.display_length;
 		self.tables.push(TableInfo {
 			offset: start_offset,
 			text: table_caption,
 			html_content: table_xml,
-			length: table_text.len(),
+			length: display_length,
 		});
+	}
+
+	/// Push a line to the output verbatim (no whitespace collapsing/trimming), updating the cached
+	/// length so position tracking stays correct. Used for table rows whose tab separators and empty
+	/// cells must not be mangled by `add_line`.
+	fn push_finalized_line(&mut self, line: String) {
+		self.cached_char_length += display_len(&line) + 1; // +1 for the line's newline
+		self.lines.push(line);
 	}
 
 	fn handle_list_item_xml(&mut self, node: Node<'_, '_>) {
@@ -795,5 +775,67 @@ mod tests {
 		let lines: Vec<&str> = text.lines().collect();
 		assert!(lines.iter().any(|l| *l == "Term"), "dt content should be on its own line");
 		assert!(lines.iter().any(|l| *l == "Definition"), "dd content should be on its own line");
+	}
+	/// `TableInfo.length` must equal the emitted display extent (display units), NOT the
+	/// emitted text's byte length. Prefix text ensures start_offset > 0. With inline rendering the
+	/// emitted row is the TSV "A\t𝄞"; a non-BMP char (U+1D11E, G Clef, width 2) locks the math.
+	#[test]
+	fn xml_table_display_length_is_display_extent_not_byte_length() {
+		// "Intro\n" → 6 display units. Inline table row: "A\t𝄞" = 4 display units + newline = 5.
+		let xml = concat!(
+			"<root><body><p>Intro</p>",
+			"<table><tr><td>A</td><td>\u{1D11E}</td></tr></table>",
+			"</body></root>"
+		);
+		let mut converter = XmlToText::with_render_tables_inline(true);
+		assert!(converter.convert(xml));
+		let tables = converter.get_tables();
+		assert_eq!(tables.len(), 1, "expected exactly one table");
+		let table = &tables[0];
+
+		assert_eq!(table.offset, 6, "table starts after 'Intro\\n'");
+		// display_length = 5 (display extent); emitted byte length = 6 — they differ.
+		assert_eq!(table.length, 5, "length must be the display extent (5), not byte length (6)");
+	}
+
+	/// OFF mode emits the `"[Table]: <first row>"` placeholder; ON mode emits the full TSV.
+	#[test]
+	fn xml_table_emits_placeholder_or_tsv_by_flag() {
+		let xml = "<root><body><table><tr><td>A</td><td>B</td></tr><tr><td>c</td><td>d</td></tr></table></body></root>";
+
+		let mut off = XmlToText::new();
+		assert!(off.convert(xml));
+		assert_eq!(off.get_text(), "[Table]: A B");
+
+		let mut on = XmlToText::with_render_tables_inline(true);
+		assert!(on.convert(xml));
+		assert_eq!(on.get_text(), "A\tB\nc\td");
+	}
+
+	/// Two XML tables: second table's offset equals first offset + first display_length.
+	#[test]
+	fn xml_two_tables_offsets_are_cumulative() {
+		let xml = concat!(
+			"<root><body>",
+			"<table><tr><td>X</td></tr></table>",
+			"<table><tr><td>Y</td></tr></table>",
+			"</body></root>"
+		);
+		let mut converter = XmlToText::new();
+		assert!(converter.convert(xml));
+		let tables = converter.get_tables();
+		assert_eq!(tables.len(), 2, "expected two tables");
+
+		let t1_offset = tables[0].offset;
+		let t1_display_length = tables[0].length;
+		let t2_offset = tables[1].offset;
+
+		assert_eq!(t1_offset, 0, "first table starts at 0");
+		assert!(t1_display_length > 0, "first table has non-zero display_length");
+		assert_eq!(
+			t2_offset,
+			t1_offset + t1_display_length,
+			"second table offset must equal first offset + first display_length"
+		);
 	}
 }

--- a/crates/paperback-core/src/parser/xml_to_text.rs
+++ b/crates/paperback-core/src/parser/xml_to_text.rs
@@ -318,8 +318,7 @@ impl XmlToText {
 	/// length so position tracking stays correct. Used for table rows whose tab separators and empty
 	/// cells must not be mangled by `add_line`.
 	fn push_finalized_line(&mut self, line: String) {
-		self.cached_char_length += display_len(&line) + 1; // +1 for the line's newline
-		self.lines.push(line);
+		crate::parser::table_text::push_finalized_line(&mut self.lines, &mut self.cached_char_length, line);
 	}
 
 	fn handle_list_item_xml(&mut self, node: Node<'_, '_>) {

--- a/crates/paperback-core/src/session.rs
+++ b/crates/paperback-core/src/session.rs
@@ -285,7 +285,12 @@ impl DocumentSession {
 	/// # Errors
 	///
 	/// Returns an error if the document cannot be parsed.
-	pub fn new(file_path: &str, password: &str, forced_extension: &str) -> Result<Self, String> {
+	pub fn new(
+		file_path: &str,
+		password: &str,
+		forced_extension: &str,
+		render_tables_inline: bool,
+	) -> Result<Self, String> {
 		let mut context = ParserContext::new(file_path.to_string());
 		if !password.is_empty() {
 			context = context.with_password(password.to_string());
@@ -293,6 +298,7 @@ impl DocumentSession {
 		if !forced_extension.is_empty() {
 			context = context.with_forced_extension(forced_extension.to_string());
 		}
+		context = context.with_render_tables_inline(render_tables_inline);
 		let parser_flags = parser::get_parser_flags_for_context(&context);
 		let doc = parser::parse_document(&context).map_err(|e| e.to_string())?;
 		Ok(Self {
@@ -305,10 +311,16 @@ impl DocumentSession {
 		})
 	}
 
-	pub fn new_ffi(file_path: String, password: String, forced_extension: String) -> Result<Self, DocumentError> {
-		Self::new(&file_path, &password, &forced_extension).map_err(DocumentError::ParseError)
+	pub fn new_ffi(
+		file_path: String,
+		password: String,
+		forced_extension: String,
+		render_tables_inline: bool,
+	) -> Result<Self, DocumentError> {
+		Self::new(&file_path, &password, &forced_extension, render_tables_inline).map_err(DocumentError::ParseError)
 	}
 
+	/// The parsed document handle backing this session.
 	#[must_use]
 	pub const fn handle(&self) -> &DocumentHandle {
 		&self.handle
@@ -871,8 +883,9 @@ impl DocumentSession {
 		let pos_usize = usize::try_from(position.max(0)).unwrap_or(0);
 		let table_index = self.handle.current_marker_index(pos_usize, MarkerType::Table)?;
 		let marker = self.handle.document().buffer.markers.get(table_index)?;
-		let table_end = marker.position + marker.text.chars().count();
-		if pos_usize < marker.position || pos_usize > table_end {
+		// `length` is the display extent (Tasks 2-3); valid range is the half-open `[position, end)`.
+		let table_end = marker.position + marker.length;
+		if pos_usize < marker.position || pos_usize >= table_end {
 			return None;
 		}
 		if marker.reference.is_empty() {
@@ -1379,7 +1392,10 @@ mod tests {
 		buffer.add_marker(Marker::new(MarkerType::ListItem, 6).with_level(1).with_text("item".to_string()));
 		buffer.add_marker(Marker::new(MarkerType::PageBreak, 8));
 		buffer.add_marker(
-			Marker::new(MarkerType::Table, 12).with_text("line3".to_string()).with_reference("<table/>".to_string()),
+			Marker::new(MarkerType::Table, 12)
+				.with_length(5)
+				.with_text("line3".to_string())
+				.with_reference("<table/>".to_string()),
 		);
 		buffer.add_marker(Marker::new(MarkerType::Separator, 5).with_length(1));
 		let mut doc = Document::new().with_title("Title".to_string()).with_author("Author".to_string());
@@ -1707,7 +1723,7 @@ mod tests {
 		let src = dir.join("notes.md");
 		fs::write(&src, md.as_bytes()).unwrap();
 		// A real session populates id_positions with pb-block-N anchors.
-		let session = DocumentSession::new(&src.to_string_lossy(), "", "").expect("open markdown");
+		let session = DocumentSession::new(&src.to_string_lossy(), "", "", false).expect("open markdown");
 
 		let rendered = session.content();
 		let pos = i64::try_from(rendered.find("Second").expect("second block rendered")).unwrap();
@@ -1816,6 +1832,72 @@ mod tests {
 			last_stable_position: None,
 		};
 		assert!(session.extract_resource("x", "y").is_err());
+	}
+
+	/// Builds a session whose buffer contains a table marker spanning a display range, used to
+	/// exercise `get_table_at_position`'s half-open `[position, position + length)` check.
+	fn table_session() -> DocumentSession {
+		// Layout (display units): "before\n" (0..7), table span "tbl\n" (7..11), "after\n" (11..17).
+		let html = "<table><tr><td>a</td><td>b</td></tr></table>";
+		let mut buffer = DocumentBuffer::with_content("before\ntbl\nafter\n".to_string());
+		// Table marker length is the DISPLAY extent of the emitted span ("tbl\n" -> 4).
+		buffer.add_marker(
+			Marker::new(MarkerType::Table, 7)
+				.with_length(4)
+				.with_text("tbl".to_string())
+				.with_reference(html.to_string()),
+		);
+		let mut doc = Document::new();
+		doc.set_buffer(buffer);
+		doc.compute_stats();
+		DocumentSession {
+			handle: DocumentHandle::new(doc),
+			file_path: "book.epub".to_string(),
+			history: Vec::new(),
+			history_index: 0,
+			parser_flags: ParserFlags::NONE,
+			last_stable_position: None,
+		}
+	}
+
+	#[test]
+	fn get_table_at_position_uses_display_length() {
+		let session = table_session();
+		// Table marker at display position 7 with length 4 -> half-open range [7, 11).
+		assert_eq!(session.get_table_at_position(7).as_deref(), Some("<table><tr><td>a</td><td>b</td></tr></table>"));
+		assert_eq!(session.get_table_at_position(10).as_deref(), Some("<table><tr><td>a</td><td>b</td></tr></table>"));
+		assert!(session.get_table_at_position(11).is_none());
+		assert!(session.get_table_at_position(2).is_none());
+	}
+
+	#[test]
+	fn get_table_at_position_handles_multibyte_extent() {
+		// A table marker whose display extent exceeds its char-count would have been mis-measured
+		// by the old `text.chars().count()` logic. Here the displayed text is shorter (in chars)
+		// than the display extent, so the caret near the end is only inside the table when using
+		// `marker.length`.
+		let mut buffer = DocumentBuffer::with_content("\u{1F600}\u{1F600}\u{1F600}".to_string());
+		// Three non-BMP emoji: 3 chars but 6 display (UTF-16) units. Marker spans the whole range.
+		buffer.add_marker(
+			Marker::new(MarkerType::Table, 0)
+				.with_length(6)
+				.with_text("x".to_string())
+				.with_reference("<table/>".to_string()),
+		);
+		let mut doc = Document::new();
+		doc.set_buffer(buffer);
+		doc.compute_stats();
+		let session = DocumentSession {
+			handle: DocumentHandle::new(doc),
+			file_path: "book.epub".to_string(),
+			history: Vec::new(),
+			history_index: 0,
+			parser_flags: ParserFlags::NONE,
+			last_stable_position: None,
+		};
+		// Position 5 is within [0, 6) by display length but would be outside [0, 1) by char count.
+		assert_eq!(session.get_table_at_position(5).as_deref(), Some("<table/>"));
+		assert!(session.get_table_at_position(6).is_none());
 	}
 
 	#[test]

--- a/crates/paperback-core/src/types.rs
+++ b/crates/paperback-core/src/types.rs
@@ -58,6 +58,7 @@ pub struct TableInfo {
 	pub offset: usize,
 	pub text: String,
 	pub html_content: String,
+	/// Display-unit span of the emitted table text.
 	pub length: usize,
 }
 

--- a/crates/paperback/src/ui/dialogs/options.rs
+++ b/crates/paperback/src/ui/dialogs/options.rs
@@ -16,6 +16,7 @@ use crate::{accessibility, config_ext::UpdateChannel, translation_manager::Trans
 pub struct OptionsDialogResult {
 	pub restore_previous_documents: bool,
 	pub word_wrap: bool,
+	pub render_tables_inline: bool,
 	pub minimize_to_tray: bool,
 	pub start_maximized: bool,
 	pub compact_go_menu: bool,
@@ -40,6 +41,7 @@ struct OptionsDialogUi {
 	notebook: Notebook,
 	restore_docs_check: CheckBox,
 	word_wrap_check: CheckBox,
+	render_tables_inline_check: CheckBox,
 	minimize_to_tray_check: CheckBox,
 	start_maximized_check: CheckBox,
 	compact_go_menu_check: CheckBox,
@@ -83,6 +85,7 @@ pub fn show_options_dialog(parent: &Frame, config: &ConfigManager) -> Option<Opt
 	Some(OptionsDialogResult {
 		restore_previous_documents: ui.restore_docs_check.is_checked(),
 		word_wrap: ui.word_wrap_check.is_checked(),
+		render_tables_inline: ui.render_tables_inline_check.is_checked(),
 		minimize_to_tray: ui.minimize_to_tray_check.is_checked(),
 		start_maximized: ui.start_maximized_check.is_checked(),
 		compact_go_menu: ui.compact_go_menu_check.is_checked(),
@@ -115,6 +118,8 @@ fn build_options_dialog_ui(parent: &Frame, config: &ConfigManager) -> OptionsDia
 	let restore_docs_check =
 		CheckBox::builder(&general_panel).with_label(&t("&Restore previously opened documents on startup")).build();
 	let word_wrap_check = CheckBox::builder(&readability_panel).with_label(&t("&Word wrap")).build();
+	let render_tables_inline_check =
+		CheckBox::builder(&readability_panel).with_label(&t("Render tables &inline")).build();
 	let minimize_to_tray_check = CheckBox::builder(&general_panel).with_label(&t("&Minimize to system tray")).build();
 	let start_maximized_check = CheckBox::builder(&general_panel).with_label(&t("&Start maximized")).build();
 	let compact_go_menu_check = CheckBox::builder(&reading_panel).with_label(&t("Show compact &go menu")).build();
@@ -264,6 +269,7 @@ fn build_options_dialog_ui(parent: &Frame, config: &ConfigManager) -> OptionsDia
 	);
 	text_alignment_sizer.add(&text_alignment_ctrl, 0, SizerFlag::AlignCenterVertical, 0);
 	readability_sizer.add(&word_wrap_check, 0, SizerFlag::All, option_padding);
+	readability_sizer.add(&render_tables_inline_check, 0, SizerFlag::All, option_padding);
 	readability_sizer.add_sizer(&line_spacing_sizer, 0, SizerFlag::All, option_padding);
 	readability_sizer.add_sizer(&paragraph_spacing_sizer, 0, SizerFlag::All, option_padding);
 	readability_sizer.add_sizer(&letter_spacing_sizer, 0, SizerFlag::All, option_padding);
@@ -276,6 +282,7 @@ fn build_options_dialog_ui(parent: &Frame, config: &ConfigManager) -> OptionsDia
 	notebook.add_page(&readability_panel, &t("Readability"), false, None);
 	restore_docs_check.set_value(config.get_app_bool("restore_previous_documents", true));
 	word_wrap_check.set_value(config.get_app_bool("word_wrap", false));
+	render_tables_inline_check.set_value(config.get_app_bool("render_tables_inline", true));
 	minimize_to_tray_check.set_value(config.get_app_bool("minimize_to_tray", false));
 	start_maximized_check.set_value(config.get_app_bool("start_maximized", false));
 	compact_go_menu_check.set_value(config.get_app_bool("compact_go_menu", true));
@@ -376,6 +383,7 @@ fn build_options_dialog_ui(parent: &Frame, config: &ConfigManager) -> OptionsDia
 		notebook,
 		restore_docs_check,
 		word_wrap_check,
+		render_tables_inline_check,
 		minimize_to_tray_check,
 		start_maximized_check,
 		compact_go_menu_check,

--- a/crates/paperback/src/ui/document_manager.rs
+++ b/crates/paperback/src/ui/document_manager.rs
@@ -12,6 +12,7 @@ use std::{
 use paperback_core::{
 	config::{ConfigManager, ReadabilityFont},
 	parser::PASSWORD_REQUIRED_ERROR_PREFIX,
+	reader_core::nearest_fragment_before,
 	session::DocumentSession,
 };
 use patois::t;
@@ -127,18 +128,19 @@ impl DocumentManager {
 			}
 		}
 
-		let (password, forced_extension) = {
+		let (password, forced_extension, render_tables_inline) = {
 			let config = self.config.lock().unwrap();
 			let path_str = path.to_string_lossy();
 			config.refresh_document_hash(&path_str);
 			let forced_extension = config.get_document_format(&path_str);
 			let password = config.get_document_password(&path_str);
+			let render_tables_inline = config.get_app_bool("render_tables_inline", true);
 			drop(config);
-			(password, forced_extension)
+			(password, forced_extension, render_tables_inline)
 		};
 		let path_str = path.to_string_lossy().to_string();
 		tracing::info!(path = %path.display(), "opening document");
-		match DocumentSession::new(&path_str, &password, &forced_extension) {
+		match DocumentSession::new(&path_str, &password, &forced_extension, render_tables_inline) {
 			Ok(session) => self.add_session_tab(self_rc, path, session, &password, track, title_override),
 			Err(err) => {
 				if err.starts_with(PASSWORD_REQUIRED_ERROR_PREFIX) {
@@ -150,7 +152,7 @@ impl DocumentManager {
 						show_error_dialog(&self.notebook, &t("Password is required."), &t("Error"));
 						return false;
 					};
-					match DocumentSession::new(&path_str, &password, &forced_extension) {
+					match DocumentSession::new(&path_str, &password, &forced_extension, render_tables_inline) {
 						Ok(session) => self.add_session_tab(self_rc, path, session, &password, track, title_override),
 						Err(retry_error) => {
 							tracing::error!(path = %path.display(), error = %retry_error, "failed to open document");
@@ -564,6 +566,95 @@ impl DocumentManager {
 			text_ctrl.show_position(pos);
 			old_ctrl.destroy();
 			tab.text_ctrl = text_ctrl;
+		}
+	}
+
+	/// Re-parses every open document with the new `render_tables_inline` setting and refills its
+	/// text control. Re-parsing (rather than transforming in place) keeps every format's table
+	/// rendering identical via the shared parse-time helper. A tab whose re-parse fails is left
+	/// unchanged.
+	pub fn apply_render_tables_inline(&mut self, render_tables_inline: bool) {
+		// Read readability settings and collect each tab's parse inputs (path, password, forced
+		// format) under a single config lock, so we don't re-lock per tab while mutating the tabs.
+		let (rf, line_spacing, bg_color, text_alignment, letter_spacing, paragraph_spacing, parse_inputs) = {
+			let cfg = self.config.lock().unwrap();
+			let parse_inputs: Vec<(String, String, String)> = self
+				.tabs
+				.iter()
+				.map(|tab| {
+					let path_str = tab.file_path.to_string_lossy().to_string();
+					let password = cfg.get_document_password(&path_str);
+					let forced_extension = cfg.get_document_format(&path_str);
+					(path_str, password, forced_extension)
+				})
+				.collect();
+			(
+				cfg.get_readability_font(),
+				cfg.get_line_spacing(),
+				cfg.get_bg_color(),
+				cfg.get_text_alignment(),
+				cfg.get_letter_spacing(),
+				cfg.get_paragraph_spacing(),
+				parse_inputs,
+			)
+		};
+		for (tab, (path_str, password, forced_extension)) in self.tabs.iter_mut().zip(parse_inputs) {
+			let current_pos = tab.text_ctrl.get_insertion_point();
+			let pos = usize::try_from(current_pos.max(0)).unwrap_or(0);
+
+			// Snapshot a structural anchor before reparsing so we can restore position
+			// accurately even when inline-table toggling changes content length.
+			// Strategy: find the nearest element anchor (pb-block-N / HTML id / etc.)
+			// at-or-before the cursor and record the cursor's offset within that anchor's
+			// block. After reparsing the anchor's absolute position is looked up in the
+			// new id_positions map and the within-block offset is added back.
+			// Fallback: percentage-based position when no anchor exists (e.g. plain-text
+			// formats that emit no anchors).
+			let stable_anchor = nearest_fragment_before(tab.session.handle(), pos).map(|id| {
+				let anchor_pos = tab.session.handle().document().id_positions.get(&id).copied().unwrap_or(0);
+				let within = pos.saturating_sub(anchor_pos);
+				(id, within)
+			});
+			let fallback_percent = tab.session.get_status_info(current_pos).percentage;
+
+			let new_session = match DocumentSession::new(&path_str, &password, &forced_extension, render_tables_inline)
+			{
+				Ok(session) => session,
+				Err(err) => {
+					tracing::error!(path = %path_str, error = %err, "failed to re-parse document for render_tables_inline toggle");
+					continue;
+				}
+			};
+			tab.session = new_session;
+			let content = tab.session.content();
+			fill_text_ctrl(tab.text_ctrl, &content);
+			if let Some(font) = build_font_from_readability(&rf) {
+				tab.text_ctrl.set_font(&font);
+			}
+			apply_foreground_color_to_ctrl(tab.text_ctrl, rf.color);
+			apply_bg_color_to_ctrl(tab.text_ctrl, bg_color);
+			apply_readability_format_to_ctrl(
+				tab.text_ctrl,
+				line_spacing,
+				paragraph_spacing,
+				letter_spacing,
+				text_alignment,
+			);
+			tab.panel.layout();
+			let max_pos = tab.text_ctrl.get_last_position();
+
+			// Resolve the restored position from the anchor snapshot or fall back to %.
+			let restored_pos = if let Some((id, within)) = stable_anchor {
+				let new_anchor_pos = tab.session.handle().document().id_positions.get(&id).copied().unwrap_or(0);
+				let candidate = (new_anchor_pos + within) as i64;
+				candidate.clamp(0, max_pos)
+			} else {
+				tab.session.position_from_percent(fallback_percent).clamp(0, max_pos)
+			};
+
+			tab.text_ctrl.set_insertion_point(restored_pos);
+			tab.text_ctrl.show_position(restored_pos);
+			tab.session.set_stable_position(restored_pos);
 		}
 	}
 

--- a/crates/paperback/src/ui/document_manager.rs
+++ b/crates/paperback/src/ui/document_manager.rs
@@ -12,7 +12,6 @@ use std::{
 use paperback_core::{
 	config::{ConfigManager, ReadabilityFont},
 	parser::PASSWORD_REQUIRED_ERROR_PREFIX,
-	reader_core::nearest_fragment_before,
 	session::DocumentSession,
 };
 use patois::t;
@@ -602,19 +601,19 @@ impl DocumentManager {
 			let current_pos = tab.text_ctrl.get_insertion_point();
 			let pos = usize::try_from(current_pos.max(0)).unwrap_or(0);
 
-			// Snapshot a structural anchor before reparsing so we can restore position
-			// accurately even when inline-table toggling changes content length.
-			// Strategy: find the nearest element anchor (pb-block-N / HTML id / etc.)
-			// at-or-before the cursor and record the cursor's offset within that anchor's
-			// block. After reparsing the anchor's absolute position is looked up in the
-			// new id_positions map and the within-block offset is added back.
-			// Fallback: percentage-based position when no anchor exists (e.g. plain-text
-			// formats that emit no anchors).
-			let stable_anchor = nearest_fragment_before(tab.session.handle(), pos).map(|id| {
-				let anchor_pos = tab.session.handle().document().id_positions.get(&id).copied().unwrap_or(0);
-				let within = pos.saturating_sub(anchor_pos);
-				(id, within)
-			});
+			// Find the nearest anchor at-or-before the cursor using the full id_positions key
+			// (unlike nearest_fragment_before, which strips the "path#" prefix for epub keys
+			// making the subsequent lookup fail). Record the within-block offset so the cursor
+			// lands at the same structural position after reparsing. Fallback: percentage-based
+			// position for formats with no anchors.
+			let stable_anchor = {
+				let id_positions = &tab.session.handle().document().id_positions;
+				id_positions
+					.iter()
+					.filter(|&(_, &off)| off <= pos)
+					.max_by_key(|&(_, &off)| off)
+					.map(|(key, &anchor_off)| (key.clone(), pos.saturating_sub(anchor_off)))
+			};
 			let fallback_percent = tab.session.get_status_info(current_pos).percentage;
 
 			let new_session = match DocumentSession::new(&path_str, &password, &forced_extension, render_tables_inline)
@@ -643,11 +642,11 @@ impl DocumentManager {
 			tab.panel.layout();
 			let max_pos = tab.text_ctrl.get_last_position();
 
-			// Resolve the restored position from the anchor snapshot or fall back to %.
-			let restored_pos = if let Some((id, within)) = stable_anchor {
-				let new_anchor_pos = tab.session.handle().document().id_positions.get(&id).copied().unwrap_or(0);
-				let candidate = (new_anchor_pos + within) as i64;
-				candidate.clamp(0, max_pos)
+			let restored_pos = if let Some((ref key, within)) = stable_anchor {
+				match tab.session.handle().document().id_positions.get(key) {
+					Some(&new_anchor_off) => i64::try_from(new_anchor_off + within).unwrap_or(0).clamp(0, max_pos),
+					None => tab.session.position_from_percent(fallback_percent).clamp(0, max_pos),
+				}
 			} else {
 				tab.session.position_from_percent(fallback_percent).clamp(0, max_pos)
 			};

--- a/crates/paperback/src/ui/main_window.rs
+++ b/crates/paperback/src/ui/main_window.rs
@@ -1384,6 +1384,7 @@ impl MainWindow {
 					};
 					let (
 						old_word_wrap,
+						old_render_tables_inline,
 						old_compact_menu,
 						old_readability_font,
 						old_line_spacing,
@@ -1395,6 +1396,7 @@ impl MainWindow {
 						let cfg = config.lock().unwrap();
 						(
 							cfg.get_app_bool("word_wrap", false),
+							cfg.get_app_bool("render_tables_inline", true),
 							cfg.get_app_bool("compact_go_menu", true),
 							cfg.get_readability_font(),
 							cfg.get_line_spacing(),
@@ -1407,6 +1409,7 @@ impl MainWindow {
 					let cfg = config.lock().unwrap();
 					cfg.set_app_bool("restore_previous_documents", options.restore_previous_documents);
 					cfg.set_app_bool("word_wrap", options.word_wrap);
+					cfg.set_app_bool("render_tables_inline", options.render_tables_inline);
 					cfg.set_app_bool("minimize_to_tray", options.minimize_to_tray);
 					cfg.set_app_bool("start_maximized", options.start_maximized);
 					cfg.set_app_bool("compact_go_menu", options.compact_go_menu);
@@ -1431,6 +1434,8 @@ impl MainWindow {
 					}
 					drop(cfg);
 					let options_word_wrap = options.word_wrap;
+					let options_render_tables_inline = options.render_tables_inline;
+					let render_tables_inline_changed = old_render_tables_inline != options_render_tables_inline;
 					let font_changed = old_readability_font != options.readability_font;
 					let line_spacing_changed = old_line_spacing != options.line_spacing;
 					let bg_color_changed = old_bg_color != options.bg_color;
@@ -1469,6 +1474,10 @@ impl MainWindow {
 						if paragraph_spacing_changed {
 							dm_ref.apply_paragraph_spacing(options.paragraph_spacing);
 						}
+					}
+					if render_tables_inline_changed {
+						let mut dm_ref = dm.lock().unwrap();
+						dm_ref.apply_render_tables_inline(options_render_tables_inline);
 					}
 					let options_compact_menu = options.compact_go_menu;
 					if current_language != options.language || old_compact_menu != options_compact_menu {

--- a/crates/pb/src/main.rs
+++ b/crates/pb/src/main.rs
@@ -33,7 +33,10 @@ fn main() -> Result<()> {
 		};
 	}
 
-	let mut context = ParserContext { file_path, password: cli.password, forced_extension: None };
+	let mut context = ParserContext::new(file_path).with_render_tables_inline(true);
+	if let Some(password) = cli.password {
+		context = context.with_password(password);
+	}
 	let doc = match parse_document(&context) {
 		Ok(doc) => doc,
 		Err(e) if e.to_string().starts_with(PASSWORD_REQUIRED_ERROR_PREFIX) => {

--- a/po/paperback.pot
+++ b/po/paperback.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: paperback 0.8.5\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-06-26 14:10-0600\n"
+"POT-Creation-Date: 2026-06-27 11:48+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -228,6 +228,9 @@ msgid "&Restore previously opened documents on startup"
 msgstr ""
 
 msgid "&Word wrap"
+msgstr ""
+
+msgid "Render tables &inline"
 msgstr ""
 
 msgid "&Minimize to system tray"


### PR DESCRIPTION
## Summary

Closes #535: a "Render tables inline" toggle (Options, Readability tab) that
uniformly controls table rendering across all document formats.

- **ON (default):** the table rendered inline as tab-separated rows (cells separated by
  tab, rows by newline).
- **OFF:** uniform placeholder `[Table]: <first row>` (the table's first row, with tabs
  replaced by spaces; just `[Table]` when the table has no rows).

Both representations are produced by a single helper (`html_table_to_display`), so PDF,
Word, ODT, HTML/EPUB and Markdown render identically.

## Design

The flag is threaded from the config through `ParserContext` into each parser, which
emits the table text at parse time. Toggling the setting re-parses the open documents.
Markers get correct positions during the normal parse pass, so there is no post-parse
offset-shifting and no dual-variant cached document.

## Known limitations

- PowerPoint tables are still not detected; out of scope, follow-up.
