### PR TITLE
FEAT(parser): parallelize epub parsing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -501,6 +501,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-deque"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5181e0de7b61eb03a81e347d6dd8797bae9da5146707b51077e2d71a54ec0ceb"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1616,6 +1635,7 @@ dependencies = [
  "pdfium",
  "percent-encoding",
  "pulldown-cmark",
+ "rayon",
  "regex",
  "roman",
  "roxmltree",
@@ -1940,6 +1960,26 @@ name = "rawzip"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d9575f44c8cf85bc843ad666dcdf20d05a7753772bef56eb2a5140282b32150"
+
+[[package]]
+name = "rayon"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
 
 [[package]]
 name = "rc4"

--- a/crates/paperback-core/Cargo.toml
+++ b/crates/paperback-core/Cargo.toml
@@ -29,6 +29,7 @@ patois = { git = "https://github.com/trypsynth/patois.git" }
 pdfium = "0.10.4"
 percent-encoding = "2.3.2"
 pulldown-cmark = { version = "0.13.4", default-features = false, features = ["html"] }
+rayon = "1.11.0"
 regex = "1.13.1"
 roman = "0.2.1"
 roxmltree = "0.21.1"

--- a/crates/paperback-core/src/parser/epub.rs
+++ b/crates/paperback-core/src/parser/epub.rs
@@ -6,6 +6,7 @@ use std::{
 };
 
 use anyhow::{Context, Result};
+use rayon::prelude::*;
 use roxmltree::{Document as XmlDocument, Node, NodeType, ParsingOptions};
 use zip::ZipArchive;
 
@@ -189,19 +190,36 @@ fn convert_spine_items<R: Read + Seek>(
 	spine: &[String],
 	render_tables_inline: bool,
 ) -> SpineConversionResult {
+	// Reading from the archive must be single-threaded (archive is &mut).
+	let entries: Vec<Result<(&ManifestItem, String), String>> = spine
+		.iter()
+		.map(|idref| {
+			let item = manifest.get(idref).ok_or_else(|| format!("missing manifest item for {idref}"))?;
+			let data = read_zip_entry_by_name(archive, &item.path).map_err(|err| format!("{} ({err})", item.path))?;
+			Ok((item, data))
+		})
+		.collect();
+
+	// parallel parsing makes large, math-heavy books go from ~60s to ~16s.
+	let converted: Vec<Result<(&ManifestItem, SectionContent), String>> = entries
+		.into_par_iter()
+		.map(|entry| {
+			let (item, data) = entry?;
+			let section =
+				convert_section(&data, render_tables_inline).map_err(|err| format!("{} ({err})", item.path))?;
+			Ok((item, section))
+		})
+		.collect();
+
 	let mut buffer = DocumentBuffer::new();
 	let mut id_positions = HashMap::new();
 	let mut sections = Vec::new();
 	let mut conversion_errors = Vec::new();
-	for (idx, idref) in spine.iter().enumerate() {
-		let Some(item) = manifest.get(idref) else {
-			conversion_errors.push(format!("missing manifest item for {idref}"));
-			continue;
-		};
-		let section_data = match read_zip_entry_by_name(archive, &item.path) {
-			Ok(v) => v,
+	for (idx, slot) in converted.into_iter().enumerate() {
+		let (item, section) = match slot {
+			Ok(pair) => pair,
 			Err(err) => {
-				conversion_errors.push(format!("{} ({err})", item.path));
+				conversion_errors.push(err);
 				continue;
 			}
 		};
@@ -212,36 +230,29 @@ fn convert_spine_items<R: Read + Seek>(
 				.with_text(section_label)
 				.with_reference(item.path.clone()),
 		);
-		match convert_section(&section_data, render_tables_inline) {
-			Ok(section) => {
-				for (id, relative) in &section.id_positions {
-					let absolute = section_start + relative;
-					// Keep the first occurrence for bare ids to avoid later sections overwriting earlier ones.
-					id_positions.entry(id.clone()).or_insert(absolute);
-					id_positions.insert(format!("{}#{id}", item.path), absolute);
-				}
-				add_converter_markers_excluding_links(&mut buffer, &section, section_start);
-				for link in &section.links {
-					let resolved = resolve_href(&item.path, &link.reference);
-					buffer.add_marker(
-						Marker::new(MarkerType::Link, section_start + link.offset)
-							.with_text(link.text.clone())
-							.with_reference(resolved),
-					);
-				}
-				if !section.text.is_empty() {
-					buffer.append(&section.text);
-					if !buffer.content.ends_with('\n') {
-						buffer.append("\n");
-					}
-				}
-				let section_end = buffer.current_position();
-				sections.push(SectionMeta { path: item.path.clone(), start: section_start, end: section_end });
-			}
-			Err(err) => {
-				conversion_errors.push(format!("{} ({err})", item.path));
+		for (id, relative) in &section.id_positions {
+			let absolute = section_start + relative;
+			// Keep the first occurrence for bare ids to avoid later sections overwriting earlier ones.
+			id_positions.entry(id.clone()).or_insert(absolute);
+			id_positions.insert(format!("{}#{id}", item.path), absolute);
+		}
+		add_converter_markers_excluding_links(&mut buffer, &section, section_start);
+		for link in &section.links {
+			let resolved = resolve_href(&item.path, &link.reference);
+			buffer.add_marker(
+				Marker::new(MarkerType::Link, section_start + link.offset)
+					.with_text(link.text.clone())
+					.with_reference(resolved),
+			);
+		}
+		if !section.text.is_empty() {
+			buffer.append(&section.text);
+			if !buffer.content.ends_with('\n') {
+				buffer.append("\n");
 			}
 		}
+		let section_end = buffer.current_position();
+		sections.push(SectionMeta { path: item.path.clone(), start: section_start, end: section_end });
 	}
 	SpineConversionResult { buffer, id_positions, sections, conversion_errors }
 }

--- a/crates/paperback-core/src/parser/epub.rs
+++ b/crates/paperback-core/src/parser/epub.rs
@@ -190,7 +190,6 @@ fn convert_spine_items<R: Read + Seek>(
 	spine: &[String],
 	render_tables_inline: bool,
 ) -> SpineConversionResult {
-	// Reading from the archive must be single-threaded (archive is &mut).
 	let entries: Vec<Result<(&ManifestItem, String), String>> = spine
 		.iter()
 		.map(|idref| {
@@ -199,8 +198,6 @@ fn convert_spine_items<R: Read + Seek>(
 			Ok((item, data))
 		})
 		.collect();
-
-	// parallel parsing makes large, math-heavy books go from ~60s to ~16s.
 	let converted: Vec<Result<(&ManifestItem, SectionContent), String>> = entries
 		.into_par_iter()
 		.map(|entry| {
@@ -210,7 +207,6 @@ fn convert_spine_items<R: Read + Seek>(
 			Ok((item, section))
 		})
 		.collect();
-
 	let mut buffer = DocumentBuffer::new();
 	let mut id_positions = HashMap::new();
 	let mut sections = Vec::new();


### PR DESCRIPTION
This is the first in a very long series of upcoming PRs aimed at adding MathML support to Paperback. I have most of this work done already, but it would be basically unreviewable if sent as one patch, so I'll break it into atomic PRs.

As math parsing is costly and breaks several assumptions that Paperback makes about how cheap documents are to load, we need to land some performance improvements first. This is one of such improvements.

This PR moves Epub section parsing to a worker thread pool, with parallelism implemented through the Rayon crate.

Reading section files from the zip archive stays serial (because the zip reader relies on an underlying seekable file reader, which is `&mut`, so does constructing the final buffer.

For books containing many complex math expressions, this provides a ~4x speedup. For the [canonical Epub MathML example](https://github.com/IDPF/epub3-samples/releases/download/20230704/linear-algebra.epub), which is a 250k-word doorstop, it goes from ~60s -> ~15s) on my machine.

Moving the main parser logic off the UI thread will be a separate PR series.