### PR TITLE
FEAT(pptx): Add table support to the PowerPoint parser

### DIFF
--- a/crates/paperback-core/src/parser/powerpoint.rs
+++ b/crates/paperback-core/src/parser/powerpoint.rs
@@ -20,8 +20,17 @@ use crate::{
 		word::try_decrypt_office_file,
 	},
 	types::LinkInfo,
-	util::zip::read_zip_entry_by_name,
+	util::{text::display_len, zip::read_zip_entry_by_name},
 };
+
+/// A table found while traversing a slide. Markers are added after the slide text is appended to
+/// the buffer (mirroring the deferred link-marker handling), so positions stay in display units.
+struct TableData {
+	offset: usize,
+	caption: String,
+	html: String,
+	length: usize,
+}
 
 const PPT_RECORD_HEADER_SIZE: usize = 8;
 const PPT_REC_SLIDE: u16 = 1006;
@@ -95,7 +104,15 @@ fn parse_pptx(context: &ParserContext) -> Result<Document> {
 		let slide_title = extract_slide_title(slide_doc.root());
 		let slide_start = buffer.current_position();
 		let mut links = Vec::new();
-		let slide_text = extract_slide_text(slide_doc.root(), &mut links, slide_start, &rels);
+		let mut tables = Vec::new();
+		let slide_text = extract_slide_text(
+			slide_doc.root(),
+			&mut links,
+			&mut tables,
+			slide_start,
+			&rels,
+			context.render_tables_inline,
+		);
 		if !slide_text.trim().is_empty() {
 			buffer.append(&slide_text);
 			if !buffer.content.ends_with('\n') {
@@ -109,6 +126,14 @@ fn parse_pptx(context: &ParserContext) -> Result<Document> {
 			for link in links {
 				buffer.add_marker(
 					Marker::new(MarkerType::Link, link.offset).with_text(link.text).with_reference(link.reference),
+				);
+			}
+			for table in tables {
+				buffer.add_marker(
+					Marker::new(MarkerType::Table, table.offset)
+						.with_text(table.caption)
+						.with_reference(table.html)
+						.with_length(table.length),
 				);
 			}
 			let toc_name = if slide_title.is_empty() { format!("Slide {}", index + 1) } else { slide_title.clone() };
@@ -341,11 +366,13 @@ fn is_title_shape(node: Node) -> bool {
 fn extract_slide_text(
 	root: Node,
 	links: &mut Vec<LinkInfo>,
+	tables: &mut Vec<TableData>,
 	slide_start: usize,
 	rels: &HashMap<String, String>,
+	render_tables_inline: bool,
 ) -> String {
 	let mut text = String::new();
-	traverse_for_text(root, &mut text, links, slide_start, rels);
+	traverse_for_text(root, &mut text, links, tables, slide_start, rels, render_tables_inline);
 	text
 }
 
@@ -353,8 +380,10 @@ fn traverse_for_text(
 	node: Node,
 	text: &mut String,
 	links: &mut Vec<LinkInfo>,
+	tables: &mut Vec<TableData>,
 	slide_start: usize,
 	rels: &HashMap<String, String>,
+	render_tables_inline: bool,
 ) {
 	match node.node_type() {
 		NodeType::Element => {
@@ -370,9 +399,15 @@ fn traverse_for_text(
 					text.push('\n');
 					return;
 				}
+				"tbl" => {
+					// Handle the table here and skip generic recursion: otherwise the walk below would
+					// re-emit every cell's `<a:t>` text as flat paragraph lines, duplicating the table.
+					process_pptx_table(node, text, tables, slide_start, render_tables_inline);
+					return;
+				}
 				"p" => {
 					for child in node.children() {
-						traverse_for_text(child, text, links, slide_start, rels);
+						traverse_for_text(child, text, links, tables, slide_start, rels, render_tables_inline);
 					}
 					if !text.ends_with('\n') {
 						text.push('\n');
@@ -404,8 +439,55 @@ fn traverse_for_text(
 		_ => {}
 	}
 	for child in node.children() {
-		traverse_for_text(child, text, links, slide_start, rels);
+		traverse_for_text(child, text, links, tables, slide_start, rels, render_tables_inline);
 	}
+}
+
+/// Convert a DrawingML `<a:tbl>` into the shared HTML-table representation, append its display text
+/// to `text`, and record a [`TableData`] for later marker creation. pptx cells nest one level
+/// deeper than Word (`tc > txBody > p`), so cell text is gathered from every descendant `<a:t>`.
+fn process_pptx_table(
+	node: Node,
+	text: &mut String,
+	tables: &mut Vec<TableData>,
+	slide_start: usize,
+	render_tables_inline: bool,
+) {
+	let mut rows: Vec<Vec<String>> = Vec::new();
+	for tr in node.children() {
+		if tr.node_type() != NodeType::Element || tr.tag_name().name() != "tr" {
+			continue;
+		}
+		let mut cells: Vec<String> = Vec::new();
+		for tc in tr.children() {
+			if tc.node_type() != NodeType::Element || tc.tag_name().name() != "tc" {
+				continue;
+			}
+			// Join paragraphs within the cell with a space so multi-paragraph cells stay readable.
+			let mut cell_text = String::new();
+			for p in tc.descendants() {
+				if p.node_type() == NodeType::Element && p.tag_name().name() == "p" {
+					let para = collect_text_from_tagged_elements(p, "t");
+					if !para.is_empty() {
+						if !cell_text.is_empty() {
+							cell_text.push(' ');
+						}
+						cell_text.push_str(&para);
+					}
+				}
+			}
+			cells.push(cell_text.trim().to_string());
+		}
+		rows.push(cells);
+	}
+	let html = crate::parser::table_text::build_html_table_from_grid(&rows);
+	let caption = crate::parser::table_text::table_caption_from_html(&html).unwrap_or_else(|| "table".to_string());
+	let display_text = crate::parser::table_text::html_table_to_display(&html, render_tables_inline);
+	let (_, length) = crate::parser::table_text::display_lines_and_length(&display_text);
+	let offset = slide_start + display_len(text);
+	text.push_str(&display_text);
+	text.push('\n');
+	tables.push(TableData { offset, caption, html, length });
 }
 
 #[cfg(test)]
@@ -416,8 +498,8 @@ mod tests {
 	use rstest::rstest;
 
 	use super::{
-		extract_legacy_text, extract_slide_number, extract_slide_text, extract_slide_title, is_title_shape,
-		normalize_legacy_slide_text, parse_cstring, parse_text_bytes_atom, parse_text_chars_atom,
+		display_len, extract_legacy_text, extract_slide_number, extract_slide_text, extract_slide_title,
+		is_title_shape, normalize_legacy_slide_text, parse_cstring, parse_text_bytes_atom, parse_text_chars_atom,
 	};
 
 	#[rstest]
@@ -480,10 +562,57 @@ mod tests {
 		"#;
 		let doc = XmlDocument::parse(xml).expect("xml parse");
 		let mut links = Vec::new();
+		let mut tables = Vec::new();
 		let rels = HashMap::new();
-		let text = extract_slide_text(doc.root(), &mut links, 0, &rels);
+		let text = extract_slide_text(doc.root(), &mut links, &mut tables, 0, &rels, true);
 		assert_eq!(text, "Hello\nWorld\nNext\n");
 		assert!(links.is_empty());
+		assert!(tables.is_empty());
+	}
+
+	const TABLE_SLIDE_XML: &str = r#"
+		<root>
+			<graphicFrame><graphic><graphicData>
+				<tbl>
+					<tblPr/>
+					<tblGrid><gridCol/><gridCol/></tblGrid>
+					<tr><tc><txBody><p><r><t>One</t></r></p></txBody></tc><tc><txBody><p><r><t>Two</t></r></p></txBody></tc></tr>
+					<tr><tc><txBody><p><r><t>Three</t></r></p></txBody></tc><tc><txBody><p><r><t>Four</t></r></p></txBody></tc></tr>
+				</tbl>
+			</graphicData></graphic></graphicFrame>
+		</root>
+	"#;
+
+	#[test]
+	fn extract_slide_text_renders_table_inline_with_marker_data() {
+		let doc = XmlDocument::parse(TABLE_SLIDE_XML).expect("xml parse");
+		let mut links = Vec::new();
+		let mut tables = Vec::new();
+		let rels = HashMap::new();
+		let text = extract_slide_text(doc.root(), &mut links, &mut tables, 0, &rels, true);
+		// Tab-separated rows, no flat duplication of the cell text.
+		assert_eq!(text, "One\tTwo\nThree\tFour\n");
+		assert_eq!(tables.len(), 1);
+		let table = &tables[0];
+		assert_eq!(table.offset, 0);
+		assert_eq!(table.caption, "One Two");
+		assert!(table.html.contains("<table"));
+		assert!(table.html.contains("Four"));
+		// Two rows, each contributing its display width + a trailing newline.
+		assert_eq!(table.length, display_len("One\tTwo") + 1 + display_len("Three\tFour") + 1);
+		assert!(links.is_empty());
+	}
+
+	#[test]
+	fn extract_slide_text_renders_table_placeholder() {
+		let doc = XmlDocument::parse(TABLE_SLIDE_XML).expect("xml parse");
+		let mut links = Vec::new();
+		let mut tables = Vec::new();
+		let rels = HashMap::new();
+		let text = extract_slide_text(doc.root(), &mut links, &mut tables, 0, &rels, false);
+		assert_eq!(text, "[Table]: One Two\n");
+		assert_eq!(tables.len(), 1);
+		assert_eq!(tables[0].caption, "One Two");
 	}
 
 	#[test]

--- a/crates/paperback-core/src/parser/table_text.rs
+++ b/crates/paperback-core/src/parser/table_text.rs
@@ -24,6 +24,26 @@ pub fn html_table_to_display(html: &str, inline: bool) -> String {
 	tsv_to_display(&html_table_to_tsv(html), inline)
 }
 
+/// Build a `<table border="1">…</table>` string from a rectangular grid of pre-extracted,
+/// plain-text cell values (one inner `Vec` per row). Cells are inserted verbatim (no
+/// HTML-escaping); the downstream `html_table_to_*` functions handle whitespace collapsing.
+/// Callers extract the cell text themselves, so this only owns the grid-to-HTML wrapping.
+#[must_use]
+pub fn build_html_table_from_grid(rows: &[Vec<String>]) -> String {
+	let mut html = String::from("<table border=\"1\">");
+	for row in rows {
+		html.push_str("<tr>");
+		for cell in row {
+			html.push_str("<td>");
+			html.push_str(cell);
+			html.push_str("</td>");
+		}
+		html.push_str("</tr>");
+	}
+	html.push_str("</table>");
+	html
+}
+
 /// Render a tab-separated table body in the requested display mode.
 ///
 /// - `inline == true`  -> the TSV unchanged.
@@ -326,5 +346,27 @@ mod tests {
 		assert_eq!(bundle.caption, "table");
 		assert!(bundle.lines.is_empty());
 		assert_eq!(bundle.display_length, 0);
+	}
+
+	#[test]
+	fn build_html_table_from_grid_2x2() {
+		let rows = vec![vec!["a".to_string(), "b".to_string()], vec!["c".to_string(), "d".to_string()]];
+		assert_eq!(
+			build_html_table_from_grid(&rows),
+			"<table border=\"1\"><tr><td>a</td><td>b</td></tr><tr><td>c</td><td>d</td></tr></table>"
+		);
+		// Round-trips through the shared TSV renderer.
+		assert_eq!(html_table_to_tsv(&build_html_table_from_grid(&rows)), "a\tb\nc\td");
+	}
+
+	#[test]
+	fn build_html_table_from_grid_empty() {
+		assert_eq!(build_html_table_from_grid(&[]), "<table border=\"1\"></table>");
+	}
+
+	#[test]
+	fn build_html_table_from_grid_empty_cell() {
+		let rows = vec![vec![String::new(), "b".to_string()]];
+		assert_eq!(build_html_table_from_grid(&rows), "<table border=\"1\"><tr><td></td><td>b</td></tr></table>");
 	}
 }

--- a/crates/paperback-core/src/parser/word.rs
+++ b/crates/paperback-core/src/parser/word.rs
@@ -548,13 +548,12 @@ fn process_table(
 	render_tables_inline: bool,
 ) {
 	let table_start = buffer.current_position();
-	let mut html_content = String::from("<table border=\"1\">");
+	let mut rows: Vec<Vec<String>> = Vec::new();
 	for child in element.children() {
 		if child.node_type() == NodeType::Element && child.tag_name().name() == "tr" {
-			html_content.push_str("<tr>");
+			let mut cells: Vec<String> = Vec::new();
 			for tc in child.children() {
 				if tc.node_type() == NodeType::Element && tc.tag_name().name() == "tc" {
-					html_content.push_str("<td>");
 					let mut cell_text = String::new();
 					for p in tc.children() {
 						if p.node_type() == NodeType::Element && p.tag_name().name() == "p" {
@@ -566,14 +565,13 @@ fn process_table(
 							cell_text.push(' ');
 						}
 					}
-					html_content.push_str(cell_text.trim());
-					html_content.push_str("</td>");
+					cells.push(cell_text.trim().to_string());
 				}
 			}
-			html_content.push_str("</tr>");
+			rows.push(cells);
 		}
 	}
-	html_content.push_str("</table>");
+	let html_content = crate::parser::table_text::build_html_table_from_grid(&rows);
 	// Derive the caption the same way HTML/XML do (first-row text, no prefix) for consistent
 	// labels across formats; fall back to "table" for an empty table like `table_caption_from_tsv`.
 	let final_caption =


### PR DESCRIPTION
## What

PowerPoint (`.pptx`) tables are now parsed and rendered like tables in every
other supported format.

Previously a DrawingML table (`a:tbl` inside a `p:graphicFrame`) was walked by
the generic text traversal, so its cells were dumped as separate flat lines
with no row/column structure and **no `Table` marker** — meaning the reader's
table navigation never fired on PowerPoint tables.

## How

- Parse `a:tbl` the same way the Word parser handles `w:tbl`: extract the cell
  grid, build an HTML `<table>`, and run it through the shared
  `parser::table_text` pipeline. This produces tab-separated output (or a
  `[Table]: …` placeholder, honoring the existing `render_tables_inline`
  config) plus a navigable `MarkerType::Table` whose HTML opens in the Table
  View dialog.
- Factor the duplicated grid-to-HTML wrapping out of `word.rs` into a shared
  `table_text::build_html_table_from_grid` helper, used by both parsers. Cell
  text extraction stays format-specific (pptx nests cells one level deeper:
  `tc > txBody > p`).

## Out of scope

- **Header cells (`<th>`)** — emitted as `<td>` only, matching Word/ODT/PDF.
- **Legacy binary `.ppt`** — its OLE text atoms expose no table grid.

## Tests

- New unit tests for `build_html_table_from_grid` and for inline/placeholder
  pptx table rendering (incl. marker offset/length and no flat-text duplication).
- Verified end-to-end on a sample deck: a 2×2 table renders as
  `One<TAB>Two` / `Three<TAB>Four` in text and as a proper `<table>` in HTML export.
- Full `paperback-core` suite passes (370 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)