### PR TITLE
FIX(mac) Make the menu bar appear in development

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1651,6 +1651,7 @@ dependencies = [
  "embed-manifest",
  "flate2",
  "live-region",
+ "objc",
  "paperback-core",
  "patois",
  "patois-build",

--- a/crates/paperback/Cargo.toml
+++ b/crates/paperback/Cargo.toml
@@ -28,6 +28,16 @@ wxdragon = { version = "0.9.16", features = ["webview"] }
 [target.'cfg(windows)'.dependencies]
 windows = { version = "0.62.2", features = ["Win32_UI_Accessibility", "Win32_System_Com", "Win32_UI_WindowsAndMessaging", "Win32_Foundation", "Win32_System_Ole", "Win32_System_Variant", "Win32_UI_Controls_RichEdit", "Win32_Graphics_Gdi", "Win32_Security", "Win32_Storage_FileSystem", "Win32_System_IO", "Win32_System_Pipes", "Win32_UI_Input", "Win32_UI_Input_KeyboardAndMouse", "Win32_System_Threading"] }
 
+[target.'cfg(target_os = "macos")'.dependencies]
+objc = "0.2.7"
+
+[lints.rust]
+# `objc`'s `msg_send!` macro expands to a `cfg(feature = "cargo-clippy")` check.
+# This is not a feature that this crate defines and the Rust compiler understands, so a warning would normally be generated.
+# When using macros from older crates (written before this compiler check
+# existed) that rely on this feature, such warnings must be suppressed.
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(feature, values("cargo-clippy"))'] }
+
 [build-dependencies]
 embed-manifest = "1.5.0"
 flate2 = { version = "1.1.9", default-features = false }

--- a/crates/paperback/src/main.rs
+++ b/crates/paperback/src/main.rs
@@ -22,11 +22,34 @@ fn main() {
 	tracing::info!(version = env!("CARGO_PKG_VERSION"), commit = version::COMMIT_HASH, "starting");
 	set_pdfium_path_from_exe();
 	cleanup_legacy_files();
+
+	// When running in dev via `cargo run`, make sure the app gets a proper menu bar on Mac OS.
+	// Binaries not inside an app bundle are essentially treated as background processes of Terminal.app, which leads to all sorts of nastiness.
+	// This needs to be called before WX initializes to properly take effect.
+	#[cfg(target_os = "macos")]
+	promote_unbundled_to_regular_app();
 	let _ = wxdragon::main(|app| {
 		let _ = set_appearance(Appearance::System);
 		let app_state = PaperbackApp::new(app);
 		let _ = Box::leak(Box::new(app_state));
 	});
+}
+
+#[cfg(target_os = "macos")]
+fn promote_unbundled_to_regular_app() {
+	use objc::{class, msg_send, runtime::Object, sel, sel_impl};
+
+	// When in a bundle, MacOS handles this for us.
+	let in_bundle = env::current_exe().is_ok_and(|exe| exe.to_string_lossy().contains(".app/Contents/MacOS/"));
+	if in_bundle {
+		return;
+	}
+	// NSApplicationActivationPolicyRegular = 0.
+	unsafe {
+		let ns_app: *mut Object = msg_send![class!(NSApplication), sharedApplication];
+		let _: () = msg_send![ns_app, setActivationPolicy: 0_isize];
+		let _: () = msg_send![ns_app, activateIgnoringOtherApps: true];
+	}
 }
 
 fn set_pdfium_path_from_exe() {


### PR DESCRIPTION
By default, apps launched straight from a Mach-O binary, such as when executed via `cargo run` in development, are essentially treated by LaunchServices as subprocesses of Terminal.app. Hence, they do not get their own menu bar (and probably also a bunch of other things I'm not aware of).

As app developers, we can modify this behavior by instructing LaunchServices to change our activation policy, as is done here.

For this change to take effect, the policy must be modified before the app's main loop runs, which is exactly what we do.