### PR TITLE
Fix page navigation announcing the page number twice

### DIFF
--- a/crates/paperback-core/src/session.rs
+++ b/crates/paperback-core/src/session.rs
@@ -1343,6 +1343,32 @@ impl DocumentSession {
 		buf.content[start_byte..line_end_byte].to_string()
 	}
 
+	/// Returns the first non-blank line of real content at or after `position`, skipping blank
+	/// lines and bare page-number headers (e.g. "27" or "Page 27"). Returns an empty string if
+	/// no such line exists. Used for page-navigation announcements so the page number isn't
+	/// announced twice (the page marker's own text is a "Page N" label).
+	#[must_use]
+	pub fn first_content_line_after(&self, position: i64) -> String {
+		let buf = &self.handle.document().buffer;
+		let total_chars = buf.char_count();
+		let mut pos = usize::try_from(position.max(0)).unwrap_or(0).min(total_chars);
+		let newlines = buf.newline_positions();
+		loop {
+			let idx = newlines.partition_point(|&p| p < pos);
+			let line_start = if idx == 0 { 0 } else { newlines[idx - 1] + 1 };
+			let line_end = newlines.get(idx).copied().unwrap_or(total_chars);
+			let line =
+				self.get_text_range(i64::try_from(line_start).unwrap_or(0), i64::try_from(line_end).unwrap_or(0));
+			if is_content_line(line.trim()) {
+				return line;
+			}
+			if line_end >= total_chars {
+				return String::new();
+			}
+			pos = line_end + 1;
+		}
+	}
+
 	#[must_use]
 	pub fn get_line_markers(&self, line: i64) -> Vec<LineMarker> {
 		let start_pos = self.position_from_line(line);
@@ -1409,6 +1435,17 @@ impl DocumentSession {
 	}
 }
 
+/// Whether a trimmed line looks like real page content rather than a blank line, a bare page
+/// number ("27", "27 / 300"), or a "Page N" header.
+fn is_content_line(trimmed: &str) -> bool {
+	if trimmed.is_empty() {
+		return false;
+	}
+	let lower = trimmed.to_ascii_lowercase();
+	let body = lower.strip_prefix("page ").unwrap_or(&lower);
+	body.chars().any(|c| c.is_alphabetic())
+}
+
 #[cfg(test)]
 mod tests {
 	use super::*;
@@ -1444,6 +1481,38 @@ mod tests {
 			parser_flags,
 			last_stable_position: None,
 		}
+	}
+
+	fn session_with_content(content: &str) -> DocumentSession {
+		let mut buffer = DocumentBuffer::with_content(content.to_string());
+		let mut doc = Document::new().with_title("Title".to_string()).with_author("Author".to_string());
+		doc.set_buffer(buffer);
+		DocumentSession {
+			handle: DocumentHandle::new(doc),
+			file_path: "book.epub".to_string(),
+			history: Vec::new(),
+			history_index: 0,
+			parser_flags: ParserFlags::empty(),
+			last_stable_position: None,
+		}
+	}
+
+	#[test]
+	fn first_content_line_after_skips_headers_and_blank_lines() {
+		let session = session_with_content("27\n\nChapter One\nThe old house stood at the end of the lane.\n");
+		assert_eq!(session.first_content_line_after(0), "Chapter One");
+	}
+
+	#[test]
+	fn first_content_line_after_skips_bare_page_number_header() {
+		let session = session_with_content("27\n\nThe old house stood at the end of the lane.\n");
+		assert_eq!(session.first_content_line_after(0), "The old house stood at the end of the lane.");
+	}
+
+	#[test]
+	fn first_content_line_after_returns_empty_without_content() {
+		let session = session_with_content("27\n\n");
+		assert_eq!(session.first_content_line_after(0), "");
 	}
 
 	#[test]

--- a/crates/paperback/src/ui/navigation.rs
+++ b/crates/paperback/src/ui/navigation.rs
@@ -219,10 +219,14 @@ fn format_nav_found_message(
 			format!("{wrap_prefix}{message}")
 		}
 		NavFoundFormat::PageFormat => {
-			// TRANSLATORS: Announcement when landing on a page; %d is the page number, %s is the page text
-			let template = t("Page %d: %s");
 			let page_text = (context_index + 1).to_string();
-			let message = template.replacen("%d", &page_text, 1).replacen("%s", context_text, 1);
+			let message = if context_text.is_empty() {
+				// TRANSLATORS: Announcement when landing on a page with no extractable text; %d is the page number
+				t("Page %d").replacen("%d", &page_text, 1)
+			} else {
+				// TRANSLATORS: Announcement when landing on a page; %d is the page number, %s is the page text
+				t("Page %d: %s").replacen("%d", &page_text, 1).replacen("%s", context_text, 1)
+			};
 			format!("{wrap_prefix}{message}")
 		}
 		NavFoundFormat::LinkFormat => {
@@ -258,8 +262,14 @@ fn apply_navigation_result(
 		live_region::announce(live_region_label, message);
 		return false;
 	}
-	let mut context_text = result.marker_text.clone();
-	if context_text.is_empty() {
+	let mut context_text = match target {
+		// PDFs fabricate a "Page N" label on page markers; announcing it alongside the page
+		// number the formatter adds would read the number twice, so use the page's first line
+		// of real content instead.
+		MarkerNavTarget::Page => tab.session.first_content_line_after(result.offset),
+		_ => result.marker_text.clone(),
+	};
+	if context_text.is_empty() && !matches!(target, MarkerNavTarget::Page) {
 		context_text = tab.session.get_line_text(result.offset);
 	}
 	let context_index = match target {


### PR DESCRIPTION
## Summary

Fixes page navigation announcing the page number twice: pressing `p`/`Shift+p` used to read something like **"Page 27: Page 27"**, because the page marker's text is itself the fabricated label "Page N". Now it announces the page number once, followed by the first line of the page's real content — e.g. **"Page 27: The old house stood at the end of the lane."**

## Root cause

For PDFs, the parser stamps each page marker with a label like `"Page 27"` (`parser/pdf.rs`). Page navigation copies that label into the announcement, and the formatter prefixes it with `"Page %d: "` built from the page index — so the number was read twice, from two different sources.

## The fix

- **New session helper** `DocumentSession::first_content_line_after(position)`: scans forward from the page start, skipping blank lines and bare page-number headers ("27", "Page 27"), and returns the first line of real content.
- **Announcement** (`navigation.rs`): for page navigation, use that content line instead of the marker label. Pages with no extractable text (e.g. image-only) announce just "Page N".
- I'm testing some epub files, but none of the ones I've tried (only a few TBH) online seem to have pages that Paperback can detect... p and shift+p just say "no pages".

## Testing

- New core tests: header/blank skipping, bare page-number header, and no-content cases. Full `paperback-core` suite: 517 passing.
- `cargo +nightly fmt --check`, `cargo clippy --workspace --all-targets --release`, and the release build all pass.
- Manually tested with NVDA on Windows.
- Also tried several EPUBs; none exposed a page list, so `p`/`Shift+p` on EPUBs still reports "No pages." (unchanged). The page-name nuance only applies to EPUBs that carry a page list, which I wasn't able to find.
- I can only test on Windows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
