### PR TITLE
Stop creating a macOS home-directory lock file

### DIFF
--- a/crates/paperback/src/ipc.rs
+++ b/crates/paperback/src/ipc.rs
@@ -3,11 +3,14 @@ use std::{
 	path::{Path, PathBuf},
 };
 
+#[cfg(any(target_os = "linux", target_os = "windows", test))]
 pub const IPC_COMMAND_ACTIVATE: &str = "ACTIVATE";
 #[cfg(any(target_os = "linux", target_os = "windows", test))]
 pub const IPC_COMMAND_TOGGLE_VISIBILITY: &str = "TOGGLE";
+#[cfg(any(target_os = "linux", target_os = "windows"))]
 pub const SINGLE_INSTANCE_NAME: &str = "paperback_running";
 
+#[cfg(any(target_os = "linux", target_os = "windows", test))]
 #[derive(Debug, Clone)]
 pub enum IpcCommand {
 	Activate,

--- a/crates/paperback/src/ui/app.rs
+++ b/crates/paperback/src/ui/app.rs
@@ -1,7 +1,8 @@
+#[cfg(any(target_os = "linux", target_os = "windows"))]
+use std::process;
 use std::{
 	env,
 	path::Path,
-	process,
 	rc::Rc,
 	sync::{
 		Mutex,
@@ -15,12 +16,12 @@ use wxdragon::prelude::*;
 use super::MainWindow;
 #[cfg(not(target_os = "macos"))]
 use crate::config_ext::get_update_channel;
-#[cfg(any(target_os = "linux", target_os = "windows", test))]
+#[cfg(any(target_os = "linux", target_os = "windows"))]
 use crate::ipc::IPC_COMMAND_TOGGLE_VISIBILITY;
+#[cfg(any(target_os = "linux", target_os = "windows"))]
+use crate::ipc::{IPC_COMMAND_ACTIVATE, IpcCommand, SINGLE_INSTANCE_NAME};
 use crate::{
-	config_ext::config_toml_path,
-	ipc::{IPC_COMMAND_ACTIVATE, IpcCommand, SINGLE_INSTANCE_NAME, normalize_cli_path},
-	legacy_config::migrate_if_needed,
+	config_ext::config_toml_path, ipc::normalize_cli_path, legacy_config::migrate_if_needed,
 	translation_manager::TranslationManager,
 };
 
@@ -28,6 +29,7 @@ pub struct PaperbackApp {
 	_config: Rc<Mutex<ConfigManager>>,
 	_main_window: Rc<MainWindow>,
 	_pipe_server: PipeServer,
+	#[cfg(any(target_os = "linux", target_os = "windows"))]
 	_single_instance_checker: Option<SingleInstanceChecker>,
 }
 
@@ -47,15 +49,19 @@ impl PaperbackApp {
 			}
 		}
 		let config = Rc::new(Mutex::new(config));
-		let single_instance_checker = SingleInstanceChecker::new(SINGLE_INSTANCE_NAME, None);
-		if let Some(checker) = single_instance_checker.as_ref()
-			&& checker.is_another_running()
-		{
-			let cmd = ipc_command_from_cli();
-			tracing::info!(command = ?cmd, "another instance is running, forwarding command and exiting");
-			send_ipc_command(&cmd);
-			process::exit(0);
-		}
+		#[cfg(any(target_os = "linux", target_os = "windows"))]
+		let single_instance_checker = {
+			let checker = SingleInstanceChecker::new(SINGLE_INSTANCE_NAME, None);
+			if let Some(checker) = checker.as_ref()
+				&& checker.is_another_running()
+			{
+				let cmd = ipc_command_from_cli();
+				tracing::info!(command = ?cmd, "another instance is running, forwarding command and exiting");
+				send_ipc_command(&cmd);
+				process::exit(0);
+			}
+			checker
+		};
 		let main_window = Rc::new(MainWindow::new(Rc::clone(&config)));
 		MAIN_WINDOW_PTR.store(Rc::as_ptr(&main_window) as usize, Ordering::SeqCst);
 		set_top_window(main_window.frame());
@@ -94,6 +100,7 @@ impl PaperbackApp {
 			_config: config,
 			_main_window: main_window,
 			_pipe_server: pipe_server,
+			#[cfg(any(target_os = "linux", target_os = "windows"))]
 			_single_instance_checker: single_instance_checker,
 		}
 	}
@@ -115,6 +122,7 @@ pub fn main_window_from_ptr() -> Option<&'static MainWindow> {
 	unsafe { (ptr as *const MainWindow).as_ref() }
 }
 
+#[cfg(any(target_os = "linux", target_os = "windows"))]
 fn ipc_command_from_cli() -> IpcCommand {
 	if let Some(path) = env::args().nth(1) {
 		let normalized = normalize_cli_path(Path::new(&path));
@@ -328,6 +336,7 @@ fn start_pipe_server(main_window: &Rc<MainWindow>) -> PipeServer {
 	PipeServer {}
 }
 
+#[cfg(any(target_os = "linux", target_os = "windows"))]
 fn send_ipc_command(command: &IpcCommand) {
 	tracing::debug!(?command, "sending IPC command to existing instance");
 	let payload = match command {
@@ -346,6 +355,4 @@ fn send_ipc_command(command: &IpcCommand) {
 	}
 	#[cfg(target_os = "linux")]
 	pipe_unix::send(&payload);
-	#[cfg(not(any(windows, target_os = "linux")))]
-	let _ = payload;
 }


### PR DESCRIPTION
## Summary

- disable wxWidgets single-instance lock handling on macOS
- retain the existing single-instance and IPC behavior on Windows and Linux
- compile platform-specific IPC declarations only where they are used

## Why

Paperback passed no lock directory to wxDragon's `SingleInstanceChecker`. On Unix platforms, wxDragon defaults that lock to the user's home directory, causing the mac client to create `~/paperback_running`.

macOS already delivers reopen and document-open events to the running application through native application events. Paperback also has no macOS command-forwarding transport, so retaining the cross-platform lock checker there created an unwanted home-directory file without providing functional IPC forwarding.

## User impact

The mac client no longer creates `~/paperback_running`. Windows and Linux single-instance behavior is unchanged.

## Validation

- `cargo check -p paperback`
- `cargo test -p paperback ipc::tests` (10 passed)
- project pre-commit hooks, including nightly `cargo fmt`
