### PR TITLE
Add property page accessible role for settings tabs and anounce document name on tab switch

### DIFF
--- a/crates/paperback/src/ui/dialogs/options.rs
+++ b/crates/paperback/src/ui/dialogs/options.rs
@@ -7,6 +7,8 @@ use std::{
 
 use paperback_core::config::{ConfigManager, HotkeyConfig, ReadabilityFont};
 use patois::{t, ui::populate_language_choice};
+#[cfg(target_os = "windows")]
+use wxdragon::accessible::AccRole;
 use wxdragon::prelude::*;
 
 use super::DIALOG_PADDING;
@@ -273,9 +275,21 @@ fn build_options_dialog_ui(parent: &Frame, config: &ConfigManager) -> OptionsDia
 	readability_panel.set_sizer(readability_sizer, true);
 	general_panel.set_sizer(general_sizer, true);
 	reading_panel.set_sizer(reading_sizer, true);
-	notebook.add_page(&general_panel, &t("General"), true, None);
-	notebook.add_page(&reading_panel, &t("Reading"), false, None);
-	notebook.add_page(&readability_panel, &t("Readability"), false, None);
+	let general_label = t("General");
+	let reading_label = t("Reading");
+	let readability_label = t("Readability");
+	general_panel.set_accessibility_label(&general_label);
+	reading_panel.set_accessibility_label(&reading_label);
+	readability_panel.set_accessibility_label(&readability_label);
+	#[cfg(target_os = "windows")]
+	{
+		general_panel.set_accessibility_role(AccRole::PropertyPage);
+		reading_panel.set_accessibility_role(AccRole::PropertyPage);
+		readability_panel.set_accessibility_role(AccRole::PropertyPage);
+	}
+	notebook.add_page(&general_panel, &general_label, true, None);
+	notebook.add_page(&reading_panel, &reading_label, false, None);
+	notebook.add_page(&readability_panel, &readability_label, false, None);
 	restore_docs_check.set_value(config.get_app_bool("restore_previous_documents", true));
 	word_wrap_check.set_value(config.get_app_bool("word_wrap", false));
 	render_tables_inline_check.set_value(config.get_app_bool("render_tables_inline", true));

--- a/crates/paperback/src/ui/document_manager.rs
+++ b/crates/paperback/src/ui/document_manager.rs
@@ -36,6 +36,18 @@ pub struct DocumentTab {
 	pub track: bool,
 }
 
+pub fn title_or_filename(title: String, path: &Path) -> String {
+	if title.is_empty() {
+		path.file_name().map_or_else(|| t("Untitled"), |s| s.to_string_lossy().to_string())
+	} else {
+		title
+	}
+}
+
+pub fn display_title(tab: &DocumentTab) -> String {
+	title_or_filename(tab.session.title(), &tab.file_path)
+}
+
 const POSITION_SAVE_INTERVAL_SECS: u64 = 3;
 const WXK_F10: i32 = 349;
 const WXK_WINDOWS_MENU: i32 = 395;
@@ -185,17 +197,8 @@ impl DocumentManager {
 			self.notebook.set_selection(index);
 			return true;
 		}
-		let title = title_override.map_or_else(
-			|| {
-				let title = session.title();
-				if title.is_empty() {
-					path.file_name().map_or_else(|| t("Untitled"), |s| s.to_string_lossy().to_string())
-				} else {
-					title
-				}
-			},
-			std::string::ToString::to_string,
-		);
+		let title =
+			title_override.map_or_else(|| title_or_filename(session.title(), path), std::string::ToString::to_string);
 		let panel = Panel::builder(&self.notebook).build();
 		let config = self.config.lock().unwrap();
 		let mut session = session;
@@ -280,6 +283,15 @@ impl DocumentManager {
 			self.notebook.set_selection(new_index);
 		}
 		true
+	}
+
+	pub fn active_index_after_closing(&self, index: usize) -> Option<usize> {
+		let count = self.tabs.len();
+		if index >= count || count <= 1 {
+			return None;
+		}
+		let new_index = index.min(count - 2);
+		Some(if new_index < index { new_index } else { new_index + 1 })
 	}
 
 	pub fn close_all_documents(&mut self) {

--- a/crates/paperback/src/ui/main_window.rs
+++ b/crates/paperback/src/ui/main_window.rs
@@ -25,7 +25,7 @@ use wxdragon::{prelude::*, timer::Timer};
 use super::tray;
 use super::{
 	dialogs,
-	document_manager::{DocumentManager, build_font_from_readability},
+	document_manager::{DocumentManager, build_font_from_readability, display_title},
 	find::{self, FindDialogState},
 	help::{self, MAIN_WINDOW_PTR},
 	menu, menu_ids,
@@ -95,9 +95,22 @@ impl MainWindow {
 			#[cfg(target_os = "windows")]
 			&hotkey_handle,
 		);
-		let dm = Rc::clone(&doc_manager);
 		let frame_copy = frame;
 		let notebook = *doc_manager.lock().unwrap().notebook();
+		let dm = Rc::clone(&doc_manager);
+		notebook.on_page_changing(move |event| {
+			let Ok(dm_ref) = dm.try_lock() else {
+				return;
+			};
+			if !dm_ref.notebook().has_focus()
+				&& let Some(new_index) = event.get_selection()
+				&& let Ok(new_index) = usize::try_from(new_index)
+				&& let Some(tab) = dm_ref.get_tab(new_index)
+			{
+				live_region::announce(live_region_label, &t("Switched to {}").replace("{}", &display_title(tab)));
+			}
+		});
+		let dm = Rc::clone(&doc_manager);
 		notebook.on_page_changed(move |_event| {
 			let Ok(dm_ref) = dm.try_lock() else {
 				return;
@@ -113,9 +126,7 @@ impl MainWindow {
 				&& (key == KEY_DELETE || key == KEY_NUMPAD_DELETE)
 			{
 				let mut dm = dm.lock().unwrap();
-				if let Some(index) = dm.active_tab_index() {
-					dm.close_document(index, true);
-				}
+				close_active_document_announced(&mut dm, live_region_label);
 				update_title_from_manager(&frame_copy, &dm);
 				let has_docs = dm.tab_count() > 0;
 				let has_reopen = dm.has_recently_closed();
@@ -339,14 +350,8 @@ impl MainWindow {
 			return;
 		}
 		if let Some(tab) = dm.active_tab() {
-			let title = tab.session.title();
-			let display_title = if title.is_empty() {
-				tab.file_path.file_name().map_or_else(|| t("Untitled"), |s| s.to_string_lossy().to_string())
-			} else {
-				title
-			};
 			let template = t("Paperback - {}");
-			self.frame.set_title(&template.replace("{}", &display_title));
+			self.frame.set_title(&template.replace("{}", &display_title(tab)));
 			let chars_label = t("{} chars");
 			self.frame.set_status_text(&chars_label.replace("{}", &tab.session.content().len().to_string()), 0);
 		}
@@ -531,9 +536,7 @@ impl MainWindow {
 				}
 				menu_ids::CLOSE => {
 					let mut dm = dm.lock().unwrap();
-					if let Some(index) = dm.active_tab_index() {
-						dm.close_document(index, true);
-					}
+					close_active_document_announced(&mut dm, live_region_label);
 					update_title_from_manager(&frame_copy, &dm);
 					let has_docs = dm.tab_count() > 0;
 					if has_docs {
@@ -548,6 +551,7 @@ impl MainWindow {
 				menu_ids::CLOSE_ALL => {
 					let mut dm = dm.lock().unwrap();
 					dm.close_all_documents();
+					live_region::announce(live_region_label, &t("Closed all documents."));
 					update_title_from_manager(&frame_copy, &dm);
 					dm.notebook().set_focus();
 					drop(dm);
@@ -1723,6 +1727,27 @@ fn ensure_parser_for_unknown_file(parent: &Frame, path: &Path, config: &ConfigMa
 	true
 }
 
+/// Close the active document and announce the change for screen readers.
+///
+/// The `set_selection` inside `close_document` fires `on_page_changed` while the
+/// caller holds the manager lock, so the generic switch announcement is suppressed
+/// and only this message speaks.
+fn close_active_document_announced(dm: &mut DocumentManager, live_region_label: StaticText) {
+	let Some(index) = dm.active_tab_index() else {
+		return;
+	};
+	let Some(tab) = dm.get_tab(index) else {
+		return;
+	};
+	let closed = display_title(tab);
+	let msg = match dm.active_index_after_closing(index).and_then(|i| dm.get_tab(i)) {
+		Some(next) => t("Closed {a}. Now on {b}.").replace("{a}", &closed).replace("{b}", &display_title(next)),
+		None => t("Closed {a}. No documents open.").replace("{a}", &closed),
+	};
+	live_region::announce(live_region_label, &msg);
+	dm.close_document(index, true);
+}
+
 fn update_title_from_manager(frame: &Frame, dm: &DocumentManager) {
 	let sleep_start = SLEEP_TIMER_START_MS.load(Ordering::SeqCst);
 	let sleep_duration = SLEEP_TIMER_DURATION_MINUTES.load(Ordering::SeqCst);
@@ -1739,14 +1764,8 @@ fn update_title_from_manager(frame: &Frame, dm: &DocumentManager) {
 		return;
 	}
 	if let Some(tab) = dm.active_tab() {
-		let title = tab.session.title();
-		let display_title = if title.is_empty() {
-			tab.file_path.file_name().map_or_else(|| t("Untitled"), |s| s.to_string_lossy().to_string())
-		} else {
-			title
-		};
 		let template = t("Paperback - {}");
-		frame.set_title(&template.replace("{}", &display_title));
+		frame.set_title(&template.replace("{}", &display_title(tab)));
 		let position = tab.text_ctrl.get_insertion_point();
 		let status_info = tab.session.get_status_info(position);
 		let mut status_text = status::format_status_text(&status_info);

--- a/crates/paperback/src/ui/main_window.rs
+++ b/crates/paperback/src/ui/main_window.rs
@@ -107,7 +107,7 @@ impl MainWindow {
 				&& let Ok(new_index) = usize::try_from(new_index)
 				&& let Some(tab) = dm_ref.get_tab(new_index)
 			{
-				live_region::announce(live_region_label, &t("Switched to {}").replace("{}", &display_title(tab)));
+				live_region::announce(live_region_label, &display_title(tab));
 			}
 		});
 		let dm = Rc::clone(&doc_manager);
@@ -551,7 +551,6 @@ impl MainWindow {
 				menu_ids::CLOSE_ALL => {
 					let mut dm = dm.lock().unwrap();
 					dm.close_all_documents();
-					live_region::announce(live_region_label, &t("Closed all documents."));
 					update_title_from_manager(&frame_copy, &dm);
 					dm.notebook().set_focus();
 					drop(dm);
@@ -1727,24 +1726,20 @@ fn ensure_parser_for_unknown_file(parent: &Frame, path: &Path, config: &ConfigMa
 	true
 }
 
-/// Close the active document and announce the change for screen readers.
+/// Close the active document, announcing the newly focused document for screen readers.
 ///
-/// The `set_selection` inside `close_document` fires `on_page_changed` while the
+/// The `set_selection` inside `close_document` fires `on_page_changing` while the
 /// caller holds the manager lock, so the generic switch announcement is suppressed
-/// and only this message speaks.
+/// and this function announces the new focus itself instead, before the focus change
+/// actually happens.
 fn close_active_document_announced(dm: &mut DocumentManager, live_region_label: StaticText) {
 	let Some(index) = dm.active_tab_index() else {
 		return;
 	};
-	let Some(tab) = dm.get_tab(index) else {
-		return;
-	};
-	let closed = display_title(tab);
-	let msg = match dm.active_index_after_closing(index).and_then(|i| dm.get_tab(i)) {
-		Some(next) => t("Closed {a}. Now on {b}.").replace("{a}", &closed).replace("{b}", &display_title(next)),
-		None => t("Closed {a}. No documents open.").replace("{a}", &closed),
-	};
-	live_region::announce(live_region_label, &msg);
+	let next = dm.active_index_after_closing(index).and_then(|i| dm.get_tab(i)).map(display_title);
+	if let Some(next) = &next {
+		live_region::announce(live_region_label, next);
+	}
 	dm.close_document(index, true);
 }
 


### PR DESCRIPTION
- Add a small `accessibility` module exposing `AccProps`/`AccessibleExt` for setting accessible name/role on any wxdragon widget
- Set `ROLE_PROPERTYPAGE` + the tab's title as accessible name on the three Options dialog tab panels, so screen readers announce them as pages on Ctrl+Tab
- Set the accessible name on each document tab's rich edit control to the document title. This ensures that switching between them with ctrl+tab announces the newly selected document properly.
Note that this only works on Windows, I'm too unfamiliar with Mac to see what might need changing there.
Also this slightly increases verbosity on the edit control because it mentions the title.