### PR TITLE
test: use a platform-appropriate absolute path in normalize_cli_path …

### DIFF
--- a/crates/paperback/src/ipc.rs
+++ b/crates/paperback/src/ipc.rs
@@ -87,8 +87,11 @@ mod tests {
 
 	#[test]
 	fn normalize_cli_path_handles_absolute_and_relative() {
+		#[cfg(windows)]
 		let abs = Path::new("C:\\nonexistent_abs_path");
-		assert_eq!(normalize_cli_path(abs), PathBuf::from("C:\\nonexistent_abs_path"));
+		#[cfg(not(windows))]
+		let abs = Path::new("/nonexistent_abs_path");
+		assert_eq!(normalize_cli_path(abs), abs.to_path_buf());
 		let rel = Path::new("nonexistent_rel_path");
 		let expected = env::current_dir().unwrap().join(rel);
 		assert_eq!(normalize_cli_path(rel), expected);


### PR DESCRIPTION
…test

normalize_cli_path_handles_absolute_and_relative hardcoded C:\nonexistent_abs_path as its absolute-path input, but Path::is_absolute only treats drive-letter paths as absolute on Windows; on macOS the path counts as relative and gets joined onto the cwd, failing the assertion. The test had never actually run on macOS before because the whole test target failed to compile until the preceding commit.

Pick the absolute path per platform via cfg so the test exercises the same behavior everywhere.