### PR TITLE
fix(desktop): don't offer untracked tabs for Reopen Last Closed

### DIFF
--- a/crates/paperback/src/ui/document_manager.rs
+++ b/crates/paperback/src/ui/document_manager.rs
@@ -266,7 +266,10 @@ impl DocumentManager {
 		}
 		if let Some(tab) = self.tabs.get(index) {
 			tracing::info!(path = %tab.file_path.display(), "closing document");
-			self.recently_closed.push(tab.file_path.clone());
+			// don't make an untracked document reopenable; reopening would give it the wrong title and make it tracked.
+			if tab.track {
+				self.recently_closed.push(tab.file_path.clone());
+			}
 			let path_str = tab.file_path.to_string_lossy();
 			let config = self.config.lock().unwrap();
 			if save_state && tab.track {


### PR DESCRIPTION
Closing any tab pushed its path onto the reopen stack, including untracked synthetic tabs like help and View Source. Reopening one of those with Ctrl+Shift+T goes through the generic open path, which knows nothing about the tab's origin: the temp file came back as a regular tracked document, titled with its raw internal filename (e.g. "chapter3.xhtml.source.txt"), and from there leaked into the recents menu, the startup-restore list (restoring a stale temp path or failing with "File not found" on the next launch), and a per-document settings entry.

Push onto the reopen stack only for tracked tabs, establishing the invariant that everything on the stack is an ordinary document that can be reopened through the generic open path.