### PR TITLE
Add temporary bookmark: / to set, \ to jump

### DIFF
--- a/crates/paperback-core/src/config.rs
+++ b/crates/paperback-core/src/config.rs
@@ -213,6 +213,8 @@ pub struct DocumentConfig {
 	pub navigation_history_index: usize,
 	#[serde(default)]
 	pub bookmarks: Vec<StoredBookmark>,
+	#[serde(default, skip_serializing_if = "Option::is_none")]
+	pub temporary_bookmark: Option<i64>,
 	#[serde(default, skip_serializing_if = "String::is_empty")]
 	pub format: String,
 	#[serde(default, skip_serializing_if = "String::is_empty")]
@@ -229,6 +231,8 @@ struct SidecarData {
 	format: Option<String>,
 	#[serde(default, skip_serializing_if = "Vec::is_empty")]
 	bookmarks: Vec<StoredBookmark>,
+	#[serde(default, skip_serializing_if = "Option::is_none")]
+	temporary_bookmark: Option<i64>,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
@@ -757,6 +761,28 @@ impl ConfigManager {
 		if saved > 0 && saved <= max_position { saved } else { -1 }
 	}
 
+	/// Sets the single per-document temporary bookmark position (`None` clears it).
+	pub fn set_temporary_bookmark(&self, path: &str, position: Option<i64>) {
+		if !self.initialized {
+			return;
+		}
+		{
+			let key = self.get_doc_key(path);
+			let mut data = self.data.borrow_mut();
+			Self::doc_entry_mut(&mut data, key, path).temporary_bookmark = position;
+		}
+		self.dirty.set(true);
+	}
+
+	#[must_use]
+	pub fn get_temporary_bookmark(&self, path: &str) -> Option<i64> {
+		if !self.initialized {
+			return None;
+		}
+		let key = self.get_doc_key(path);
+		self.data.borrow().documents.get(&key).and_then(|d| d.temporary_bookmark)
+	}
+
 	pub fn set_navigation_history(&self, path: &str, history: &[i64], history_index: usize) {
 		if !self.initialized {
 			return;
@@ -975,6 +1001,9 @@ impl ConfigManager {
 		if let Some(format) = sidecar.format {
 			self.set_document_format(doc_path, &format);
 		}
+		if let Some(position) = sidecar.temporary_bookmark {
+			self.set_temporary_bookmark(doc_path, Some(position));
+		}
 		if !sidecar.bookmarks.is_empty() {
 			let key = self.get_doc_key(doc_path);
 			let mut data = self.data.borrow_mut();
@@ -995,6 +1024,7 @@ impl ConfigManager {
 			last_position: doc.map(|d| d.last_position).filter(|&p| p > 0),
 			format: doc.and_then(|d| if d.format.is_empty() { None } else { Some(d.format.clone()) }),
 			bookmarks: doc.map(|d| d.bookmarks.clone()).unwrap_or_default(),
+			temporary_bookmark: doc.and_then(|d| d.temporary_bookmark),
 		};
 		if let Ok(s) = toml::to_string_pretty(&sidecar) {
 			let _ = fs::write(export_path, s);
@@ -1146,5 +1176,35 @@ mod tests {
 		assert!(!config.get_app_bool("render_tables_inline", true));
 		config.set_app_bool("render_tables_inline", true);
 		assert!(config.get_app_bool("render_tables_inline", true));
+	}
+
+	#[test]
+	fn temporary_bookmark_set_get_overwrite_clear() {
+		let mut config = ConfigManager::new();
+		config.initialized = true;
+		let path = "book.epub";
+		assert_eq!(config.get_temporary_bookmark(path), None);
+		config.set_temporary_bookmark(path, Some(42_000));
+		assert_eq!(config.get_temporary_bookmark(path), Some(42_000));
+		config.set_temporary_bookmark(path, Some(43_000));
+		assert_eq!(config.get_temporary_bookmark(path), Some(43_000));
+		config.set_temporary_bookmark(path, None);
+		assert_eq!(config.get_temporary_bookmark(path), None);
+	}
+
+	#[test]
+	fn temporary_bookmark_serializes_and_loads() {
+		let doc =
+			DocumentConfig { path: "book.epub".into(), temporary_bookmark: Some(12_345), ..DocumentConfig::default() };
+		let serialized = toml::to_string(&doc).unwrap();
+		let parsed: DocumentConfig = toml::from_str(&serialized).unwrap();
+		assert_eq!(parsed.temporary_bookmark, Some(12_345));
+	}
+
+	#[test]
+	fn temporary_bookmark_defaults_to_none_when_missing() {
+		// Old config files without the field must load as None.
+		let parsed: DocumentConfig = toml::from_str("path = \"book.epub\"\n").unwrap();
+		assert_eq!(parsed.temporary_bookmark, None);
 	}
 }

--- a/crates/paperback/src/ui/document_manager.rs
+++ b/crates/paperback/src/ui/document_manager.rs
@@ -27,7 +27,9 @@ use wxdragon::{
 use super::rtf_write::{self, RtfFontInfo};
 use super::{
 	main_window::{SLEEP_TIMER_DURATION_MINUTES, SLEEP_TIMER_START_MS},
-	menu_ids, status,
+	menu_ids,
+	navigation::{move_to_offset_and_record_history, persist_navigation_history},
+	status,
 };
 
 pub struct DocumentTab {
@@ -74,6 +76,8 @@ const WXK_UP: i32 = 315;
 #[cfg(target_os = "windows")]
 const WXK_DOWN: i32 = 317;
 const KEY_EQUALS: i32 = 61;
+const KEY_SLASH: i32 = 47;
+const KEY_BACKSLASH: i32 = 92;
 
 pub struct DocumentManager {
 	frame: Frame,
@@ -529,6 +533,56 @@ impl DocumentManager {
 		self.last_sound_position.set(None);
 	}
 
+	/// Sets the temporary bookmark at the current caret position and announces it.
+	fn set_temporary_bookmark(&self) {
+		let Some(tab) = self.active_tab() else {
+			return;
+		};
+		let position = tab.text_ctrl.get_insertion_point();
+		let path_str = tab.file_path.to_string_lossy().to_string();
+		let config = self.config.lock().unwrap();
+		config.set_temporary_bookmark(&path_str, Some(position));
+		config.flush();
+		drop(config);
+		// TRANSLATORS: Announced after setting a temporary bookmark at the current position
+		live_region::announce(self.live_region_label, &t("Temporary bookmark set."));
+	}
+
+	/// Jumps to the temporary bookmark, announcing the line text there, or "No temporary bookmark."
+	/// if none has been set.
+	fn jump_to_temporary_bookmark(&mut self) {
+		let path_str = {
+			let Some(tab) = self.active_tab() else {
+				return;
+			};
+			tab.file_path.to_string_lossy().to_string()
+		};
+		let position = {
+			let config = self.config.lock().unwrap();
+			config.get_temporary_bookmark(&path_str)
+		};
+		let Some(position) = position else {
+			// TRANSLATORS: Announced when jumping to a temporary bookmark but none has been set
+			live_region::announce(self.live_region_label, &t("No temporary bookmark."));
+			return;
+		};
+		let (message, track, update) = {
+			let tab = self.active_tab_mut().unwrap();
+			let position = position.min(tab.text_ctrl.get_last_position().max(0));
+			let line_text = tab.session.get_line_text(position);
+			let message = if line_text.trim().is_empty() {
+				// TRANSLATORS: Fallback announcement when jumping to a temporary bookmark on a blank line
+				t("Temporary bookmark.")
+			} else {
+				line_text
+			};
+			let update = move_to_offset_and_record_history(tab, position);
+			(message, tab.track, update)
+		};
+		live_region::announce(self.live_region_label, &message);
+		persist_navigation_history(&self.config, track.then_some(&update));
+	}
+
 	pub fn apply_font(&self, font: &Font) {
 		for tab in &self.tabs {
 			tab.text_ctrl.set_font(font);
@@ -821,6 +875,20 @@ impl DocumentManager {
 					kbd.event.skip(false);
 					if let Ok(dm) = dm_for_announce.try_lock() {
 						dm.announce_current_percent();
+					}
+					return;
+				}
+				if key == KEY_SLASH && !kbd.shift_down() && !kbd.control_down() && !kbd.alt_down() {
+					kbd.event.skip(false);
+					if let Ok(dm) = dm_for_announce.try_lock() {
+						dm.set_temporary_bookmark();
+					}
+					return;
+				}
+				if key == KEY_BACKSLASH && !kbd.shift_down() && !kbd.control_down() && !kbd.alt_down() {
+					kbd.event.skip(false);
+					if let Ok(mut dm) = dm_for_announce.try_lock() {
+						dm.jump_to_temporary_bookmark();
 					}
 					return;
 				}


### PR DESCRIPTION
## Summary

Adds a **temporary bookmark** — a single, per-document "scratchpad" spot you can set and jump back to without cluttering the real bookmark system. My rationale is: sometimes you need to jump back and forth between a couple of places; a temporary bookmark is great for this. And it's not an important bookmark... we just want to forget about it later and not have it clutter up our real/long-lasting bookmarks. This is similar to NVDA's Place Markers addon, which has a similar temporary bookmark feature.

- **`/`** — set the temporary bookmark at the current position (overwrites any previous one)
- **`\`** — jump back to it; announces "No temporary bookmark." if none has been set. (these keystrokes, I wasn't sure which to use... I thought these made sense at least for a proof of concept)
- Per-document and persists across restarts
- Included in `.paperback` export/import, like the reading position and real bookmarks

## Design

Stored as a separate per-document config field (`temporary_bookmark`), not inside the bookmarks list. That keeps it automatically invisible to the real bookmark system:

- Not part of `b`/`Shift+b` next/previous bookmark cycling
- Not shown in the Ctrl+B / Ctrl+Alt+B bookmark lists (or any list of bookmarks)
- Never triggers the bookmark click sound

## Testing

- New core tests: set/get/overwrite/clear, serde round-trip, and old-config compatibility (missing field loads as none). Full `paperback-core` suite: 509 passing.
- `cargo +nightly fmt --check`, `cargo clippy --workspace --all-targets --release`, and the release build all pass.
- Manually tested with NVDA on Windows (set, jump, no-temp-bookmark case, persistence across restart, and confirmed it stays out of bookmark lists/navigation).
- Don't know if it works on all platforms (the key handler is cross-platform but I can't test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
