### PR TITLE
FIX(mac): let other apps open documents in Paperback

### DIFF
--- a/crates/paperback/src/ui/app.rs
+++ b/crates/paperback/src/ui/app.rs
@@ -61,6 +61,18 @@ impl PaperbackApp {
 				window.show_from_dock();
 			}
 		});
+		// Finder delivers documents via the odoc Apple Event, not argv, so
+		// "Open with"/double-click never reaches open_from_command_line.
+		#[cfg(target_os = "macos")]
+		_app.on_open_files(|files| {
+			if let Some(window) = main_window_from_ptr() {
+				window.show_from_dock();
+				for file in &files {
+					tracing::info!(path = %file, "opening file from macOS open-files event");
+					window.open_file(Path::new(file));
+				}
+			}
+		});
 		open_from_command_line(&main_window);
 		let (check_updates, channel) = {
 			let cfg = config.lock().unwrap();


### PR DESCRIPTION
This PR adds support for using Paperback as the default app to open documents from Finder on double click / Command + down arrow, as well as making it work with things like the "open with" context menu.

The first half of this feature was implemented already, as Paperback was properly declaring supported file extensions in its info.plist, enabling it to be picked up by LaunchServices. However, because MacOS prefers to only have one instance of an app open at a time, it doesn't communicate "open file" requests by running the application's binary with a command line argument like Windows does. Instead, it sends a special Apple event which Paperback must handle.

Fortunately, WXDragon does include APIs for this, which make it a relatively simple fix.