### PR TITLE
fix: interpret path separators per-platform in extract_title_from_path

### DIFF
--- a/crates/paperback-core/src/parser/util/path.rs
+++ b/crates/paperback-core/src/parser/util/path.rs
@@ -1,12 +1,15 @@
 use std::path::Path;
 
+/// Derives a fallback document title from the path of the file being opened.
+/// Inputs are always native local paths, so separators are interpreted
+/// per-platform: on unix, a backslash is an ordinary filename character.
 #[must_use]
 pub fn extract_title_from_path(path: &str) -> String {
 	let trimmed = path.trim();
 	if trimmed.is_empty() {
 		return "Untitled".to_string();
 	}
-	if trimmed.ends_with('/') || trimmed.ends_with('\\') {
+	if trimmed.ends_with('/') || (cfg!(windows) && trimmed.ends_with('\\')) {
 		return "Untitled".to_string();
 	}
 	Path::new(trimmed).file_stem().and_then(|s| s.to_str()).unwrap_or("Untitled").to_string()
@@ -21,9 +24,7 @@ mod tests {
 	#[rstest]
 	#[case("foo.txt", "foo")]
 	#[case("/home/quin/books/worm.epub", "worm")]
-	#[case("C:\\Users\\Quin\\Desktop\\file.log", "file")]
 	#[case("/path/with/trailing/slash/", "Untitled")]
-	#[case("C:\\path\\with\\trailing\\slash\\", "Untitled")]
 	#[case("  spaced.txt  ", "spaced")]
 	#[case("", "Untitled")]
 	#[case("README", "README")]
@@ -32,6 +33,23 @@ mod tests {
 	#[case(" /tmp/dir/ ", "Untitled")]
 	#[case("archive.tar.gz", "archive.tar")]
 	fn extracts_title_from_path(#[case] input: &str, #[case] expected: &str) {
+		assert_eq!(extract_title_from_path(input), expected);
+	}
+
+	#[cfg(windows)]
+	#[rstest]
+	#[case("C:\\Users\\Quin\\Desktop\\file.log", "file")]
+	#[case("C:\\path\\with\\trailing\\slash\\", "Untitled")]
+	fn extracts_title_from_windows_path(#[case] input: &str, #[case] expected: &str) {
+		assert_eq!(extract_title_from_path(input), expected);
+	}
+
+	/// On unix, a backslash is an ordinary filename character, not a separator.
+	#[cfg(not(windows))]
+	#[rstest]
+	#[case("weird\\name.txt", "weird\\name")]
+	#[case("trailing\\", "trailing\\")]
+	fn backslash_is_a_filename_character_on_unix(#[case] input: &str, #[case] expected: &str) {
 		assert_eq!(extract_title_from_path(input), expected);
 	}
 }


### PR DESCRIPTION
extract_title_from_path only ever receives native local paths: the desktop app and pb CLI pass the opened file's path, and Android copies content URIs to a local cache file before handing the path to the core. Treating a backslash as a separator on unix was therefore speculative generality — and actively wrong, since a backslash is a legal filename character there (a file named "dir\\" got "Untitled" instead of its name).

Gate the trailing-backslash check to Windows and split the tests into platform-independent, Windows-only, and unix-only groups. This fixes extracts_title_from_path::case_03, which asserted the Windows answer for a C:\\ path on every platform and failed on macOS.