### PR TITLE
fix: cover ToggleVisibility in send_ipc_command match under cfg(test)

### DIFF
--- a/crates/paperback/src/ui/app.rs
+++ b/crates/paperback/src/ui/app.rs
@@ -322,7 +322,7 @@ fn send_ipc_command(command: IpcCommand) {
 	tracing::debug!(command = ?command, "sending IPC command to existing instance");
 	let payload = match &command {
 		IpcCommand::Activate => IPC_COMMAND_ACTIVATE.to_string(),
-		#[cfg(any(target_os = "linux", target_os = "windows"))]
+		#[cfg(any(target_os = "linux", target_os = "windows", test))]
 		IpcCommand::ToggleVisibility => crate::ipc::IPC_COMMAND_TOGGLE_VISIBILITY.to_string(),
 		IpcCommand::OpenFile(path) => path.to_string_lossy().to_string(),
 	};


### PR DESCRIPTION
The IpcCommand::ToggleVisibility variant is cfg-gated on any(linux, windows, test) so that decode_execute_payload and its unit tests compile on macOS, but the corresponding match arm in send_ipc_command was only gated on any(linux, windows). Building the test target on macOS therefore hit E0004 (non-exhaustive patterns), which made every test in the paperback crate uncompilable there.

Align the match arm cfg with the variant cfg so workspace-wide `cargo test` builds on macOS again.