### PR TITLE
Declare support for lists in the PDF parser in supported_flags

### DIFF
--- a/crates/paperback-core/src/parser/pdf.rs
+++ b/crates/paperback-core/src/parser/pdf.rs
@@ -36,7 +36,7 @@ impl Parser for PdfParser {
 	}
 
 	fn supported_flags(&self) -> ParserFlags {
-		ParserFlags::SUPPORTS_PAGES | ParserFlags::SUPPORTS_TOC
+		ParserFlags::SUPPORTS_PAGES | ParserFlags::SUPPORTS_TOC | ParserFlags::SUPPORTS_LISTS
 	}
 
 	fn parse(&self, context: &ParserContext) -> Result<Document> {


### PR DESCRIPTION
The PDF parser generates lists and list items for tagged PDFs, but right now the flag for lists is not declared in supported_flags, so navigating by list or list item will not work.