### PR TITLE
fix(desktop): don't quit on arbitrary timer expiry

### DIFF
--- a/crates/paperback/src/ui/main_window.rs
+++ b/crates/paperback/src/ui/main_window.rs
@@ -549,6 +549,12 @@ impl MainWindow {
 		let dm_for_timer = Rc::clone(doc_manager);
 		let config_for_timer = Rc::clone(&config);
 		sleep_timer.on_tick(move |_| {
+			// Due to a wxdragon bug, on_tick runs all closures of all timers owned by this frame, not just this one.
+			// We unset sleep_timer_running_for_tick here. If it is already unset or the timer is still running,
+			// the event was intended for a different timer.
+			if !sleep_timer_running_for_tick.get() || sleep_timer_for_tick.is_running() {
+				return;
+			}
 			tracing::info!("sleep timer fired, closing application");
 			sleep_timer_running_for_tick.set(false);
 			sleep_timer_for_tick.stop();


### PR DESCRIPTION
wxdragon's `Timer::on_tick`  binds its  callback  to  the owning  frame's wxEVT_TIMER without a timer id, so  every timer's tick runs the closures of all other timers bound to the same frame. This is likely an upstream bug.

The sleep-timer closure closed the application unconditionally, which also caused it to close when any other timers fired.

This  bug was  latent on  master, as  there were  no other relevant  timers which could cause  it to trigger. However,  I have future PRS  in the pipeline that do need additional timers, hence this fix.