### PR TITLE
Parse and convert bold/italic/underline formatting across document formats

### DIFF
--- a/crates/paperback-core/src/document.rs
+++ b/crates/paperback-core/src/document.rs
@@ -34,6 +34,15 @@ impl From<MarkerType> for i32 {
 	}
 }
 
+/// Yields the character-formatting marker types implied by the given
+/// bold/italic/underline flags, in a stable order. Shared by the parsers so
+/// the flag-triple → marker fan-out lives in one place.
+pub(crate) fn format_marker_types(bold: bool, italic: bool, underline: bool) -> impl Iterator<Item = MarkerType> {
+	[(bold, MarkerType::Bold), (italic, MarkerType::Italic), (underline, MarkerType::Underline)]
+		.into_iter()
+		.filter_map(|(on, kind)| on.then_some(kind))
+}
+
 impl TryFrom<i32> for MarkerType {
 	type Error = ();
 

--- a/crates/paperback-core/src/export/html.rs
+++ b/crates/paperback-core/src/export/html.rs
@@ -170,6 +170,21 @@ pub fn render(doc: &DocumentHandle) -> String {
 				events.push(Ev { pos, kind: Ek::InlineOpen(open) });
 				events.push(Ev { pos: end, kind: Ek::InlineClose("</a>") });
 			}
+			MarkerType::Bold => {
+				let end = pos + marker.length;
+				events.push(Ev { pos, kind: Ek::InlineOpen("<b>".to_string()) });
+				events.push(Ev { pos: end, kind: Ek::InlineClose("</b>") });
+			}
+			MarkerType::Italic => {
+				let end = pos + marker.length;
+				events.push(Ev { pos, kind: Ek::InlineOpen("<i>".to_string()) });
+				events.push(Ev { pos: end, kind: Ek::InlineClose("</i>") });
+			}
+			MarkerType::Underline => {
+				let end = pos + marker.length;
+				events.push(Ev { pos, kind: Ek::InlineOpen("<u>".to_string()) });
+				events.push(Ev { pos: end, kind: Ek::InlineClose("</u>") });
+			}
 			MarkerType::List if marker.length > 0 => {
 				// Only emit a <ul> wrapper when an explicit length is available; without it
 				// we cannot determine where the list ends and bare <li> items are cleaner.
@@ -380,4 +395,135 @@ fn escape(s: &str) -> String {
 
 fn escape_attr(s: &str) -> String {
 	s.replace('&', "&amp;").replace('"', "&quot;")
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use crate::document::{Document, DocumentBuffer, DocumentHandle, Marker, MarkerType};
+
+	fn simple_doc(content: &str, markers: Vec<Marker>) -> DocumentHandle {
+		let mut buffer = DocumentBuffer::with_content(content.to_string());
+		for marker in markers {
+			buffer.add_marker(marker);
+		}
+		let mut doc = Document::new();
+		doc.set_buffer(buffer);
+		DocumentHandle::new(doc)
+	}
+
+	#[test]
+	fn test_bold_basic() {
+		let doc = simple_doc("bold text", vec![Marker::new(MarkerType::Bold, 0).with_length(4)]);
+		let html = render(&doc);
+		assert!(html.contains("<b>bold</b>"), "Expected <b>bold</b> in HTML: {}", html);
+	}
+
+	#[test]
+	fn test_italic_basic() {
+		let doc = simple_doc("italic text", vec![Marker::new(MarkerType::Italic, 0).with_length(6)]);
+		let html = render(&doc);
+		assert!(html.contains("<i>italic</i>"), "Expected <i>italic</i> in HTML: {}", html);
+	}
+
+	#[test]
+	fn test_underline_basic() {
+		let doc = simple_doc("underline text", vec![Marker::new(MarkerType::Underline, 0).with_length(9)]);
+		let html = render(&doc);
+		assert!(html.contains("<u>underline</u>"), "Expected <u>underline</u> in HTML: {}", html);
+	}
+
+	#[test]
+	fn test_nested_bold_italic() {
+		// "bold italic" where 0-4 is bold, 5-11 is italic (nested/overlapping)
+		let doc = simple_doc(
+			"bold italic",
+			vec![Marker::new(MarkerType::Bold, 0).with_length(4), Marker::new(MarkerType::Italic, 5).with_length(6)],
+		);
+		let html = render(&doc);
+		// Both tags should be present and properly ordered
+		assert!(html.contains("<b>bold</b>"), "Expected <b>bold</b> in HTML: {}", html);
+		assert!(html.contains("<i>italic</i>"), "Expected <i>italic</i> in HTML: {}", html);
+	}
+
+	#[test]
+	fn test_nested_same_start_different_end() {
+		// "bold italic" where 0-11 is bold, 0-6 is italic (nested: italic entirely inside bold)
+		let doc = simple_doc(
+			"bold italic",
+			vec![Marker::new(MarkerType::Bold, 0).with_length(11), Marker::new(MarkerType::Italic, 0).with_length(6)],
+		);
+		let html = render(&doc);
+		// Check both are present
+		assert!(html.contains("<b>"), "Expected <b> in HTML: {}", html);
+		assert!(html.contains("</b>"), "Expected </b> in HTML: {}", html);
+		assert!(html.contains("<i>"), "Expected <i> in HTML: {}", html);
+		assert!(html.contains("</i>"), "Expected </i> in HTML: {}", html);
+	}
+
+	#[test]
+	fn test_coincident_end_edge_case() {
+		// "text" where both bold and italic end at position 4
+		// This tests the pre-existing characteristic where non-perfectly-nested
+		// tags can occur based on insertion order in buffer.markers
+		let doc = simple_doc(
+			"text",
+			vec![Marker::new(MarkerType::Bold, 0).with_length(4), Marker::new(MarkerType::Italic, 0).with_length(4)],
+		);
+		let html = render(&doc);
+		// Both opens and closes should be present
+		// The order of closes may vary based on insertion order (pre-existing behavior)
+		assert!(html.contains("<b>"), "Expected <b> in HTML: {}", html);
+		assert!(html.contains("</b>"), "Expected </b> in HTML: {}", html);
+		assert!(html.contains("<i>"), "Expected <i> in HTML: {}", html);
+		assert!(html.contains("</i>"), "Expected </i> in HTML: {}", html);
+		// Count tags to verify they're paired
+		let b_open = html.matches("<b>").count();
+		let b_close = html.matches("</b>").count();
+		let i_open = html.matches("<i>").count();
+		let i_close = html.matches("</i>").count();
+		assert_eq!(b_open, b_close, "Bold tags should be paired");
+		assert_eq!(i_open, i_close, "Italic tags should be paired");
+		// Note: the tag nesting order depends on marker iteration order.
+		// The output might be <b><i>text</i></b> or <i><b>text</b></i> or
+		// </b></i> before </i></b> depending on which marker is processed first.
+		// This is acceptable per the task brief.
+	}
+
+	#[test]
+	fn test_multiple_separate_bold_spans() {
+		// "bold text normal more bold"
+		// Bold at 0-4 and 22-26
+		let doc = simple_doc(
+			"bold text normal more bold",
+			vec![Marker::new(MarkerType::Bold, 0).with_length(4), Marker::new(MarkerType::Bold, 22).with_length(4)],
+		);
+		let html = render(&doc);
+		// Should have two bold pairs
+		let b_open = html.matches("<b>").count();
+		let b_close = html.matches("</b>").count();
+		assert_eq!(b_open, 2, "Expected 2 <b> opens");
+		assert_eq!(b_close, 2, "Expected 2 </b> closes");
+	}
+
+	#[test]
+	fn test_bold_italic_underline_combined() {
+		// "text" with all three marker types
+		let doc = simple_doc(
+			"text",
+			vec![
+				Marker::new(MarkerType::Bold, 0).with_length(4),
+				Marker::new(MarkerType::Italic, 1).with_length(2),
+				Marker::new(MarkerType::Underline, 2).with_length(2),
+			],
+		);
+		let html = render(&doc);
+		// All tags should be present
+		assert!(html.contains("<b>"), "Expected <b> in HTML: {}", html);
+		assert!(html.contains("</b>"), "Expected </b> in HTML: {}", html);
+		assert!(html.contains("<i>"), "Expected <i> in HTML: {}", html);
+		assert!(html.contains("</i>"), "Expected </i> in HTML: {}", html);
+		assert!(html.contains("<u>"), "Expected <u> in HTML: {}", html);
+		assert!(html.contains("</u>"), "Expected </u> in HTML: {}", html);
+	}
 }

--- a/crates/paperback-core/src/export/markdown.rs
+++ b/crates/paperback-core/src/export/markdown.rs
@@ -10,6 +10,10 @@ pub fn render(doc: &Document) -> String {
 		Prefix(&'static str),
 		LinkOpen,
 		LinkClose(String),
+		BoldOpen,
+		BoldClose,
+		ItalicOpen,
+		ItalicClose,
 		// Replace `until` display-units of content with "\n---\n"
 		Replace { until: usize },
 	}
@@ -37,10 +41,23 @@ pub fn render(doc: &Document) -> String {
 				events.push(Ev { pos, kind: Mk::LinkOpen });
 				events.push(Ev { pos: end, kind: Mk::LinkClose(marker.reference.clone()) });
 			}
+			MarkerType::Bold => {
+				let end = pos + marker.length;
+				events.push(Ev { pos, kind: Mk::BoldOpen });
+				events.push(Ev { pos: end, kind: Mk::BoldClose });
+			}
+			MarkerType::Italic => {
+				let end = pos + marker.length;
+				events.push(Ev { pos, kind: Mk::ItalicOpen });
+				events.push(Ev { pos: end, kind: Mk::ItalicClose });
+			}
 			MarkerType::Separator => {
 				// Replace the dash line written into the content by html_to_text with "---"
 				events.push(Ev { pos, kind: Mk::Replace { until: pos + marker.length } });
 			}
+			// MarkerType::Underline intentionally has no arm: CommonMark has no native
+			// underline construct; falls through to the `_` arm below and is silently
+			// dropped from markdown output rather than emitting raw HTML `<u>`.
 			_ => {}
 		}
 	}
@@ -48,10 +65,10 @@ pub fn render(doc: &Document) -> String {
 	events.sort_by(|a, b| {
 		a.pos.cmp(&b.pos).then_with(|| {
 			let p = |k: &Mk| match k {
-				Mk::LinkClose(_) => 0u8,
+				Mk::LinkClose(_) | Mk::BoldClose | Mk::ItalicClose => 0u8,
 				Mk::Replace { .. } => 1,
 				Mk::Prefix(_) => 2,
-				Mk::LinkOpen => 3,
+				Mk::LinkOpen | Mk::BoldOpen | Mk::ItalicOpen => 3,
 			};
 			p(&a.kind).cmp(&p(&b.kind))
 		})
@@ -77,6 +94,8 @@ pub fn render(doc: &Document) -> String {
 						md.push(')');
 					}
 				}
+				Mk::BoldOpen | Mk::BoldClose => md.push_str("**"),
+				Mk::ItalicOpen | Mk::ItalicClose => md.push('*'),
 				Mk::Replace { until } => {
 					// Leading newline ensures "---" is never parsed as a setext heading underline
 					md.push_str("\n---\n");
@@ -95,15 +114,20 @@ pub fn render(doc: &Document) -> String {
 		md.push(ch);
 		display_pos += ch_width(ch);
 	}
-	// Flush any link closes that fall at or past end of content
+	// Flush any closes that fall at or past end of content
 	while event_idx < events.len() {
-		if let Mk::LinkClose(url) = &events[event_idx].kind {
-			md.push(']');
-			if !url.is_empty() {
-				md.push('(');
-				md.push_str(url);
-				md.push(')');
+		match &events[event_idx].kind {
+			Mk::LinkClose(url) => {
+				md.push(']');
+				if !url.is_empty() {
+					md.push('(');
+					md.push_str(url);
+					md.push(')');
+				}
 			}
+			Mk::BoldClose => md.push_str("**"),
+			Mk::ItalicClose => md.push('*'),
+			_ => {}
 		}
 		event_idx += 1;
 	}
@@ -130,4 +154,81 @@ fn normalize_newlines(s: String) -> String {
 		out.push('\n');
 	}
 	out
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use crate::document::{Document, DocumentBuffer, Marker, MarkerType};
+
+	fn simple_doc(content: &str, markers: Vec<Marker>) -> Document {
+		let mut buffer = DocumentBuffer::with_content(content.to_string());
+		for marker in markers {
+			buffer.add_marker(marker);
+		}
+		let mut doc = Document::new();
+		doc.set_buffer(buffer);
+		doc
+	}
+
+	#[test]
+	fn test_bold_basic() {
+		let doc = simple_doc("bold text", vec![Marker::new(MarkerType::Bold, 0).with_length(4)]);
+		let md = render(&doc);
+		assert!(md.contains("**bold**"), "Expected **bold** in markdown: {}", md);
+	}
+
+	#[test]
+	fn test_italic_basic() {
+		let doc = simple_doc("italic text", vec![Marker::new(MarkerType::Italic, 0).with_length(6)]);
+		let md = render(&doc);
+		assert!(md.contains("*italic*"), "Expected *italic* in markdown: {}", md);
+	}
+
+	#[test]
+	fn test_underline_produces_no_syntax() {
+		let doc = simple_doc("underline text", vec![Marker::new(MarkerType::Underline, 0).with_length(9)]);
+		let md = render(&doc);
+		// The text should still appear, but without any markdown syntax
+		assert!(md.contains("underline"), "Expected text 'underline' in markdown: {}", md);
+		// No underline syntax should be present
+		assert!(!md.contains("__"), "Expected no __ syntax for underline");
+		assert!(!md.contains("_underline_"), "Expected no _underline_ italic-like syntax");
+		// No HTML-like underline either
+		assert!(!md.contains("<u>"), "Expected no <u> HTML in markdown output");
+	}
+
+	#[test]
+	fn test_nested_bold_italic() {
+		// "bold italic" where 0-4 is bold, 5-11 is italic
+		let doc = simple_doc(
+			"bold italic",
+			vec![Marker::new(MarkerType::Bold, 0).with_length(4), Marker::new(MarkerType::Italic, 5).with_length(6)],
+		);
+		let md = render(&doc);
+		assert!(md.contains("**bold**"), "Expected **bold** in markdown: {}", md);
+		assert!(md.contains("*italic*"), "Expected *italic* in markdown: {}", md);
+	}
+
+	#[test]
+	fn test_bold_close_at_end_of_content() {
+		// Test that a bold span ending exactly at end-of-content doesn't lose its closing **
+		let doc = simple_doc("bold", vec![Marker::new(MarkerType::Bold, 0).with_length(4)]);
+		let md = render(&doc);
+		assert!(md.contains("**bold**"), "Expected **bold** in markdown with closing **: {}", md);
+		// Count ** to verify both open and close are present
+		let count = md.matches("**").count();
+		assert_eq!(count, 2, "Expected exactly 2 occurrences of ** (open and close)");
+	}
+
+	#[test]
+	fn test_italic_close_at_end_of_content() {
+		// Test that an italic span ending exactly at end-of-content doesn't lose its closing *
+		let doc = simple_doc("italic", vec![Marker::new(MarkerType::Italic, 0).with_length(6)]);
+		let md = render(&doc);
+		assert!(md.contains("*italic*"), "Expected *italic* in markdown with closing *: {}", md);
+		// Count * to verify both open and close are present (should be 2)
+		let count = md.matches("*").count();
+		assert_eq!(count, 2, "Expected exactly 2 occurrences of * (open and close)");
+	}
 }

--- a/crates/paperback-core/src/parser/html_to_text.rs
+++ b/crates/paperback-core/src/parser/html_to_text.rs
@@ -716,6 +716,7 @@ mod tests {
 	use rstest::rstest;
 
 	use super::*;
+	use crate::document::MarkerType;
 
 	/// End-to-end: the HtmlToText converter emits each table's on-screen text at parse time, and a
 	/// heading that follows the table is offset by the emitted display extent. Verified in both
@@ -784,6 +785,73 @@ mod tests {
 		assert_eq!(links[0].text, "Hello world");
 		assert_eq!(links[0].reference, "https://example.com");
 		assert_eq!(converter.get_text(), "Hello world");
+	}
+
+	#[rstest]
+	#[case("b", MarkerType::Bold)]
+	#[case("strong", MarkerType::Bold)]
+	#[case("i", MarkerType::Italic)]
+	#[case("em", MarkerType::Italic)]
+	#[case("u", MarkerType::Underline)]
+	fn test_format_span_collection(#[case] tag: &str, #[case] kind: MarkerType) {
+		let html = format!("<html><body><p>Some <{tag}>bold</{tag}> text</p></body></html>");
+		let mut converter = HtmlToText::new();
+		assert!(converter.convert(&html, HtmlSourceMode::NativeHtml));
+		let spans = match kind {
+			MarkerType::Bold => converter.get_bolds(),
+			MarkerType::Italic => converter.get_italics(),
+			MarkerType::Underline => converter.get_underlines(),
+			_ => unreachable!(),
+		};
+		assert_eq!(spans.len(), 1);
+		let text = converter.get_text();
+		assert_eq!(&text[spans[0].offset..spans[0].offset + spans[0].length], "bold");
+	}
+
+	#[test]
+	fn test_format_span_nested_bold_and_italic() {
+		let html = "<html><body><p><b>outer <i>inner</i></b></p></body></html>";
+		let mut converter = HtmlToText::new();
+		assert!(converter.convert(html, HtmlSourceMode::NativeHtml));
+		let text = converter.get_text();
+
+		let italics = converter.get_italics();
+		assert_eq!(italics.len(), 1);
+		assert_eq!(&text[italics[0].offset..italics[0].offset + italics[0].length], "inner");
+
+		let bolds = converter.get_bolds();
+		assert_eq!(bolds.len(), 1);
+		assert_eq!(&text[bolds[0].offset..bolds[0].offset + bolds[0].length], "outer inner");
+	}
+
+	#[test]
+	fn test_format_span_fully_inside_link_is_dropped_known_limitation() {
+		// Known limitation: text inside an `<a>` is buffered in `current_link_text` and only
+		// pushed into `current_line` on `</a>` (see `handle_text_node`/`handle_element_closing`),
+		// so `get_current_text_position()` does not advance while inside a link. A `<b>`/`<i>`/`<u>`
+		// that opens and closes fully inside an `<a>` therefore sees `start == end` and is recorded
+		// as a zero-length span rather than spanning the link's text. This degrades gracefully (no
+		// panic, no bad offset; the link itself is still recorded correctly) rather than corrupting
+		// data, so it is left as-is (no changes to the `<a>` deferred-buffering behavior).
+		let html = "<html><body><a href=\"https://example.com\"><b>bold</b></a></body></html>";
+		let mut converter = HtmlToText::new();
+		assert!(converter.convert(html, HtmlSourceMode::NativeHtml));
+		let bolds = converter.get_bolds();
+		assert_eq!(bolds.len(), 1);
+		assert_eq!(bolds[0].length, 0);
+		let links = converter.get_links();
+		assert_eq!(links.len(), 1);
+		assert_eq!(links[0].text, "bold");
+	}
+
+	#[test]
+	fn test_no_format_spans_without_formatting_tags() {
+		let html = "<html><body><p>Plain paragraph with no formatting.</p></body></html>";
+		let mut converter = HtmlToText::new();
+		assert!(converter.convert(html, HtmlSourceMode::NativeHtml));
+		assert!(converter.get_bolds().is_empty());
+		assert!(converter.get_italics().is_empty());
+		assert!(converter.get_underlines().is_empty());
 	}
 
 	#[test]

--- a/crates/paperback-core/src/parser/odt.rs
+++ b/crates/paperback-core/src/parser/odt.rs
@@ -40,9 +40,10 @@ impl Parser for OdtParser {
 		let content_str = read_zip_entry_by_name(&mut archive, "content.xml")
 			.context("ODT file does not contain content.xml or it is empty")?;
 		let xml_doc = XmlDocument::parse(&content_str).context("Invalid ODT content.xml")?;
+		let format_style_map = build_odt_format_style_map(xml_doc.root());
 		let mut buffer = DocumentBuffer::new();
 		let mut id_positions = HashMap::new();
-		traverse(xml_doc.root(), &mut buffer, &mut id_positions, context.render_tables_inline);
+		traverse(xml_doc.root(), &mut buffer, &mut id_positions, context.render_tables_inline, &format_style_map);
 		let title = extract_title_from_path(&context.file_path);
 		let toc_items = build_toc_from_buffer(&buffer);
 		let mut document = Document::new().with_title(title);
@@ -72,9 +73,10 @@ impl Parser for FodtParser {
 		let content_str = fs::read_to_string(&context.file_path)
 			.with_context(|| format!("Failed to open FODT file '{}'", context.file_path))?;
 		let xml_doc = XmlDocument::parse(&content_str).context("Invalid FODT document")?;
+		let format_style_map = build_odt_format_style_map(xml_doc.root());
 		let mut buffer = DocumentBuffer::new();
 		let mut id_positions = HashMap::new();
-		traverse(xml_doc.root(), &mut buffer, &mut id_positions, context.render_tables_inline);
+		traverse(xml_doc.root(), &mut buffer, &mut id_positions, context.render_tables_inline, &format_style_map);
 		let title = extract_title_from_path(&context.file_path);
 		let toc_items = build_toc_from_buffer(&buffer);
 		let mut document = Document::new().with_title(title);
@@ -85,11 +87,45 @@ impl Parser for FodtParser {
 	}
 }
 
+/// Builds a style-name → `(bold, italic, underline)` map from `<office:automatic-styles>` /
+/// `<style:style style:family="text">` entries, so that `<text:span text:style-name="...">`
+/// elements encountered during traversal can be resolved to direct character formatting.
+fn build_odt_format_style_map(root: Node) -> HashMap<String, (bool, bool, bool)> {
+	let mut map = HashMap::new();
+	let Some(automatic_styles) =
+		root.descendants().find(|n| n.is_element() && n.tag_name().name() == "automatic-styles")
+	else {
+		return map;
+	};
+	for style_node in automatic_styles.children() {
+		if !style_node.is_element() || style_node.tag_name().name() != "style" {
+			continue;
+		}
+		if style_node.attribute("family") != Some("text") {
+			continue;
+		}
+		let Some(name) = style_node.attribute("name") else { continue };
+		let Some(text_props) =
+			style_node.children().find(|n| n.is_element() && n.tag_name().name() == "text-properties")
+		else {
+			continue;
+		};
+		let bold = text_props.attribute("font-weight").is_some_and(|v| v == "bold");
+		let italic = text_props.attribute("font-style").is_some_and(|v| v == "italic");
+		let underline = text_props.attribute("text-underline-style").is_some_and(|v| v != "none");
+		if bold || italic || underline {
+			map.insert(name.to_string(), (bold, italic, underline));
+		}
+	}
+	map
+}
+
 fn traverse(
 	node: Node,
 	buffer: &mut DocumentBuffer,
 	id_positions: &mut HashMap<String, usize>,
 	render_tables_inline: bool,
+	format_style_map: &HashMap<String, (bool, bool, bool)>,
 ) {
 	if node.node_type() == NodeType::Element {
 		let tag_name = node.tag_name().name();
@@ -106,7 +142,7 @@ fn traverse(
 			return; // Don't traverse children, we already got the text
 		}
 		if tag_name == "p" {
-			traverse_children(node, buffer, id_positions, render_tables_inline);
+			traverse_children(node, buffer, id_positions, render_tables_inline, format_style_map);
 			buffer.append("\n");
 			return;
 		}
@@ -128,6 +164,27 @@ fn traverse(
 		if let Some(id) = node.attribute("id") {
 			id_positions.insert(id.to_string(), buffer.current_position());
 		}
+		if tag_name == "span"
+			&& let Some(style_name) = node.attribute("style-name")
+			&& let Some(&(bold, italic, underline)) = format_style_map.get(style_name)
+			&& (bold || italic || underline)
+		{
+			let start = buffer.current_position();
+			traverse_children(node, buffer, id_positions, render_tables_inline, format_style_map);
+			let end = buffer.current_position();
+			if end > start {
+				if bold {
+					buffer.add_marker(Marker::new(MarkerType::Bold, start).with_length(end - start));
+				}
+				if italic {
+					buffer.add_marker(Marker::new(MarkerType::Italic, start).with_length(end - start));
+				}
+				if underline {
+					buffer.add_marker(Marker::new(MarkerType::Underline, start).with_length(end - start));
+				}
+			}
+			return;
+		}
 		if tag_name == "table" {
 			process_table(node, buffer, id_positions, render_tables_inline);
 			return;
@@ -138,7 +195,7 @@ fn traverse(
 		}
 		return;
 	}
-	traverse_children(node, buffer, id_positions, render_tables_inline);
+	traverse_children(node, buffer, id_positions, render_tables_inline, format_style_map);
 }
 
 fn traverse_children(
@@ -146,9 +203,10 @@ fn traverse_children(
 	buffer: &mut DocumentBuffer,
 	id_positions: &mut HashMap<String, usize>,
 	render_tables_inline: bool,
+	format_style_map: &HashMap<String, (bool, bool, bool)>,
 ) {
 	for child in node.children() {
-		traverse(child, buffer, id_positions, render_tables_inline);
+		traverse(child, buffer, id_positions, render_tables_inline, format_style_map);
 	}
 }
 
@@ -223,7 +281,7 @@ mod tests {
 
 	use roxmltree::Document as XmlDocument;
 
-	use super::traverse;
+	use super::{build_odt_format_style_map, traverse};
 	use crate::{
 		document::{DocumentBuffer, MarkerType},
 		util::text::display_len,
@@ -238,7 +296,8 @@ mod tests {
 		let xml_doc = XmlDocument::parse(xml).expect("valid xml");
 		let mut buffer = DocumentBuffer::new();
 		let mut id_positions = HashMap::new();
-		traverse(xml_doc.root(), &mut buffer, &mut id_positions, false);
+		let format_style_map = HashMap::new();
+		traverse(xml_doc.root(), &mut buffer, &mut id_positions, false, &format_style_map);
 
 		assert_eq!(buffer.content, "[Table]: Kop \u{1D11E}\n");
 		let table_marker = buffer.markers.iter().find(|m| m.mtype == MarkerType::Table).expect("Table marker");
@@ -255,10 +314,11 @@ mod tests {
 	fn odt_table_cell_id_registered_at_table_start() {
 		let xml = "<document><p>before</p><table><table-row><table-cell><span id=\"anchor1\">Kop</span></table-cell></table-row></table></document>";
 		let xml_doc = XmlDocument::parse(xml).expect("valid xml");
+		let format_style_map = HashMap::new();
 		for inline in [false, true] {
 			let mut buffer = DocumentBuffer::new();
 			let mut id_positions = HashMap::new();
-			traverse(xml_doc.root(), &mut buffer, &mut id_positions, inline);
+			traverse(xml_doc.root(), &mut buffer, &mut id_positions, inline, &format_style_map);
 			let table_marker = buffer.markers.iter().find(|m| m.mtype == MarkerType::Table).expect("Table marker");
 			assert_eq!(
 				id_positions.get("anchor1"),
@@ -275,10 +335,124 @@ mod tests {
 		let xml_doc = XmlDocument::parse(xml).expect("valid xml");
 		let mut buffer = DocumentBuffer::new();
 		let mut id_positions = HashMap::new();
-		traverse(xml_doc.root(), &mut buffer, &mut id_positions, true);
+		let format_style_map = HashMap::new();
+		traverse(xml_doc.root(), &mut buffer, &mut id_positions, true, &format_style_map);
 
 		assert_eq!(buffer.content, "Kop\t\u{1D11E}\n");
 		let table_marker = buffer.markers.iter().find(|m| m.mtype == MarkerType::Table).expect("Table marker");
 		assert_eq!(table_marker.length, display_len("Kop\t\u{1D11E}") + 1, "marker length spans the TSV");
+	}
+
+	/// Builds the standard test fixture: an `<automatic-styles>` block defining style `"T1"` with the
+	/// given text-properties attribute (name, value), wrapping a `<span style-name="T1">` around
+	/// `text`. Uses bare/local tag and attribute names — this file's roxmltree usage strips namespace
+	/// prefixes, so test XML omits them too, matching real ODT content.xml parsing.
+	fn span_fixture(prop_name: &str, prop_value: &str, text: &str) -> String {
+		format!(
+			"<document><automatic-styles><style family=\"text\" name=\"T1\"><text-properties {prop_name}=\"{prop_value}\"/></style></automatic-styles><p><span style-name=\"T1\">{text}</span></p></document>"
+		)
+	}
+
+	fn traverse_fixture(xml: &str) -> DocumentBuffer {
+		let xml_doc = XmlDocument::parse(xml).expect("valid xml");
+		let format_style_map = build_odt_format_style_map(xml_doc.root());
+		let mut buffer = DocumentBuffer::new();
+		let mut id_positions = HashMap::new();
+		traverse(xml_doc.root(), &mut buffer, &mut id_positions, false, &format_style_map);
+		buffer
+	}
+
+	#[test]
+	fn odt_span_bold_style_adds_bold_marker() {
+		let xml = span_fixture("font-weight", "bold", "bold text");
+		let buffer = traverse_fixture(&xml);
+
+		assert_eq!(buffer.content, "bold text\n");
+		let marker = buffer.markers.iter().find(|m| m.mtype == MarkerType::Bold).expect("Bold marker");
+		assert_eq!(marker.position, 0);
+		assert_eq!(marker.length, display_len("bold text"));
+		assert!(buffer.markers.iter().all(|m| m.mtype != MarkerType::Italic && m.mtype != MarkerType::Underline));
+	}
+
+	#[test]
+	fn odt_span_italic_style_adds_italic_marker() {
+		let xml = span_fixture("font-style", "italic", "italic text");
+		let buffer = traverse_fixture(&xml);
+
+		assert_eq!(buffer.content, "italic text\n");
+		let marker = buffer.markers.iter().find(|m| m.mtype == MarkerType::Italic).expect("Italic marker");
+		assert_eq!(marker.position, 0);
+		assert_eq!(marker.length, display_len("italic text"));
+		assert!(buffer.markers.iter().all(|m| m.mtype != MarkerType::Bold && m.mtype != MarkerType::Underline));
+	}
+
+	#[test]
+	fn odt_span_underline_solid_style_adds_underline_marker() {
+		let xml = span_fixture("text-underline-style", "solid", "underlined text");
+		let buffer = traverse_fixture(&xml);
+
+		assert_eq!(buffer.content, "underlined text\n");
+		let marker = buffer.markers.iter().find(|m| m.mtype == MarkerType::Underline).expect("Underline marker");
+		assert_eq!(marker.position, 0);
+		assert_eq!(marker.length, display_len("underlined text"));
+		assert!(buffer.markers.iter().all(|m| m.mtype != MarkerType::Bold && m.mtype != MarkerType::Italic));
+	}
+
+	#[test]
+	fn odt_span_underline_none_style_adds_no_underline_marker() {
+		let xml = span_fixture("text-underline-style", "none", "plain text");
+		let buffer = traverse_fixture(&xml);
+
+		assert_eq!(buffer.content, "plain text\n");
+		assert!(
+			buffer.markers.iter().all(|m| m.mtype != MarkerType::Underline),
+			"text-underline-style=none must not be treated as underlined"
+		);
+	}
+
+	#[test]
+	fn odt_span_combined_bold_and_italic_style_adds_both_markers() {
+		let xml = "<document><automatic-styles><style family=\"text\" name=\"T1\"><text-properties font-weight=\"bold\" font-style=\"italic\"/></style></automatic-styles><p><span style-name=\"T1\">both</span></p></document>";
+		let buffer = traverse_fixture(xml);
+
+		assert_eq!(buffer.content, "both\n");
+		let bold = buffer.markers.iter().find(|m| m.mtype == MarkerType::Bold).expect("Bold marker");
+		let italic = buffer.markers.iter().find(|m| m.mtype == MarkerType::Italic).expect("Italic marker");
+		assert_eq!(bold.position, 0);
+		assert_eq!(bold.length, display_len("both"));
+		assert_eq!(italic.position, 0);
+		assert_eq!(italic.length, display_len("both"));
+		assert!(buffer.markers.iter().all(|m| m.mtype != MarkerType::Underline));
+	}
+
+	/// A span with no matching/known style-name (or a style resolving to no formatting) falls through
+	/// to exactly today's behavior: text renders, but no bold/italic/underline marker is added.
+	#[test]
+	fn odt_span_with_unknown_style_falls_through_unformatted() {
+		let xml = "<document><automatic-styles><style family=\"text\" name=\"T1\"><text-properties font-weight=\"bold\"/></style></automatic-styles><p><span style-name=\"Unknown\">plain</span></p></document>";
+		let buffer = traverse_fixture(xml);
+
+		assert_eq!(buffer.content, "plain\n");
+		assert!(
+			buffer.markers.iter().all(|m| m.mtype != MarkerType::Bold
+				&& m.mtype != MarkerType::Italic
+				&& m.mtype != MarkerType::Underline),
+			"unknown style-name must not add any formatting marker"
+		);
+	}
+
+	/// A span with no `style-name` attribute at all also falls through unformatted.
+	#[test]
+	fn odt_span_without_style_name_falls_through_unformatted() {
+		let xml = "<document><p><span>plain</span></p></document>";
+		let buffer = traverse_fixture(xml);
+
+		assert_eq!(buffer.content, "plain\n");
+		assert!(
+			buffer.markers.iter().all(|m| m.mtype != MarkerType::Bold
+				&& m.mtype != MarkerType::Italic
+				&& m.mtype != MarkerType::Underline),
+			"span without style-name must not add any formatting marker"
+		);
 	}
 }

--- a/crates/paperback-core/src/parser/odt.rs
+++ b/crates/paperback-core/src/parser/odt.rs
@@ -5,7 +5,7 @@ use roxmltree::{Document as XmlDocument, Node, NodeType};
 use zip::ZipArchive;
 
 use crate::{
-	document::{Document, DocumentBuffer, Marker, MarkerType, ParserContext, ParserFlags},
+	document::{Document, DocumentBuffer, Marker, MarkerType, ParserContext, ParserFlags, format_marker_types},
 	parser::{
 		Parser,
 		util::{
@@ -173,14 +173,8 @@ fn traverse(
 			traverse_children(node, buffer, id_positions, render_tables_inline, format_style_map);
 			let end = buffer.current_position();
 			if end > start {
-				if bold {
-					buffer.add_marker(Marker::new(MarkerType::Bold, start).with_length(end - start));
-				}
-				if italic {
-					buffer.add_marker(Marker::new(MarkerType::Italic, start).with_length(end - start));
-				}
-				if underline {
-					buffer.add_marker(Marker::new(MarkerType::Underline, start).with_length(end - start));
+				for kind in format_marker_types(bold, italic, underline) {
+					buffer.add_marker(Marker::new(kind, start).with_length(end - start));
 				}
 			}
 			return;

--- a/crates/paperback-core/src/parser/rtf.rs
+++ b/crates/paperback-core/src/parser/rtf.rs
@@ -368,6 +368,32 @@ const fn hex_digit(b: u8) -> Option<u8> {
 	}
 }
 
+/// Applies a formatting toggle for a single marker kind, recording spans as they
+/// open and close. No-op when the requested state already matches the current one
+/// (handles redundant toggles and group-close reverts that don't change this kind).
+/// Turning ON records the start position; turning OFF emits the span, guarded by
+/// `position > s` to skip degenerate zero-length spans.
+fn apply_format_toggle(
+	on: &mut bool,
+	start: &mut Option<usize>,
+	want_on: bool,
+	position: usize,
+	kind: MarkerType,
+	buffer: &mut DocumentBuffer,
+) {
+	if want_on == *on {
+		return;
+	}
+	if want_on {
+		*start = Some(position);
+	} else if let Some(s) = start.take()
+		&& position > s
+	{
+		buffer.add_marker(Marker::new(kind, s).with_length(position - s));
+	}
+	*on = want_on;
+}
+
 #[allow(clippy::too_many_lines)]
 fn extract_content_from_tokens(tokens: &[Token]) -> DocumentBuffer {
 	let mut buffer = DocumentBuffer::new();
@@ -376,12 +402,44 @@ fn extract_content_from_tokens(tokens: &[Token]) -> DocumentBuffer {
 	let mut pending_link: Option<PendingLink> = None;
 	let mut depth: i32 = 0;
 	let mut skip_until_depth: Option<i32> = None;
+	let mut bold_on = false;
+	let mut italic_on = false;
+	let mut underline_on = false;
+	let mut bold_start: Option<usize> = None;
+	let mut italic_start: Option<usize> = None;
+	let mut underline_start: Option<usize> = None;
+	let mut format_stack: Vec<(bool, bool, bool)> = Vec::new();
 	for token in tokens {
 		// Depth tracking for group nesting (needed for IgnorableDestination skipping).
 		match token {
-			Token::OpeningBracket => depth += 1,
+			Token::OpeningBracket => {
+				depth += 1;
+				// Snapshot formatting state so a group close reverts to it (RTF group scoping).
+				// Push/pop happen unconditionally to stay in lockstep with `depth`.
+				format_stack.push((bold_on, italic_on, underline_on));
+			}
 			Token::ClosingBracket => {
 				depth -= 1;
+				if let Some((want_bold, want_italic, want_underline)) = format_stack.pop() {
+					let pos = buffer.current_position();
+					apply_format_toggle(&mut bold_on, &mut bold_start, want_bold, pos, MarkerType::Bold, &mut buffer);
+					apply_format_toggle(
+						&mut italic_on,
+						&mut italic_start,
+						want_italic,
+						pos,
+						MarkerType::Italic,
+						&mut buffer,
+					);
+					apply_format_toggle(
+						&mut underline_on,
+						&mut underline_start,
+						want_underline,
+						pos,
+						MarkerType::Underline,
+						&mut buffer,
+					);
+				}
 				if skip_until_depth.is_some_and(|sd| depth <= sd) {
 					skip_until_depth = None;
 				}
@@ -444,6 +502,49 @@ fn extract_content_from_tokens(tokens: &[Token]) -> DocumentBuffer {
 							}
 						}
 					}
+					ControlWord::Bold if !in_header => {
+						let want_on = !matches!(property, Property::Value(0));
+						apply_format_toggle(
+							&mut bold_on,
+							&mut bold_start,
+							want_on,
+							buffer.current_position(),
+							MarkerType::Bold,
+							&mut buffer,
+						);
+					}
+					ControlWord::Italic if !in_header => {
+						let want_on = !matches!(property, Property::Value(0));
+						apply_format_toggle(
+							&mut italic_on,
+							&mut italic_start,
+							want_on,
+							buffer.current_position(),
+							MarkerType::Italic,
+							&mut buffer,
+						);
+					}
+					ControlWord::Underline if !in_header => {
+						let want_on = !matches!(property, Property::Value(0));
+						apply_format_toggle(
+							&mut underline_on,
+							&mut underline_start,
+							want_on,
+							buffer.current_position(),
+							MarkerType::Underline,
+							&mut buffer,
+						);
+					}
+					ControlWord::UnderlineNone if !in_header => {
+						apply_format_toggle(
+							&mut underline_on,
+							&mut underline_start,
+							false,
+							buffer.current_position(),
+							MarkerType::Underline,
+							&mut buffer,
+						);
+					}
 					ControlWord::Unknown(name) if !in_header => match *name {
 						r"\page" => {
 							let ends_with_ws = buffer.content.chars().next_back().is_some_and(char::is_whitespace);
@@ -489,6 +590,13 @@ fn extract_content_from_tokens(tokens: &[Token]) -> DocumentBuffer {
 			_ => {}
 		}
 	}
+	// Defensive flush for malformed/truncated RTF with unbalanced braces. In a
+	// well-formed document the outermost group close already reverted all three to
+	// `false` (step 3), so this is a no-op in the common case.
+	let final_pos = buffer.current_position();
+	apply_format_toggle(&mut bold_on, &mut bold_start, false, final_pos, MarkerType::Bold, &mut buffer);
+	apply_format_toggle(&mut italic_on, &mut italic_start, false, final_pos, MarkerType::Italic, &mut buffer);
+	apply_format_toggle(&mut underline_on, &mut underline_start, false, final_pos, MarkerType::Underline, &mut buffer);
 	let trimmed = buffer.content.trim().to_string();
 	let mut result = DocumentBuffer::with_content(trimmed);
 	let leading_trim = buffer.content.len() - buffer.content.trim_start().len();
@@ -715,5 +823,123 @@ mod tests {
 		assert!(buffer.content.contains("decisão"));
 		assert!(buffer.content.contains("execução"));
 		assert!(buffer.content.contains("2ª executada"));
+	}
+
+	#[test]
+	fn extract_content_maps_bold_toggle_to_marker() {
+		// \b bold \b0 not-bold  → one Bold marker spanning exactly "bold ".
+		let tokens = vec![
+			Token::ControlSymbol((ControlWord::Pard, Property::None)),
+			Token::ControlSymbol((ControlWord::Bold, Property::None)),
+			Token::PlainText("bold "),
+			Token::ControlSymbol((ControlWord::Bold, Property::Value(0))),
+			Token::PlainText("not-bold"),
+		];
+		let buffer = extract_content_from_tokens(&tokens);
+		assert_eq!(buffer.content, "bold not-bold");
+		let bold: Vec<_> = buffer.markers.iter().filter(|m| m.mtype == MarkerType::Bold).collect();
+		assert_eq!(bold.len(), 1);
+		assert_eq!(bold[0].position, 0);
+		assert_eq!(bold[0].length, "bold ".chars().count());
+	}
+
+	#[test]
+	fn extract_content_scopes_nested_group_formatting() {
+		// \b bold {\i more} still-bold \b0
+		// Bold spans the whole "bold more still-bold " (uninterrupted by the group);
+		// Italic spans only "more" (opened and closed within the group).
+		let tokens = vec![
+			Token::ControlSymbol((ControlWord::Pard, Property::None)),
+			Token::ControlSymbol((ControlWord::Bold, Property::None)),
+			Token::PlainText("bold "),
+			Token::OpeningBracket,
+			Token::ControlSymbol((ControlWord::Italic, Property::None)),
+			Token::PlainText("more"),
+			Token::ClosingBracket,
+			Token::PlainText(" still-bold "),
+			Token::ControlSymbol((ControlWord::Bold, Property::Value(0))),
+		];
+		let buffer = extract_content_from_tokens(&tokens);
+		assert_eq!(buffer.content, "bold more still-bold");
+
+		let bold: Vec<_> = buffer.markers.iter().filter(|m| m.mtype == MarkerType::Bold).collect();
+		assert_eq!(bold.len(), 1);
+		assert_eq!(bold[0].position, 0);
+		assert_eq!(bold[0].length, "bold more still-bold ".chars().count());
+
+		let italic: Vec<_> = buffer.markers.iter().filter(|m| m.mtype == MarkerType::Italic).collect();
+		assert_eq!(italic.len(), 1);
+		assert_eq!(italic[0].position, "bold ".chars().count());
+		assert_eq!(italic[0].length, "more".chars().count());
+	}
+
+	#[test]
+	fn extract_content_maps_underline_off_via_ulnone() {
+		// \ul under \ulnone plain → one Underline marker spanning "under ".
+		let tokens = vec![
+			Token::ControlSymbol((ControlWord::Pard, Property::None)),
+			Token::ControlSymbol((ControlWord::Underline, Property::None)),
+			Token::PlainText("under "),
+			Token::ControlSymbol((ControlWord::UnderlineNone, Property::None)),
+			Token::PlainText("plain"),
+		];
+		let buffer = extract_content_from_tokens(&tokens);
+		assert_eq!(buffer.content, "under plain");
+		let underline: Vec<_> = buffer.markers.iter().filter(|m| m.mtype == MarkerType::Underline).collect();
+		assert_eq!(underline.len(), 1);
+		assert_eq!(underline[0].position, 0);
+		assert_eq!(underline[0].length, "under ".chars().count());
+	}
+
+	#[test]
+	fn extract_content_reverts_bold_on_group_close() {
+		// \b before {\b0 middle} after \b0
+		// Two separate Bold markers ("before " and " after "), "middle" in neither.
+		let tokens = vec![
+			Token::ControlSymbol((ControlWord::Pard, Property::None)),
+			Token::ControlSymbol((ControlWord::Bold, Property::None)),
+			Token::PlainText("before "),
+			Token::OpeningBracket,
+			Token::ControlSymbol((ControlWord::Bold, Property::Value(0))),
+			Token::PlainText("middle"),
+			Token::ClosingBracket,
+			Token::PlainText(" after "),
+			Token::ControlSymbol((ControlWord::Bold, Property::Value(0))),
+		];
+		let buffer = extract_content_from_tokens(&tokens);
+		assert_eq!(buffer.content, "before middle after");
+
+		let bold: Vec<_> = buffer.markers.iter().filter(|m| m.mtype == MarkerType::Bold).collect();
+		assert_eq!(bold.len(), 2, "expected two Bold spans, got {bold:?}");
+		// "before "
+		assert_eq!(bold[0].position, 0);
+		assert_eq!(bold[0].length, "before ".chars().count());
+		// " after " starts right after "before middle"
+		assert_eq!(bold[1].position, "before middle".chars().count());
+		assert_eq!(bold[1].length, " after ".chars().count());
+		// "middle" is covered by neither span.
+		let middle_start = "before ".chars().count();
+		let middle_end = "before middle".chars().count();
+		for m in &bold {
+			let span_end = m.position + m.length;
+			assert!(
+				m.position >= middle_end || span_end <= middle_start,
+				"Bold span {m:?} should not overlap \"middle\""
+			);
+		}
+	}
+
+	#[test]
+	fn extract_content_renders_bold_from_real_rtf_string() {
+		// Round-trip through the real lexer to confirm \b / \b0 map to Bold markers.
+		let rtf = r"{\rtf1\ansi\pard normal \b bold\b0  normal}";
+		let normalized = resolve_hex_escapes(rtf, encoding_rs::WINDOWS_1252, &HashMap::new()).replace('\r', "");
+		let tokens = Lexer::scan(&normalized).expect("RTF tokenization should succeed");
+		let buffer = extract_content_from_tokens(&tokens);
+		assert_eq!(buffer.content, "normal bold normal");
+		let bold: Vec<_> = buffer.markers.iter().filter(|m| m.mtype == MarkerType::Bold).collect();
+		assert_eq!(bold.len(), 1);
+		assert_eq!(bold[0].position, "normal ".chars().count());
+		assert_eq!(bold[0].length, "bold".chars().count());
 	}
 }

--- a/crates/paperback-core/src/parser/word.rs
+++ b/crates/paperback-core/src/parser/word.rs
@@ -13,7 +13,7 @@ use roxmltree::{Document as XmlDocument, Node, NodeType};
 use zip::ZipArchive;
 
 use crate::{
-	document::{Document, DocumentBuffer, Marker, MarkerType, ParserContext, ParserFlags},
+	document::{Document, DocumentBuffer, Marker, MarkerType, ParserContext, ParserFlags, format_marker_types},
 	parser::{
 		PASSWORD_REQUIRED_ERROR_PREFIX, Parser,
 		util::{
@@ -598,6 +598,7 @@ fn process_paragraph(
 ) {
 	let paragraph_start = buffer.current_position();
 	let mut paragraph_text = String::new();
+	let mut para_display_len = 0usize;
 	let mut heading_level = 0;
 	let mut is_paragraph_style_heading = false;
 	let mut format_spans: Vec<(MarkerType, usize, usize)> = Vec::new();
@@ -616,7 +617,7 @@ fn process_paragraph(
 				id_positions.insert(name.to_string(), paragraph_start + paragraph_text.len());
 			}
 		} else if tag_name == "hyperlink" {
-			process_hyperlink(child, &mut paragraph_text, buffer, rels, paragraph_start);
+			para_display_len += process_hyperlink(child, &mut paragraph_text, buffer, rels, paragraph_start);
 		} else if tag_name == "r" {
 			if heading_level == 0
 				&& let Some(rpr_node) = find_child_element(child, "rPr")
@@ -633,6 +634,7 @@ fn process_paragraph(
 					if !display_text.is_empty() {
 						let link_offset = paragraph_start + paragraph_text.len();
 						paragraph_text.push_str(&display_text);
+						para_display_len += display_len(&display_text);
 						buffer.add_marker(
 							Marker::new(MarkerType::Link, link_offset)
 								.with_text(display_text.clone())
@@ -643,23 +645,19 @@ fn process_paragraph(
 			}
 			let run_text = collect_ooxml_run_text(child);
 			if !run_text.is_empty() {
-				let run_start = paragraph_start + display_len(&paragraph_text);
+				let run_start = paragraph_start + para_display_len;
+				let run_len = display_len(&run_text);
 				if let Some(rpr_node) = find_child_element(child, "rPr") {
 					let (bold, italic, underline) = get_run_format_flags(rpr_node);
-					let run_end = run_start + display_len(&run_text);
+					let run_end = run_start + run_len;
 					if run_end > run_start {
-						if bold {
-							format_spans.push((MarkerType::Bold, run_start, run_end));
-						}
-						if italic {
-							format_spans.push((MarkerType::Italic, run_start, run_end));
-						}
-						if underline {
-							format_spans.push((MarkerType::Underline, run_start, run_end));
-						}
+						format_spans.extend(
+							format_marker_types(bold, italic, underline).map(|kind| (kind, run_start, run_end)),
+						);
 					}
 				}
 				paragraph_text.push_str(&run_text);
+				para_display_len += run_len;
 			}
 		}
 	}
@@ -687,13 +685,15 @@ fn process_paragraph(
 	}
 }
 
+/// Appends the hyperlink's display text to `paragraph_text`, records a Link
+/// marker, and returns the number of display units appended.
 fn process_hyperlink(
 	element: Node,
 	paragraph_text: &mut String,
 	buffer: &mut DocumentBuffer,
 	rels: &HashMap<String, String>,
 	paragraph_start: usize,
-) {
+) -> usize {
 	let r_id = element.attribute("id").unwrap_or("");
 	let anchor = element.attribute("anchor").unwrap_or("");
 	let link_target = if !r_id.is_empty() {
@@ -710,7 +710,7 @@ fn process_hyperlink(
 		}
 	}
 	if link_text.is_empty() {
-		return;
+		return 0;
 	}
 	let link_offset = paragraph_start + paragraph_text.len();
 	paragraph_text.push_str(&link_text);
@@ -719,6 +719,7 @@ fn process_hyperlink(
 			Marker::new(MarkerType::Link, link_offset).with_text(link_text.clone()).with_reference(link_target),
 		);
 	}
+	display_len(&link_text)
 }
 
 fn get_paragraph_heading_level(pr_element: Node, style_heading_map: &HashMap<String, i32>) -> i32 {

--- a/crates/paperback-core/src/parser/word.rs
+++ b/crates/paperback-core/src/parser/word.rs
@@ -24,7 +24,7 @@ use crate::{
 		},
 	},
 	types::HeadingInfo,
-	util::{encoding::convert_to_utf8, zip::read_zip_entry_by_name},
+	util::{encoding::convert_to_utf8, text::display_len, zip::read_zip_entry_by_name},
 };
 
 const FIB_MAGIC_DOC: u16 = 0xA5EC;
@@ -600,6 +600,7 @@ fn process_paragraph(
 	let mut paragraph_text = String::new();
 	let mut heading_level = 0;
 	let mut is_paragraph_style_heading = false;
+	let mut format_spans: Vec<(MarkerType, usize, usize)> = Vec::new();
 	for child in element.children() {
 		if child.node_type() != NodeType::Element {
 			continue;
@@ -640,12 +641,39 @@ fn process_paragraph(
 					}
 				}
 			}
-			paragraph_text.push_str(&collect_ooxml_run_text(child));
+			let run_text = collect_ooxml_run_text(child);
+			if !run_text.is_empty() {
+				let run_start = paragraph_start + display_len(&paragraph_text);
+				if let Some(rpr_node) = find_child_element(child, "rPr") {
+					let (bold, italic, underline) = get_run_format_flags(rpr_node);
+					let run_end = run_start + display_len(&run_text);
+					if run_end > run_start {
+						if bold {
+							format_spans.push((MarkerType::Bold, run_start, run_end));
+						}
+						if italic {
+							format_spans.push((MarkerType::Italic, run_start, run_end));
+						}
+						if underline {
+							format_spans.push((MarkerType::Underline, run_start, run_end));
+						}
+					}
+				}
+				paragraph_text.push_str(&run_text);
+			}
 		}
 	}
 	let trimmed = paragraph_text.trim();
 	buffer.append(trimmed);
 	buffer.append("\n");
+	let leading_trim = display_len(&paragraph_text) - display_len(paragraph_text.trim_start());
+	for (kind, start, end) in format_spans {
+		let adj_start = start.saturating_sub(leading_trim);
+		let adj_end = end.saturating_sub(leading_trim);
+		if adj_end > adj_start {
+			buffer.add_marker(Marker::new(kind, adj_start).with_length(adj_end - adj_start));
+		}
+	}
 	if heading_level > 0 && !trimmed.is_empty() {
 		let heading_text =
 			if is_paragraph_style_heading { trimmed.to_string() } else { extract_heading_text(element, heading_level) };
@@ -742,6 +770,18 @@ fn get_run_heading_level(rpr_element: Node) -> i32 {
 		}
 	}
 	0
+}
+
+fn get_run_format_flags(rpr_element: Node) -> (bool, bool, bool) {
+	let is_toggle_on = |tag: &str| {
+		find_child_element(rpr_element, tag)
+			.is_some_and(|node| node.attribute("val").is_none_or(|v| !matches!(v, "false" | "0")))
+	};
+	let bold = is_toggle_on("b");
+	let italic = is_toggle_on("i");
+	let underline =
+		find_child_element(rpr_element, "u").is_some_and(|node| node.attribute("val").is_none_or(|v| v != "none"));
+	(bold, italic, underline)
 }
 
 fn extract_heading_text(paragraph: Node, heading_level: i32) -> String {
@@ -854,7 +894,10 @@ mod tests {
 	use roxmltree::Document as XmlDocument;
 
 	use super::{looks_like_text_content, normalize_doc_text, parse_doc_clx, parse_doc_piece_table, traverse};
-	use crate::document::{DocumentBuffer, MarkerType};
+	use crate::{
+		document::{DocumentBuffer, MarkerType},
+		util::text::display_len,
+	};
 
 	#[test]
 	fn parse_doc_piece_table_extracts_ansi_text() {
@@ -908,7 +951,6 @@ mod tests {
 	/// equals the emitted display extent.
 	#[test]
 	fn word_table_emits_placeholder_or_tsv_by_flag() {
-		use crate::util::text::display_len;
 		// Minimal OOXML XML: one table with one row, two cells.
 		let xml = r#"<document><body>
 			<tbl>
@@ -940,5 +982,115 @@ mod tests {
 		assert_eq!(buffer.content, "Kop\t\u{1D11E}\n");
 		let table_marker = buffer.markers.iter().find(|m| m.mtype == MarkerType::Table).expect("Table marker");
 		assert_eq!(table_marker.length, display_len("Kop\t\u{1D11E}") + 1, "marker length spans the TSV");
+	}
+
+	/// Parse a single paragraph and return the buffer, so run-property (`<w:rPr>`) format markers
+	/// can be inspected. Test XML uses unnamespaced tags/attributes to match `attribute("val")`
+	/// (roxmltree matches on the local name here, mirroring the existing table test fixtures).
+	fn parse_run_props(xml: &str) -> DocumentBuffer {
+		let xml_doc = XmlDocument::parse(xml).expect("valid xml");
+		let mut buffer = DocumentBuffer::new();
+		let mut headings = Vec::new();
+		let mut id_positions = HashMap::new();
+		let rels = HashMap::new();
+		traverse(xml_doc.root(), &mut buffer, &mut headings, &mut id_positions, &rels, &HashMap::new(), false);
+		buffer
+	}
+
+	#[test]
+	fn run_bold_property_emits_bold_marker() {
+		let buffer = parse_run_props(r"<document><body><p><r><rPr><b/></rPr><t>bold</t></r></p></body></document>");
+		let marker = buffer.markers.iter().find(|m| m.mtype == MarkerType::Bold).expect("Bold marker");
+		assert_eq!(marker.position, 0);
+		assert_eq!(marker.length, display_len("bold"));
+	}
+
+	#[test]
+	fn run_italic_property_emits_italic_marker() {
+		let buffer = parse_run_props(r"<document><body><p><r><rPr><i/></rPr><t>italic</t></r></p></body></document>");
+		let marker = buffer.markers.iter().find(|m| m.mtype == MarkerType::Italic).expect("Italic marker");
+		assert_eq!(marker.position, 0);
+		assert_eq!(marker.length, display_len("italic"));
+	}
+
+	#[test]
+	fn run_underline_property_emits_underline_marker() {
+		let buffer = parse_run_props(
+			r#"<document><body><p><r><rPr><u val="single"/></rPr><t>under</t></r></p></body></document>"#,
+		);
+		let marker = buffer.markers.iter().find(|m| m.mtype == MarkerType::Underline).expect("Underline marker");
+		assert_eq!(marker.position, 0);
+		assert_eq!(marker.length, display_len("under"));
+	}
+
+	#[test]
+	fn run_bold_and_italic_together_emit_both_spanning_same_range() {
+		let buffer = parse_run_props(r"<document><body><p><r><rPr><b/><i/></rPr><t>both</t></r></p></body></document>");
+		let bold = buffer.markers.iter().find(|m| m.mtype == MarkerType::Bold).expect("Bold marker");
+		let italic = buffer.markers.iter().find(|m| m.mtype == MarkerType::Italic).expect("Italic marker");
+		assert_eq!(bold.position, italic.position);
+		assert_eq!(bold.length, italic.length);
+		assert_eq!(bold.position, 0);
+		assert_eq!(bold.length, display_len("both"));
+	}
+
+	#[test]
+	fn run_underline_none_is_not_underlined() {
+		let buffer = parse_run_props(
+			r#"<document><body><p><r><rPr><u val="none"/></rPr><t>plain</t></r></p></body></document>"#,
+		);
+		assert!(
+			!buffer.markers.iter().any(|m| m.mtype == MarkerType::Underline),
+			"u val=none must not produce an Underline marker"
+		);
+	}
+
+	#[test]
+	fn run_bold_false_cancels_bold() {
+		let buffer = parse_run_props(
+			r#"<document><body><p><r><rPr><b val="false"/></rPr><t>plain</t></r></p></body></document>"#,
+		);
+		assert!(
+			!buffer.markers.iter().any(|m| m.mtype == MarkerType::Bold),
+			"b val=false must not produce a Bold marker"
+		);
+	}
+
+	#[test]
+	fn run_bold_zero_cancels_bold() {
+		let buffer =
+			parse_run_props(r#"<document><body><p><r><rPr><b val="0"/></rPr><t>plain</t></r></p></body></document>"#);
+		assert!(!buffer.markers.iter().any(|m| m.mtype == MarkerType::Bold), "b val=0 must not produce a Bold marker");
+	}
+
+	/// The offset of a format marker must be computed in DISPLAY units, not byte length. A paragraph
+	/// beginning with a multi-byte (but display-stable) character before the bold run would place the
+	/// Bold marker at the wrong position if `String::len()` (bytes) were used instead of `display_len`.
+	#[test]
+	fn run_format_offset_uses_display_units_not_bytes() {
+		// "é" is 2 bytes in UTF-8 but 1 display unit (single UTF-16 code unit / one char).
+		let buffer = parse_run_props(
+			r"<document><body><p><r><t>é</t></r><r><rPr><b/></rPr><t>bold</t></r></p></body></document>",
+		);
+		let marker = buffer.markers.iter().find(|m| m.mtype == MarkerType::Bold).expect("Bold marker");
+		assert_eq!(marker.position, display_len("é"), "offset must be display-unit, not byte length");
+		assert_ne!(marker.position, "é".len(), "byte length (2) would be the bug");
+		assert_eq!(marker.length, display_len("bold"));
+	}
+
+	/// A paragraph starting with a whitespace-only unformatted run before a bold run must not
+	/// desync the Bold marker's offset. `process_paragraph` only appends the TRIMMED paragraph
+	/// text to the buffer, so the leading spaces never make it into the final content - the
+	/// bold run's offset must be shifted left by the same amount that gets trimmed, or the
+	/// marker ends up pointing past the start of "bold" into the wrong text.
+	#[test]
+	fn run_format_offset_accounts_for_leading_whitespace_trim() {
+		let buffer = parse_run_props(
+			r#"<document><body><p><r><t xml:space="preserve">  </t></r><r><rPr><b/></rPr><t>bold</t></r></p></body></document>"#,
+		);
+		assert_eq!(buffer.content, "bold\n", "leading whitespace run must be trimmed from the final content");
+		let marker = buffer.markers.iter().find(|m| m.mtype == MarkerType::Bold).expect("Bold marker");
+		assert_eq!(marker.position, 0, "Bold marker must point at the start of the trimmed content");
+		assert_eq!(marker.length, display_len("bold"));
 	}
 }

--- a/crates/paperback-core/src/parser/xml_to_text.rs
+++ b/crates/paperback-core/src/parser/xml_to_text.rs
@@ -686,6 +686,7 @@ mod tests {
 	use rstest::rstest;
 
 	use super::*;
+	use crate::document::MarkerType;
 
 	#[test]
 	fn test_link_collection() {
@@ -899,5 +900,81 @@ mod tests {
 			t1_offset + t1_display_length,
 			"second table offset must equal first offset + first display_length"
 		);
+	}
+
+	#[rstest]
+	#[case("b", MarkerType::Bold)]
+	#[case("strong", MarkerType::Bold)]
+	#[case("i", MarkerType::Italic)]
+	#[case("em", MarkerType::Italic)]
+	#[case("u", MarkerType::Underline)]
+	fn test_format_span_collection(#[case] tag: &str, #[case] kind: MarkerType) {
+		let xml = format!("<root><body><p>Some <{tag}>bold</{tag}> text</p></body></root>");
+		let mut converter = XmlToText::new();
+		assert!(converter.convert(&xml));
+		let spans = match kind {
+			MarkerType::Bold => converter.get_bolds(),
+			MarkerType::Italic => converter.get_italics(),
+			MarkerType::Underline => converter.get_underlines(),
+			_ => unreachable!(),
+		};
+		assert_eq!(spans.len(), 1);
+		let text = converter.get_text();
+		assert_eq!(&text[spans[0].offset..spans[0].offset + spans[0].length], "bold");
+	}
+
+	#[test]
+	fn test_format_span_tag_matching_is_case_insensitive() {
+		let xml = "<root><body><p>Some <B>bold</B> text</p></body></root>";
+		let mut converter = XmlToText::new();
+		assert!(converter.convert(xml));
+		let spans = converter.get_bolds();
+		assert_eq!(spans.len(), 1);
+		let text = converter.get_text();
+		assert_eq!(&text[spans[0].offset..spans[0].offset + spans[0].length], "bold");
+	}
+
+	#[test]
+	fn test_format_span_nested_bold_and_italic() {
+		let xml = "<root><body><p><b>outer <i>inner</i></b></p></body></root>";
+		let mut converter = XmlToText::new();
+		assert!(converter.convert(xml));
+		let text = converter.get_text();
+
+		let italics = converter.get_italics();
+		assert_eq!(italics.len(), 1);
+		assert_eq!(&text[italics[0].offset..italics[0].offset + italics[0].length], "inner");
+
+		let bolds = converter.get_bolds();
+		assert_eq!(bolds.len(), 1);
+		assert_eq!(&text[bolds[0].offset..bolds[0].offset + bolds[0].length], "outer inner");
+	}
+
+	#[test]
+	fn test_format_span_fully_inside_link_is_dropped_known_limitation() {
+		// Known limitation: `<a>` handling (see `handle_element_opening_xml`) eagerly grabs the full
+		// flattened text of the element via `collect_element_text`, pushes it into `current_line`, and
+		// sets `skip_children = true`. `process_node` then skips recursing into the `<a>`'s children
+		// entirely, so the open/close handlers for a `<b>`/`<i>`/`<u>` nested inside the link never
+		// fire and no format span is recorded. This degrades gracefully (no panic, no bad offset; the
+		// link itself is still recorded correctly) and is left as-is per this task's scope (no changes
+		// to the `<a>`/`skip_children` behavior).
+		let xml = "<root><body><a href=\"https://example.com\"><b>bold</b></a></body></root>";
+		let mut converter = XmlToText::new();
+		assert!(converter.convert(xml));
+		assert!(converter.get_bolds().is_empty());
+		let links = converter.get_links();
+		assert_eq!(links.len(), 1);
+		assert_eq!(links[0].text, "bold");
+	}
+
+	#[test]
+	fn test_no_format_spans_without_formatting_tags() {
+		let xml = "<root><body><p>Plain paragraph with no formatting.</p></body></root>";
+		let mut converter = XmlToText::new();
+		assert!(converter.convert(xml));
+		assert!(converter.get_bolds().is_empty());
+		assert!(converter.get_italics().is_empty());
+		assert!(converter.get_underlines().is_empty());
 	}
 }

--- a/crates/paperback-core/src/session.rs
+++ b/crates/paperback-core/src/session.rs
@@ -195,7 +195,7 @@ pub struct TocEntry {
 	pub level: i32,
 }
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum MarkerTypeFfi {
 	Heading1,
 	Heading2,
@@ -1566,6 +1566,38 @@ mod tests {
 		assert!(session.has_headings(Some(1)));
 		assert!(!session.has_headings(Some(2)));
 		assert!(!session.has_headings(Some(99)));
+	}
+
+	#[test]
+	fn get_formatting_markers_returns_only_bold_italic_underline_markers() {
+		let mut buffer = DocumentBuffer::with_content("line1\nline2\nline3".to_string());
+		buffer.add_marker(Marker::new(MarkerType::Heading1, 0).with_level(1).with_text("H1".to_string()));
+		buffer.add_marker(Marker::new(MarkerType::Bold, 0).with_length(5));
+		buffer.add_marker(Marker::new(MarkerType::Italic, 6).with_length(5));
+		buffer.add_marker(Marker::new(MarkerType::Underline, 12).with_length(5));
+		let mut doc = Document::new().with_title("Title".to_string()).with_author("Author".to_string());
+		doc.set_buffer(buffer);
+		let session = DocumentSession {
+			handle: DocumentHandle::new(doc),
+			file_path: "book.epub".to_string(),
+			history: Vec::new(),
+			history_index: 0,
+			parser_flags: ParserFlags::NONE,
+			last_stable_position: None,
+		};
+
+		let markers = session.get_formatting_markers();
+
+		assert_eq!(markers.len(), 3);
+		assert_eq!(markers[0].mtype, MarkerTypeFfi::Bold);
+		assert_eq!(markers[0].position, 0);
+		assert_eq!(markers[0].length, 5);
+		assert_eq!(markers[1].mtype, MarkerTypeFfi::Italic);
+		assert_eq!(markers[1].position, 6);
+		assert_eq!(markers[1].length, 5);
+		assert_eq!(markers[2].mtype, MarkerTypeFfi::Underline);
+		assert_eq!(markers[2].position, 12);
+		assert_eq!(markers[2].length, 5);
 	}
 
 	#[test]


### PR DESCRIPTION
## Summary

Adds inline character-formatting (bold, italic, underline) support end to end:
detection during parsing, an intermediate marker representation, and rendering
in the exporters.

## Changes

- **Parsers** — extract bold/italic/underline and emit `Bold`/`Italic`/`Underline`
  markers into the shared `DocumentBuffer`:
  - `rtf.rs` — RTF control-word toggles with group-scope (`{...}`) bookkeeping
  - `odt.rs` — resolves `text:style-name` against `<office:automatic-styles>`
    (`font-weight` / `font-style` / `text-underline-style`)
  - `word.rs` — OOXML run properties (`b` / `i` / `u` toggles)
  - `html_to_text.rs` / `xml_to_text.rs` — tag-based formatting
- **Exporters** — render the markers:
  - `html.rs` — `<b>` / `<i>` / `<u>` via the existing inline open/close events
  - `markdown.rs` — `**` / `*`; underline is dropped (no CommonMark equivalent)
- **session.rs** — derives `PartialEq`/`Eq` on `MarkerTypeFfi` and adds test
  coverage for `get_formatting_markers`.