### PR TITLE
FEAT(mac): Add an Edit menu

### DIFF
--- a/crates/paperback/src/ui/menu.rs
+++ b/crates/paperback/src/ui/menu.rs
@@ -411,12 +411,16 @@ pub fn create_menu_bar(config: &ConfigManager) -> MenuBar {
 	let go_label = t("&Go");
 	let tools_label = t("&Tools");
 	let help_label = t("&Help");
-	MenuBar::builder()
-		.append(file_menu, &file_label)
-		.append(go_menu, &go_label)
-		.append(tools_menu, &tools_label)
-		.append(help_menu, &help_label)
-		.build()
+	let mut builder = MenuBar::builder().append(file_menu, &file_label);
+
+	// All MacOS apps need an Edit menu.
+	// This is where the OS places some items that each app should have, like "Start dictation" or "Emoji and Symbols."
+	#[cfg(target_os = "macos")]
+	{
+		let edit_label = t("&Edit");
+		builder = builder.append(create_edit_menu(), &edit_label);
+	}
+	builder.append(go_menu, &go_label).append(tools_menu, &tools_label).append(help_menu, &help_label).build()
 }
 
 pub fn create_file_menu(config: &ConfigManager) -> Menu {
@@ -451,6 +455,36 @@ pub fn create_file_menu(config: &ConfigManager) -> Menu {
 		let _ = file_menu.append(menu_ids::EXIT, &exit_label, &exit_help, ItemKind::Normal);
 	}
 	file_menu
+}
+
+/// The standard macOS Edit menu.
+///
+/// Each entry uses a real wxWidgets edit ID, so wxWidgets wires it to the matching
+/// native macOS selector. AppKit handles enabling/disabling and routing to the
+/// focused control.
+///
+/// Because a `copy:` item is present, AppKit  appends its own
+/// items, like "Emoji & Symbols" and "Start Dictation".
+#[cfg(target_os = "macos")]
+pub fn create_edit_menu() -> Menu {
+	let undo_label = t("&Undo\tCtrl+Z");
+	let redo_label = t("&Redo\tCtrl+Shift+Z");
+	let cut_label = t("Cu&t\tCtrl+X");
+	let copy_label = t("&Copy\tCtrl+C");
+	let paste_label = t("&Paste\tCtrl+V");
+	let delete_label = t("&Delete");
+	let select_all_label = t("Select &All\tCtrl+A");
+	Menu::builder()
+		.append_item(menu_ids::UNDO, &undo_label, "")
+		.append_item(menu_ids::REDO, &redo_label, "")
+		.append_separator()
+		.append_item(menu_ids::CUT, &cut_label, "")
+		.append_item(menu_ids::COPY, &copy_label, "")
+		.append_item(menu_ids::PASTE, &paste_label, "")
+		.append_item(menu_ids::DELETE, &delete_label, "")
+		.append_separator()
+		.append_item(menu_ids::SELECT_ALL, &select_all_label, "")
+		.build()
 }
 
 pub fn create_go_menu(compact: bool) -> Menu {

--- a/crates/paperback/src/ui/menu_ids.rs
+++ b/crates/paperback/src/ui/menu_ids.rs
@@ -7,6 +7,28 @@ pub const ABOUT: i32 = ID_ABOUT;
 #[allow(clippy::cast_possible_truncation)]
 pub const PREFERENCES: i32 = wxdragon::ffi::WXD_ID_PREFERENCES as i32;
 
+// Standard wxWidgets IDs for the macOS Edit menu. They must be the real wxWidgets
+// IDs (not custom ones) so wxWidgets binds each item to its native macOS selector
+// — cut:, copy:, paste:, delete:, selectAll: — with a nil target. AppKit then
+// routes the command through the responder chain to the focused control and, because
+// a `copy:` item is present, appends its own "Emoji & Symbols" and "Start Dictation"
+// items to the menu. Undo/Redo have no native selector mapping but are handled by
+// wxTextCtrl when it has focus.
+#[cfg(target_os = "macos")]
+pub use edit_ids::*;
+#[cfg(target_os = "macos")]
+mod edit_ids {
+	#![allow(clippy::cast_possible_truncation)]
+	use wxdragon::ffi;
+	pub const UNDO: i32 = ffi::WXD_ID_UNDO as i32;
+	pub const REDO: i32 = ffi::WXD_ID_REDO as i32;
+	pub const CUT: i32 = ffi::WXD_ID_CUT as i32;
+	pub const COPY: i32 = ffi::WXD_ID_COPY as i32;
+	pub const PASTE: i32 = ffi::WXD_ID_PASTE as i32;
+	pub const DELETE: i32 = ffi::WXD_ID_CLEAR as i32;
+	pub const SELECT_ALL: i32 = ffi::WXD_ID_SELECTALL as i32;
+}
+
 // Base for custom IDs
 const BASE: i32 = 5000;
 


### PR DESCRIPTION
MacOS wants all of its apps to have an Edit menu with a very specific shape. This is where options like "Copy" should go; it's also where AppKit inserts some options of its own, like "Start Dictation" or "Emoji and Symbols." (MacOS actually uses the Copy option to determine which is the Edit menu).

By default, all apps get such a menu; it comes as part of the default UI when using Xcode's InterfaceBuilder; SwiftUI also ships one.

We only need to add one of our own because we're creating the menu bar programmatically.

Thankfully, WX gives us all the necessary mechanisms to do so, so it is not too much work.