### PR TITLE
Add "Move to start of line" option for up/down navigation

### DIFF
--- a/crates/paperback/src/ui/dialogs/options.rs
+++ b/crates/paperback/src/ui/dialogs/options.rs
@@ -26,6 +26,7 @@ pub struct OptionsDialogResult {
 	pub start_maximized: bool,
 	pub compact_go_menu: bool,
 	pub navigation_wrap: bool,
+	pub line_start_navigation: bool,
 	pub check_for_updates_on_startup: bool,
 	pub bookmark_sounds: bool,
 	pub recent_documents_to_show: i32,
@@ -51,6 +52,7 @@ struct OptionsDialogUi {
 	start_maximized_check: CheckBox,
 	compact_go_menu_check: CheckBox,
 	navigation_wrap_check: CheckBox,
+	line_start_nav_check: CheckBox,
 	check_for_updates_check: CheckBox,
 	bookmark_sounds_check: CheckBox,
 	recent_docs_ctrl: SpinCtrl,
@@ -95,6 +97,7 @@ pub fn show_options_dialog(parent: &Frame, config: &ConfigManager) -> Option<Opt
 		start_maximized: ui.start_maximized_check.is_checked(),
 		compact_go_menu: ui.compact_go_menu_check.is_checked(),
 		navigation_wrap: ui.navigation_wrap_check.is_checked(),
+		line_start_navigation: ui.line_start_nav_check.is_checked(),
 		check_for_updates_on_startup: ui.check_for_updates_check.is_checked(),
 		bookmark_sounds: ui.bookmark_sounds_check.is_checked(),
 		recent_documents_to_show: ui.recent_docs_ctrl.value(),
@@ -137,6 +140,9 @@ fn build_options_dialog_ui(parent: &Frame, config: &ConfigManager) -> OptionsDia
 	let compact_go_menu_check = CheckBox::builder(&reading_panel).with_label(&t("Show compact &go menu")).build();
 	// TRANSLATORS: Option to wrap navigation around to the beginning/end when navigating elements
 	let navigation_wrap_check = CheckBox::builder(&reading_panel).with_label(&t("&Wrap navigation")).build();
+	let line_start_nav_check =
+		// TRANSLATORS: Option to move the caret to the start of the line when navigating up or down
+		CheckBox::builder(&reading_panel).with_label(&t("Move to &start of line")).build();
 	let bookmark_sounds_check =
 		// TRANSLATORS: Option to play sound effects when bookmarks or notes are encountered
 		CheckBox::builder(&reading_panel).with_label(&t("Play &sounds on bookmarks and notes")).build();
@@ -152,7 +158,10 @@ fn build_options_dialog_ui(parent: &Frame, config: &ConfigManager) -> OptionsDia
 	general_sizer.add(&minimize_to_tray_check, 0, SizerFlag::All, option_padding);
 	general_sizer.add(&check_for_updates_check, 0, SizerFlag::All, option_padding);
 	general_sizer.add(&hotkey_button, 0, SizerFlag::All, option_padding);
-	for check in [&navigation_wrap_check, &compact_go_menu_check, &bookmark_sounds_check] {
+	reading_sizer.add(&navigation_wrap_check, 0, SizerFlag::All, option_padding);
+	#[cfg(target_os = "windows")]
+	reading_sizer.add(&line_start_nav_check, 0, SizerFlag::All, option_padding);
+	for check in [&compact_go_menu_check, &bookmark_sounds_check] {
 		reading_sizer.add(check, 0, SizerFlag::All, option_padding);
 	}
 	let reading_speed_label =
@@ -343,6 +352,7 @@ fn build_options_dialog_ui(parent: &Frame, config: &ConfigManager) -> OptionsDia
 	start_maximized_check.set_value(config.get_app_bool("start_maximized", false));
 	compact_go_menu_check.set_value(config.get_app_bool("compact_go_menu", true));
 	navigation_wrap_check.set_value(config.get_app_bool("navigation_wrap", false));
+	line_start_nav_check.set_value(config.get_app_bool("line_start_navigation", false));
 	bookmark_sounds_check.set_value(config.get_app_bool("bookmark_sounds", true));
 	check_for_updates_check.set_value(config.get_app_bool("check_for_updates_on_startup", true));
 	recent_docs_ctrl.set_value(config.get_app_int("recent_documents_to_show", 25).clamp(0, max_recent_docs));
@@ -446,6 +456,7 @@ fn build_options_dialog_ui(parent: &Frame, config: &ConfigManager) -> OptionsDia
 		start_maximized_check,
 		compact_go_menu_check,
 		navigation_wrap_check,
+		line_start_nav_check,
 		check_for_updates_check,
 		bookmark_sounds_check,
 		recent_docs_ctrl,

--- a/crates/paperback/src/ui/document_manager.rs
+++ b/crates/paperback/src/ui/document_manager.rs
@@ -761,7 +761,13 @@ impl DocumentManager {
 				if (key == WXK_DOWN || key == WXK_UP) && !kbd.shift_down() && !kbd.control_down() {
 					let going_down = key == WXK_DOWN;
 					let nav_result = dm_for_nav.try_lock().ok().and_then(|dm| {
-						navigate_line_by_column(text_ctrl_for_menu, going_down, dm.preferred_column.get())
+						let start_of_line = dm.config.lock().unwrap().get_app_bool("line_start_navigation", false);
+						navigate_line_by_column(
+							text_ctrl_for_menu,
+							going_down,
+							dm.preferred_column.get(),
+							start_of_line,
+						)
 					});
 					if let Some((new_pos, new_col)) = nav_result {
 						kbd.event.skip(false);
@@ -792,11 +798,17 @@ impl DocumentManager {
 	}
 }
 
-/// Returns (`new_position`, `preferred_column`) for character-column-based vertical navigation.
-/// Uses wxdragon `PositionToXY`, `XYToPosition`, and `GetLineLength` so the cursor lands on the same
-/// character column (not pixel column) on the target visual line.
+/// Returns (`new_position`, `preferred_column`) for vertical navigation.
+/// With `start_of_line` set, the caret lands at the start of the target visual line. Otherwise it
+/// uses character-column-based navigation (`pref_col` or the current column), so the cursor lands on
+/// the same character column (not pixel column) on the target visual line.
 #[cfg(target_os = "windows")]
-fn navigate_line_by_column(text_ctrl: TextCtrl, going_down: bool, pref_col: Option<i64>) -> Option<(i64, i64)> {
+fn navigate_line_by_column(
+	text_ctrl: TextCtrl,
+	going_down: bool,
+	pref_col: Option<i64>,
+	start_of_line: bool,
+) -> Option<(i64, i64)> {
 	let current_pos = text_ctrl.get_insertion_point().max(0);
 	let (current_col, current_line) = text_ctrl.position_to_xy(current_pos)?;
 	let col = pref_col.unwrap_or(current_col);
@@ -807,6 +819,9 @@ fn navigate_line_by_column(text_ctrl: TextCtrl, going_down: bool, pref_col: Opti
 	let target_line_start = text_ctrl.xy_to_position(0, target_line);
 	if target_line_start < 0 {
 		return None;
+	}
+	if start_of_line {
+		return Some((target_line_start, 0));
 	}
 	let target_line_len = i64::from(text_ctrl.get_line_length(target_line));
 	let new_pos = target_line_start + col.min(target_line_len);

--- a/crates/paperback/src/ui/main_window.rs
+++ b/crates/paperback/src/ui/main_window.rs
@@ -1513,6 +1513,7 @@ impl MainWindow {
 					cfg.set_app_bool("start_maximized", options.start_maximized);
 					cfg.set_app_bool("compact_go_menu", options.compact_go_menu);
 					cfg.set_app_bool("navigation_wrap", options.navigation_wrap);
+					cfg.set_app_bool("line_start_navigation", options.line_start_navigation);
 					cfg.set_app_bool("check_for_updates_on_startup", options.check_for_updates_on_startup);
 					cfg.set_app_bool("bookmark_sounds", options.bookmark_sounds);
 					cfg.set_app_int("recent_documents_to_show", options.recent_documents_to_show);


### PR DESCRIPTION
## Summary

Adds a new **"Move to start of line"** checkbox to **Options → Reading**, off by default.

When enabled, pressing Up/Down places the caret at the **start** of the target line instead of preserving the current character column — matching how screen-reader virtual buffers (NVDA, etc.) navigate lines, which screen-reader users may find more predictable.

## Scope

- **Windows only.** Hooks the existing Windows-only character-column navigation handler in `document_manager.rs`. On macOS/Linux the option has no effect and the checkbox is hidden; implementing it there would be a good follow-up.
- The setting persists through the standard config system.

## Testing

- Manually tested with NVDA on Windows 11:
  - Default off: Up/Down behavior is unchanged (column-preserving).
  - Option on: Up/Down lands at the start of each line; NVDA reads each line from the beginning.
  - Setting persists across restarts.
- `cargo +nightly fmt --check`, `cargo clippy --workspace --all-targets --release`, and the release build all pass locally.
- Not covered by automated tests, since the navigation logic lives in the GUI layer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
