### PR TITLE
fix: count display units as UTF-16 code units on macOS

### DIFF
--- a/crates/paperback-core/src/util/text.rs
+++ b/crates/paperback-core/src/util/text.rs
@@ -67,29 +67,18 @@ pub fn trim_string(s: &str) -> String {
 	s.trim_matches(is_space_like).to_string()
 }
 
+/// Display units match the index space of the platform text control that the
+/// document text is loaded into: UTF-16 code units on Windows (Win32 edit
+/// control) and macOS (NSTextView's NSRange, which wxWidgets passes through
+/// unconverted); Unicode characters on GTK (GtkTextIter offsets).
 #[must_use]
 pub fn display_len(s: &str) -> usize {
-	#[cfg(windows)]
-	{
-		s.encode_utf16().count()
-	}
-	#[cfg(not(windows))]
-	{
-		s.chars().count()
-	}
+	if cfg!(any(windows, target_os = "macos")) { s.encode_utf16().count() } else { s.chars().count() }
 }
 
 #[must_use]
 pub const fn ch_width(ch: char) -> usize {
-	#[cfg(windows)]
-	{
-		ch.len_utf16()
-	}
-	#[cfg(not(windows))]
-	{
-		let _ = ch;
-		1
-	}
+	if cfg!(any(windows, target_os = "macos")) { ch.len_utf16() } else { 1 }
 }
 
 #[must_use]
@@ -171,17 +160,17 @@ mod tests {
 		assert_eq!(trim_string(input), expected);
 	}
 
-	#[cfg(windows)]
+	#[cfg(any(windows, target_os = "macos"))]
 	#[test]
-	fn test_display_len_windows() {
+	fn test_display_len_utf16_platforms() {
 		assert_eq!(display_len("abc"), 3);
 		assert_eq!(display_len("💖"), 2);
 		assert_eq!(display_len("line\nwrap"), 9);
 	}
 
-	#[cfg(not(windows))]
+	#[cfg(not(any(windows, target_os = "macos")))]
 	#[test]
-	fn test_display_len_non_windows() {
+	fn test_display_len_char_platforms() {
 		assert_eq!(display_len("abc"), 3);
 		assert_eq!(display_len("💖"), 1);
 		assert_eq!(display_len("line\nwrap"), 9);


### PR DESCRIPTION
display_len/ch_width define the "display unit" for all document offsets the core hands to the UI (tables, separators, navigation targets), so they must match the expectations of the platform text control those offsets are fed into via SetInsertionPoint/SetSelection.

Certain text controls (GTK) use Unicode codepoints as their notion of a character / "display unit". Those are equivalent to Rust chars. Other platforms (Windows and MacOS) use UTF-16 code units.

Higher codepoints (those from Unicode planes 1-16, also called Astral or BMP, notably including Emoji), must be expressed with 2 UTF-16 code units.

On macOS, the text control is backed by NSTextView, and wxWidgets passes NSRange values through unconverted (wxNSTextViewControl::GetSelection/ SetSelection in src/osx/cocoa/textctrl.mm; GetLastPosition is [NSString length]), so positions are UTF-16 code units exactly as on Windows. Verified three ways: by reading the vendored wxWidgets source through every layer including the wxdragon passthrough, empirically with a throwaway wxdragon probe on macOS — get_last_position of "A\u{1D11E}B" returns 4 (UTF-16), not 3 (chars), and with a human test, which indeed showed that navigation commands move to the wrong document position if Emojis are present and this patch is not applied.

Counting chars() on macOS therefore made every offset after an astral character (emoji, musical symbols, some CJK) undershoot by one unit per such character. Windows and macOS now share the UTF-16 arm; GTK, which indexes GtkTextIter offsets by Unicode characters, keeps chars().

This also makes the two {xml,html}_table_display_length tests pass unmodified on macOS: their hardcoded expectations asserted the correct UTF-16 semantics all along, and the macOS implementation was the bug.

Side finding, not addressed here: wxTextEntry::GetStringSelection on macOS mixes UTF-16 positions into char-indexed wxString::Mid, so it returns wrong text after astral characters (upstream wx bug). The Android app similarly indexes Kotlin strings (UTF-16) with core offsets, which remain char-based on Android.