### PR TITLE
Improvements for the All Documents dialog

### DIFF
--- a/crates/paperback-core/src/config.rs
+++ b/crates/paperback-core/src/config.rs
@@ -97,6 +97,854 @@ impl Default for HotkeyConfig {
 	}
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ShortcutCategory {
+	File,
+	Go,
+	Tools,
+	Help,
+}
+
+impl ShortcutCategory {
+	pub const fn all() -> &'static [Self] {
+		&[Self::File, Self::Go, Self::Tools, Self::Help]
+	}
+
+	pub const fn display_name(self) -> &'static str {
+		match self {
+			Self::File => "File",
+			Self::Go => "Go",
+			Self::Tools => "Tools",
+			Self::Help => "Help",
+		}
+	}
+
+	pub fn actions(self) -> Vec<ActionId> {
+		ActionId::all().iter().copied().filter(|a| a.category() == self).collect()
+	}
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ActionId {
+	Open,
+	Close,
+	CloseAll,
+	ReopenLastClosed,
+	ShowAllRecentDocuments,
+	Exit,
+	Find,
+	FindNext,
+	FindPrevious,
+	GoToLine,
+	GoToPercent,
+	GoToPage,
+	GoBack,
+	GoForward,
+	AnnouncePercent,
+	SetTemporaryBookmark,
+	JumpToTemporaryBookmark,
+	PreviousSection,
+	NextSection,
+	PreviousHeading,
+	NextHeading,
+	PreviousHeading1,
+	NextHeading1,
+	PreviousHeading2,
+	NextHeading2,
+	PreviousHeading3,
+	NextHeading3,
+	PreviousHeading4,
+	NextHeading4,
+	PreviousHeading5,
+	NextHeading5,
+	PreviousHeading6,
+	NextHeading6,
+	PreviousPage,
+	NextPage,
+	PreviousBookmark,
+	NextBookmark,
+	PreviousNote,
+	NextNote,
+	JumpToAllBookmarks,
+	JumpToBookmarksOnly,
+	JumpToNotesOnly,
+	ViewNoteText,
+	PreviousLink,
+	NextLink,
+	PreviousImage,
+	NextImage,
+	PreviousFigure,
+	NextFigure,
+	PreviousTable,
+	NextTable,
+	PreviousSeparator,
+	NextSeparator,
+	PreviousList,
+	NextList,
+	PreviousListItem,
+	NextListItem,
+	ContainerStart,
+	ContainerEnd,
+	WordCount,
+	DocumentInfo,
+	TableOfContents,
+	ElementsList,
+	RevealFileInFolder,
+	OpenInWebView,
+	ViewSource,
+	ToggleBookmark,
+	BookmarkWithNote,
+	ToggleWordWrap,
+	ToggleFullScreen,
+	Options,
+	SleepTimer,
+	CustomizeShortcuts,
+	ImportDocumentData,
+	ExportDocumentData,
+	ExportToPlainText,
+	ExportToHtml,
+	ExportToMarkdown,
+	About,
+	ViewHelpBrowser,
+	ViewHelpPaperback,
+	CheckForUpdates,
+	Donate,
+}
+
+impl ActionId {
+	pub const fn all() -> &'static [Self] {
+		&[
+			Self::Open,
+			Self::Close,
+			Self::CloseAll,
+			Self::ReopenLastClosed,
+			Self::ShowAllRecentDocuments,
+			Self::Exit,
+			Self::Find,
+			Self::FindNext,
+			Self::FindPrevious,
+			Self::GoToLine,
+			Self::GoToPercent,
+			Self::GoToPage,
+			Self::GoBack,
+			Self::GoForward,
+			Self::AnnouncePercent,
+			Self::SetTemporaryBookmark,
+			Self::JumpToTemporaryBookmark,
+			Self::PreviousSection,
+			Self::NextSection,
+			Self::PreviousHeading,
+			Self::NextHeading,
+			Self::PreviousHeading1,
+			Self::NextHeading1,
+			Self::PreviousHeading2,
+			Self::NextHeading2,
+			Self::PreviousHeading3,
+			Self::NextHeading3,
+			Self::PreviousHeading4,
+			Self::NextHeading4,
+			Self::PreviousHeading5,
+			Self::NextHeading5,
+			Self::PreviousHeading6,
+			Self::NextHeading6,
+			Self::PreviousPage,
+			Self::NextPage,
+			Self::PreviousBookmark,
+			Self::NextBookmark,
+			Self::PreviousNote,
+			Self::NextNote,
+			Self::JumpToAllBookmarks,
+			Self::JumpToBookmarksOnly,
+			Self::JumpToNotesOnly,
+			Self::ViewNoteText,
+			Self::PreviousLink,
+			Self::NextLink,
+			Self::PreviousImage,
+			Self::NextImage,
+			Self::PreviousFigure,
+			Self::NextFigure,
+			Self::PreviousTable,
+			Self::NextTable,
+			Self::PreviousSeparator,
+			Self::NextSeparator,
+			Self::PreviousList,
+			Self::NextList,
+			Self::PreviousListItem,
+			Self::NextListItem,
+			Self::ContainerStart,
+			Self::ContainerEnd,
+			Self::WordCount,
+			Self::DocumentInfo,
+			Self::TableOfContents,
+			Self::ElementsList,
+			Self::RevealFileInFolder,
+			Self::OpenInWebView,
+			Self::ViewSource,
+			Self::ToggleBookmark,
+			Self::BookmarkWithNote,
+			Self::ToggleWordWrap,
+			Self::ToggleFullScreen,
+			Self::Options,
+			Self::SleepTimer,
+			Self::CustomizeShortcuts,
+			Self::ImportDocumentData,
+			Self::ExportDocumentData,
+			Self::ExportToPlainText,
+			Self::ExportToHtml,
+			Self::ExportToMarkdown,
+			Self::About,
+			Self::ViewHelpBrowser,
+			Self::ViewHelpPaperback,
+			Self::CheckForUpdates,
+			Self::Donate,
+		]
+	}
+
+	pub const fn category(self) -> ShortcutCategory {
+		match self {
+			Self::Open
+			| Self::Close
+			| Self::CloseAll
+			| Self::ReopenLastClosed
+			| Self::ShowAllRecentDocuments
+			| Self::Exit => ShortcutCategory::File,
+			Self::Find
+			| Self::FindNext
+			| Self::FindPrevious
+			| Self::GoToLine
+			| Self::GoToPercent
+			| Self::GoToPage
+			| Self::GoBack
+			| Self::GoForward
+			| Self::AnnouncePercent
+			| Self::SetTemporaryBookmark
+			| Self::JumpToTemporaryBookmark
+			| Self::PreviousSection
+			| Self::NextSection
+			| Self::PreviousHeading
+			| Self::NextHeading
+			| Self::PreviousHeading1
+			| Self::NextHeading1
+			| Self::PreviousHeading2
+			| Self::NextHeading2
+			| Self::PreviousHeading3
+			| Self::NextHeading3
+			| Self::PreviousHeading4
+			| Self::NextHeading4
+			| Self::PreviousHeading5
+			| Self::NextHeading5
+			| Self::PreviousHeading6
+			| Self::NextHeading6
+			| Self::PreviousPage
+			| Self::NextPage
+			| Self::PreviousBookmark
+			| Self::NextBookmark
+			| Self::PreviousNote
+			| Self::NextNote
+			| Self::JumpToAllBookmarks
+			| Self::JumpToBookmarksOnly
+			| Self::JumpToNotesOnly
+			| Self::ViewNoteText
+			| Self::PreviousLink
+			| Self::NextLink
+			| Self::PreviousImage
+			| Self::NextImage
+			| Self::PreviousFigure
+			| Self::NextFigure
+			| Self::PreviousTable
+			| Self::NextTable
+			| Self::PreviousSeparator
+			| Self::NextSeparator
+			| Self::PreviousList
+			| Self::NextList
+			| Self::PreviousListItem
+			| Self::NextListItem
+			| Self::ContainerStart
+			| Self::ContainerEnd => ShortcutCategory::Go,
+			Self::WordCount
+			| Self::DocumentInfo
+			| Self::TableOfContents
+			| Self::ElementsList
+			| Self::RevealFileInFolder
+			| Self::OpenInWebView
+			| Self::ViewSource
+			| Self::ToggleBookmark
+			| Self::BookmarkWithNote
+			| Self::ToggleWordWrap
+			| Self::ToggleFullScreen
+			| Self::Options
+			| Self::SleepTimer
+			| Self::CustomizeShortcuts
+			| Self::ImportDocumentData
+			| Self::ExportDocumentData
+			| Self::ExportToPlainText
+			| Self::ExportToHtml
+			| Self::ExportToMarkdown => ShortcutCategory::Tools,
+			Self::About | Self::ViewHelpBrowser | Self::ViewHelpPaperback | Self::CheckForUpdates | Self::Donate => {
+				ShortcutCategory::Help
+			}
+		}
+	}
+
+	pub const fn display_name(self) -> &'static str {
+		match self {
+			Self::Open => "Open...",
+			Self::Close => "Close",
+			Self::CloseAll => "Close All",
+			Self::ReopenLastClosed => "Reopen Last Closed",
+			Self::ShowAllRecentDocuments => "Show All Recent Documents...",
+			Self::Exit => "Exit",
+			Self::Find => "Find...",
+			Self::FindNext => "Find Next",
+			Self::FindPrevious => "Find Previous",
+			Self::GoToLine => "Go to Line...",
+			Self::GoToPercent => "Go to Percent...",
+			Self::GoToPage => "Go to Page...",
+			Self::GoBack => "Go Back",
+			Self::GoForward => "Go Forward",
+			Self::AnnouncePercent => "Announce Percentage",
+			Self::SetTemporaryBookmark => "Set Temporary Bookmark",
+			Self::JumpToTemporaryBookmark => "Jump to Temporary Bookmark",
+			Self::PreviousSection => "Previous Section",
+			Self::NextSection => "Next Section",
+			Self::PreviousHeading => "Previous Heading",
+			Self::NextHeading => "Next Heading",
+			Self::PreviousHeading1 => "Previous Heading Level 1",
+			Self::NextHeading1 => "Next Heading Level 1",
+			Self::PreviousHeading2 => "Previous Heading Level 2",
+			Self::NextHeading2 => "Next Heading Level 2",
+			Self::PreviousHeading3 => "Previous Heading Level 3",
+			Self::NextHeading3 => "Next Heading Level 3",
+			Self::PreviousHeading4 => "Previous Heading Level 4",
+			Self::NextHeading4 => "Next Heading Level 4",
+			Self::PreviousHeading5 => "Previous Heading Level 5",
+			Self::NextHeading5 => "Next Heading Level 5",
+			Self::PreviousHeading6 => "Previous Heading Level 6",
+			Self::NextHeading6 => "Next Heading Level 6",
+			Self::PreviousPage => "Previous Page",
+			Self::NextPage => "Next Page",
+			Self::PreviousBookmark => "Previous Bookmark",
+			Self::NextBookmark => "Next Bookmark",
+			Self::PreviousNote => "Previous Note",
+			Self::NextNote => "Next Note",
+			Self::JumpToAllBookmarks => "Jump to All Bookmarks...",
+			Self::JumpToBookmarksOnly => "Jump to Bookmarks Only...",
+			Self::JumpToNotesOnly => "Jump to Notes Only...",
+			Self::ViewNoteText => "View Note Text",
+			Self::PreviousLink => "Previous Link",
+			Self::NextLink => "Next Link",
+			Self::PreviousImage => "Previous Image",
+			Self::NextImage => "Next Image",
+			Self::PreviousFigure => "Previous Figure",
+			Self::NextFigure => "Next Figure",
+			Self::PreviousTable => "Previous Table",
+			Self::NextTable => "Next Table",
+			Self::PreviousSeparator => "Previous Separator",
+			Self::NextSeparator => "Next Separator",
+			Self::PreviousList => "Previous List",
+			Self::NextList => "Next List",
+			Self::PreviousListItem => "Previous List Item",
+			Self::NextListItem => "Next List Item",
+			Self::ContainerStart => "Container Start",
+			Self::ContainerEnd => "Past Container End",
+			Self::WordCount => "Word Count",
+			Self::DocumentInfo => "Document Info",
+			Self::TableOfContents => "Table of Contents",
+			Self::ElementsList => "Elements List...",
+			Self::RevealFileInFolder => "Reveal File in Folder",
+			Self::OpenInWebView => "Open in Web View",
+			Self::ViewSource => "View Source",
+			Self::ToggleBookmark => "Toggle Bookmark",
+			Self::BookmarkWithNote => "Bookmark with Note",
+			Self::ToggleWordWrap => "Toggle Word Wrap",
+			Self::ToggleFullScreen => "Full Screen",
+			Self::Options => "Options...",
+			Self::SleepTimer => "Sleep Timer...",
+			Self::CustomizeShortcuts => "Customize Keyboard Shortcuts...",
+			Self::ImportDocumentData => "Import Document Data...",
+			Self::ExportDocumentData => "Export Document Data...",
+			Self::ExportToPlainText => "Export to Plain Text...",
+			Self::ExportToHtml => "Export to HTML...",
+			Self::ExportToMarkdown => "Export to Markdown...",
+			Self::About => "About Paperback",
+			Self::ViewHelpBrowser => "View Help in Browser",
+			Self::ViewHelpPaperback => "View Help in Paperback",
+			Self::CheckForUpdates => "Check for Updates",
+			Self::Donate => "Donate",
+		}
+	}
+
+	pub fn default_chord(self) -> Option<KeyChord> {
+		#[cfg(target_os = "macos")]
+		match self {
+			Self::Open => Some(KeyChord::new(true, false, false, "O")),
+			Self::Close => Some(KeyChord::new(true, false, false, "W")),
+			Self::CloseAll => Some(KeyChord::new(true, false, true, "W")),
+			Self::ReopenLastClosed => Some(KeyChord::new(true, false, true, "T")),
+			Self::ShowAllRecentDocuments => Some(KeyChord::new(true, false, false, "R")),
+			Self::Exit => None,
+			Self::Find => Some(KeyChord::new(true, false, false, "F")),
+			Self::FindNext => Some(KeyChord::new(true, false, false, "G")),
+			Self::FindPrevious => Some(KeyChord::new(true, false, true, "G")),
+			Self::GoToLine => Some(KeyChord::new(true, false, false, "L")),
+			Self::GoToPercent => Some(KeyChord::new(true, false, true, "L")),
+			Self::GoToPage => Some(KeyChord::new(true, false, false, "P")),
+			Self::GoBack => Some(KeyChord::new(true, false, false, "[")),
+			Self::GoForward => Some(KeyChord::new(true, false, false, "]")),
+			Self::AnnouncePercent => Some(KeyChord::new(false, false, false, "=")),
+			Self::SetTemporaryBookmark => Some(KeyChord::new(false, false, false, "/")),
+			Self::JumpToTemporaryBookmark => Some(KeyChord::new(false, false, false, "\\")),
+			Self::PreviousSection => Some(KeyChord::new(false, false, false, "[")),
+			Self::NextSection => Some(KeyChord::new(false, false, false, "]")),
+			Self::PreviousHeading => Some(KeyChord::new(false, false, true, "H")),
+			Self::NextHeading => Some(KeyChord::new(false, false, false, "H")),
+			Self::PreviousHeading1 => Some(KeyChord::new(false, false, true, "1")),
+			Self::NextHeading1 => Some(KeyChord::new(false, false, false, "1")),
+			Self::PreviousHeading2 => Some(KeyChord::new(false, false, true, "2")),
+			Self::NextHeading2 => Some(KeyChord::new(false, false, false, "2")),
+			Self::PreviousHeading3 => Some(KeyChord::new(false, false, true, "3")),
+			Self::NextHeading3 => Some(KeyChord::new(false, false, false, "3")),
+			Self::PreviousHeading4 => Some(KeyChord::new(false, false, true, "4")),
+			Self::NextHeading4 => Some(KeyChord::new(false, false, false, "4")),
+			Self::PreviousHeading5 => Some(KeyChord::new(false, false, true, "5")),
+			Self::NextHeading5 => Some(KeyChord::new(false, false, false, "5")),
+			Self::PreviousHeading6 => Some(KeyChord::new(false, false, true, "6")),
+			Self::NextHeading6 => Some(KeyChord::new(false, false, false, "6")),
+			Self::PreviousPage => Some(KeyChord::new(false, false, true, "P")),
+			Self::NextPage => Some(KeyChord::new(false, false, false, "P")),
+			Self::PreviousBookmark => Some(KeyChord::new(false, false, true, "B")),
+			Self::NextBookmark => Some(KeyChord::new(false, false, false, "B")),
+			Self::PreviousNote => Some(KeyChord::new(false, false, true, "N")),
+			Self::NextNote => Some(KeyChord::new(false, false, false, "N")),
+			Self::JumpToAllBookmarks => Some(KeyChord::new(true, false, false, "B")),
+			Self::JumpToBookmarksOnly => Some(KeyChord::new(true, true, false, "B")),
+			Self::JumpToNotesOnly => Some(KeyChord::new(true, true, false, "M")),
+			Self::ViewNoteText => Some(KeyChord::new_raw_ctrl(true, false, true, "W")),
+			Self::PreviousLink => Some(KeyChord::new(false, false, true, "K")),
+			Self::NextLink => Some(KeyChord::new(false, false, false, "K")),
+			Self::PreviousImage => Some(KeyChord::new(false, false, true, "G")),
+			Self::NextImage => Some(KeyChord::new(false, false, false, "G")),
+			Self::PreviousFigure => Some(KeyChord::new(false, false, true, "F")),
+			Self::NextFigure => Some(KeyChord::new(false, false, false, "F")),
+			Self::PreviousTable => Some(KeyChord::new(false, false, true, "T")),
+			Self::NextTable => Some(KeyChord::new(false, false, false, "T")),
+			Self::PreviousSeparator => Some(KeyChord::new(false, false, true, "S")),
+			Self::NextSeparator => Some(KeyChord::new(false, false, false, "S")),
+			Self::PreviousList => Some(KeyChord::new(false, false, true, "L")),
+			Self::NextList => Some(KeyChord::new(false, false, false, "L")),
+			Self::PreviousListItem => Some(KeyChord::new(false, false, true, "I")),
+			Self::NextListItem => Some(KeyChord::new(false, false, false, "I")),
+			Self::ContainerStart => Some(KeyChord::new(false, false, true, ",")),
+			Self::ContainerEnd => Some(KeyChord::new(false, false, false, ",")),
+			Self::WordCount => Some(KeyChord::new_raw_ctrl(true, false, false, "W")),
+			Self::DocumentInfo => Some(KeyChord::new(true, false, false, "I")),
+			Self::TableOfContents => Some(KeyChord::new(true, false, false, "T")),
+			Self::ElementsList => Some(KeyChord::new(false, false, false, "F7")),
+			Self::RevealFileInFolder => Some(KeyChord::new(true, false, true, "C")),
+			Self::OpenInWebView => Some(KeyChord::new(true, false, true, "V")),
+			Self::ViewSource => Some(KeyChord::new(true, false, false, "U")),
+			Self::ToggleBookmark => Some(KeyChord::new(true, false, true, "B")),
+			Self::BookmarkWithNote => Some(KeyChord::new(true, false, true, "N")),
+			Self::ToggleWordWrap => Some(KeyChord::new(true, true, false, "W")),
+			// The conventional shortcut is Control+Command+F; RawCtrl forces the
+			// physical Control key while plain Ctrl auto-translates to Command on mac.
+			Self::ToggleFullScreen => {
+				Some(KeyChord { ctrl: true, raw_ctrl: true, alt: false, shift: false, key: "F".to_string() })
+			}
+			Self::Options => Some(KeyChord::new(true, false, false, ",")),
+			Self::SleepTimer => Some(KeyChord::new(true, false, true, "S")),
+			Self::CustomizeShortcuts => None,
+			Self::ImportDocumentData => Some(KeyChord::new(true, false, true, "I")),
+			Self::ExportDocumentData => Some(KeyChord::new(true, false, true, "E")),
+			Self::ExportToPlainText => Some(KeyChord::new(true, false, false, "E")),
+			Self::ExportToHtml => None,
+			Self::ExportToMarkdown => None,
+			Self::About => Some(KeyChord::new(true, false, false, "F1")),
+			Self::ViewHelpBrowser => Some(KeyChord::new(false, false, false, "F1")),
+			Self::ViewHelpPaperback => Some(KeyChord::new(false, false, true, "F1")),
+			Self::CheckForUpdates => Some(KeyChord::new(true, false, true, "U")),
+			Self::Donate => Some(KeyChord::new(true, false, false, "D")),
+		}
+
+		#[cfg(not(target_os = "macos"))]
+		match self {
+			Self::Open => Some(KeyChord::new(true, false, false, "O")),
+			Self::Close => Some(KeyChord::new(true, false, false, "F4")),
+			Self::CloseAll => Some(KeyChord::new(true, false, true, "F4")),
+			Self::ReopenLastClosed => Some(KeyChord::new(true, false, true, "T")),
+			Self::ShowAllRecentDocuments => Some(KeyChord::new(true, false, false, "R")),
+			Self::Exit => Some(KeyChord::new(true, false, false, "Q")),
+			Self::Find => Some(KeyChord::new(true, false, false, "F")),
+			Self::FindNext => Some(KeyChord::new(false, false, false, "F3")),
+			Self::FindPrevious => Some(KeyChord::new(false, false, true, "F3")),
+			Self::GoToLine => Some(KeyChord::new(true, false, false, "G")),
+			Self::GoToPercent => Some(KeyChord::new(true, false, true, "G")),
+			Self::GoToPage => Some(KeyChord::new(true, false, false, "P")),
+			Self::GoBack => Some(KeyChord::new(false, true, false, "Left")),
+			Self::GoForward => Some(KeyChord::new(false, true, false, "Right")),
+			Self::AnnouncePercent => Some(KeyChord::new(false, false, false, "=")),
+			Self::SetTemporaryBookmark => Some(KeyChord::new(false, false, false, "/")),
+			Self::JumpToTemporaryBookmark => Some(KeyChord::new(false, false, false, "\\")),
+			Self::PreviousSection => Some(KeyChord::new(false, false, false, "[")),
+			Self::NextSection => Some(KeyChord::new(false, false, false, "]")),
+			Self::PreviousHeading => Some(KeyChord::new(false, false, true, "H")),
+			Self::NextHeading => Some(KeyChord::new(false, false, false, "H")),
+			Self::PreviousHeading1 => Some(KeyChord::new(false, false, true, "1")),
+			Self::NextHeading1 => Some(KeyChord::new(false, false, false, "1")),
+			Self::PreviousHeading2 => Some(KeyChord::new(false, false, true, "2")),
+			Self::NextHeading2 => Some(KeyChord::new(false, false, false, "2")),
+			Self::PreviousHeading3 => Some(KeyChord::new(false, false, true, "3")),
+			Self::NextHeading3 => Some(KeyChord::new(false, false, false, "3")),
+			Self::PreviousHeading4 => Some(KeyChord::new(false, false, true, "4")),
+			Self::NextHeading4 => Some(KeyChord::new(false, false, false, "4")),
+			Self::PreviousHeading5 => Some(KeyChord::new(false, false, true, "5")),
+			Self::NextHeading5 => Some(KeyChord::new(false, false, false, "5")),
+			Self::PreviousHeading6 => Some(KeyChord::new(false, false, true, "6")),
+			Self::NextHeading6 => Some(KeyChord::new(false, false, false, "6")),
+			Self::PreviousPage => Some(KeyChord::new(false, false, true, "P")),
+			Self::NextPage => Some(KeyChord::new(false, false, false, "P")),
+			Self::PreviousBookmark => Some(KeyChord::new(false, false, true, "B")),
+			Self::NextBookmark => Some(KeyChord::new(false, false, false, "B")),
+			Self::PreviousNote => Some(KeyChord::new(false, false, true, "N")),
+			Self::NextNote => Some(KeyChord::new(false, false, false, "N")),
+			Self::JumpToAllBookmarks => Some(KeyChord::new(true, false, false, "B")),
+			Self::JumpToBookmarksOnly => Some(KeyChord::new(true, true, false, "B")),
+			Self::JumpToNotesOnly => Some(KeyChord::new(true, true, false, "M")),
+			Self::ViewNoteText => Some(KeyChord::new(true, false, true, "W")),
+			Self::PreviousLink => Some(KeyChord::new(false, false, true, "K")),
+			Self::NextLink => Some(KeyChord::new(false, false, false, "K")),
+			Self::PreviousImage => Some(KeyChord::new(false, false, true, "G")),
+			Self::NextImage => Some(KeyChord::new(false, false, false, "G")),
+			Self::PreviousFigure => Some(KeyChord::new(false, false, true, "F")),
+			Self::NextFigure => Some(KeyChord::new(false, false, false, "F")),
+			Self::PreviousTable => Some(KeyChord::new(false, false, true, "T")),
+			Self::NextTable => Some(KeyChord::new(false, false, false, "T")),
+			Self::PreviousSeparator => Some(KeyChord::new(false, false, true, "S")),
+			Self::NextSeparator => Some(KeyChord::new(false, false, false, "S")),
+			Self::PreviousList => Some(KeyChord::new(false, false, true, "L")),
+			Self::NextList => Some(KeyChord::new(false, false, false, "L")),
+			Self::PreviousListItem => Some(KeyChord::new(false, false, true, "I")),
+			Self::NextListItem => Some(KeyChord::new(false, false, false, "I")),
+			Self::ContainerStart => Some(KeyChord::new(false, false, true, ",")),
+			Self::ContainerEnd => Some(KeyChord::new(false, false, false, ",")),
+			Self::WordCount => Some(KeyChord::new(true, false, false, "W")),
+			Self::DocumentInfo => Some(KeyChord::new(true, false, false, "I")),
+			Self::TableOfContents => Some(KeyChord::new(true, false, false, "T")),
+			Self::ElementsList => Some(KeyChord::new(false, false, false, "F7")),
+			Self::RevealFileInFolder => Some(KeyChord::new(true, false, true, "C")),
+			Self::OpenInWebView => Some(KeyChord::new(true, false, true, "V")),
+			Self::ViewSource => Some(KeyChord::new(true, false, false, "U")),
+			Self::ToggleBookmark => Some(KeyChord::new(true, false, true, "B")),
+			Self::BookmarkWithNote => Some(KeyChord::new(true, false, true, "N")),
+			Self::ToggleWordWrap => Some(KeyChord::new(true, true, false, "W")),
+			Self::ToggleFullScreen => Some(KeyChord::new(false, false, false, "F11")),
+			Self::Options => Some(KeyChord::new(true, false, false, ",")),
+			Self::SleepTimer => Some(KeyChord::new(true, false, true, "S")),
+			Self::CustomizeShortcuts => None,
+			Self::ImportDocumentData => Some(KeyChord::new(true, false, true, "I")),
+			Self::ExportDocumentData => Some(KeyChord::new(true, false, true, "E")),
+			Self::ExportToPlainText => Some(KeyChord::new(true, false, false, "E")),
+			Self::ExportToHtml => None,
+			Self::ExportToMarkdown => None,
+			Self::About => Some(KeyChord::new(true, false, false, "F1")),
+			Self::ViewHelpBrowser => Some(KeyChord::new(false, false, false, "F1")),
+			Self::ViewHelpPaperback => Some(KeyChord::new(false, false, true, "F1")),
+			Self::CheckForUpdates => Some(KeyChord::new(true, false, true, "U")),
+			Self::Donate => Some(KeyChord::new(true, false, false, "D")),
+		}
+	}
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct KeyChord {
+	pub ctrl: bool,
+	#[serde(default)]
+	pub raw_ctrl: bool,
+	pub alt: bool,
+	pub shift: bool,
+	pub key: String,
+}
+
+impl KeyChord {
+	pub fn new(ctrl: bool, alt: bool, shift: bool, key: impl Into<String>) -> Self {
+		let key_str = key.into();
+		let normalized = Self::normalize_key_name(&key_str);
+		Self { ctrl, raw_ctrl: false, alt, shift, key: normalized }
+	}
+
+	pub fn new_raw_ctrl(raw_ctrl: bool, alt: bool, shift: bool, key: impl Into<String>) -> Self {
+		let key_str = key.into();
+		let normalized = Self::normalize_key_name(&key_str);
+		Self { ctrl: false, raw_ctrl, alt, shift, key: normalized }
+	}
+
+	pub fn normalize_key_name(key: &str) -> String {
+		let trimmed = key.trim();
+		if trimmed.eq_ignore_ascii_case("return") || trimmed.eq_ignore_ascii_case("enter") {
+			"Enter".to_string()
+		} else if trimmed.eq_ignore_ascii_case("space") {
+			"Space".to_string()
+		} else if trimmed.eq_ignore_ascii_case("tab") {
+			"Tab".to_string()
+		} else if trimmed.eq_ignore_ascii_case("backspace") || trimmed.eq_ignore_ascii_case("back") {
+			"Backspace".to_string()
+		} else if trimmed.eq_ignore_ascii_case("delete") || trimmed.eq_ignore_ascii_case("del") {
+			"Delete".to_string()
+		} else if trimmed.eq_ignore_ascii_case("escape") || trimmed.eq_ignore_ascii_case("esc") {
+			"Escape".to_string()
+		} else if trimmed.eq_ignore_ascii_case("home") {
+			"Home".to_string()
+		} else if trimmed.eq_ignore_ascii_case("end") {
+			"End".to_string()
+		} else if trimmed.eq_ignore_ascii_case("pageup")
+			|| trimmed.eq_ignore_ascii_case("page up")
+			|| trimmed.eq_ignore_ascii_case("pgup")
+		{
+			"PageUp".to_string()
+		} else if trimmed.eq_ignore_ascii_case("pagedown")
+			|| trimmed.eq_ignore_ascii_case("page down")
+			|| trimmed.eq_ignore_ascii_case("pgdn")
+		{
+			"PageDown".to_string()
+		} else if trimmed.eq_ignore_ascii_case("left") || trimmed.eq_ignore_ascii_case("left arrow") {
+			"Left".to_string()
+		} else if trimmed.eq_ignore_ascii_case("right") || trimmed.eq_ignore_ascii_case("right arrow") {
+			"Right".to_string()
+		} else if trimmed.eq_ignore_ascii_case("up") || trimmed.eq_ignore_ascii_case("up arrow") {
+			"Up".to_string()
+		} else if trimmed.eq_ignore_ascii_case("down") || trimmed.eq_ignore_ascii_case("down arrow") {
+			"Down".to_string()
+		} else if trimmed.len() >= 2
+			&& trimmed.starts_with(['F', 'f'])
+			&& trimmed[1..].chars().all(|c| c.is_ascii_digit())
+		{
+			format!("F{}", &trimmed[1..])
+		} else if trimmed.len() == 1 {
+			let ch = trimmed.chars().next().unwrap();
+			if ch.is_ascii_alphabetic() { ch.to_ascii_uppercase().to_string() } else { trimmed.to_string() }
+		} else {
+			trimmed.to_string()
+		}
+	}
+
+	pub fn to_shortcut_string(&self) -> String {
+		let mut parts = Vec::new();
+		if self.raw_ctrl {
+			parts.push("RawCtrl");
+		}
+		if self.ctrl {
+			parts.push("Ctrl");
+		}
+		if self.alt {
+			parts.push("Alt");
+		}
+		if self.shift {
+			parts.push("Shift");
+		}
+		parts.push(&self.key);
+		parts.join("+")
+	}
+
+	pub fn parse(input: &str) -> Option<Self> {
+		let trimmed = input.trim();
+		if trimmed.is_empty() || trimmed.eq_ignore_ascii_case("none") {
+			return None;
+		}
+		let mut ctrl = false;
+		let mut raw_ctrl = false;
+		let mut alt = false;
+		let mut shift = false;
+		let mut remaining = trimmed;
+
+		while let Some(plus_idx) = remaining.find('+') {
+			let prefix = &remaining[..plus_idx];
+			if prefix.eq_ignore_ascii_case("rawctrl") {
+				raw_ctrl = true;
+				remaining = &remaining[plus_idx + 1..];
+			} else if prefix.eq_ignore_ascii_case("ctrl") || prefix.eq_ignore_ascii_case("control") {
+				ctrl = true;
+				remaining = &remaining[plus_idx + 1..];
+			} else if prefix.eq_ignore_ascii_case("alt") {
+				alt = true;
+				remaining = &remaining[plus_idx + 1..];
+			} else if prefix.eq_ignore_ascii_case("shift") {
+				shift = true;
+				remaining = &remaining[plus_idx + 1..];
+			} else {
+				break;
+			}
+		}
+		let key = remaining.to_string();
+		if key.is_empty() {
+			return None;
+		}
+		let normalized = Self::normalize_key_name(&key);
+		Some(Self { ctrl, raw_ctrl, alt, shift, key: normalized })
+	}
+
+	pub fn from_key_code(key_code: i32, ctrl: bool, alt: bool, shift: bool) -> Option<Self> {
+		let key_name = match key_code {
+			13 | 370 => "Enter".to_string(),
+			9 => "Tab".to_string(),
+			32 => "Space".to_string(),
+			8 => "Backspace".to_string(),
+			127 | 308 | 386 => "Delete".to_string(),
+			27 => "Escape".to_string(),
+			313 | 377 => "Home".to_string(),
+			312 | 379 => "End".to_string(),
+			366 | 376 => "PageUp".to_string(),
+			367 | 381 => "PageDown".to_string(),
+			314 | 378 => "Left".to_string(),
+			316 | 380 => "Right".to_string(),
+			315 | 382 => "Up".to_string(),
+			317 | 383 => "Down".to_string(),
+			340..=363 => format!("F{}", key_code - 340 + 1),
+			65..=90 => (char::from_u32(key_code as u32)?).to_string(),
+			97..=122 => (char::from_u32((key_code - 32) as u32)?).to_string(),
+			48..=57 => (char::from_u32(key_code as u32)?).to_string(),
+			324..=333 => (char::from_u32((key_code - 324 + 48) as u32)?).to_string(),
+			44 | 188 => ",".to_string(),
+			46 | 190 | 387 => ".".to_string(),
+			47 | 191 | 388 => "/".to_string(),
+			91 | 219 => "[".to_string(),
+			93 | 221 => "]".to_string(),
+			92 | 220 => "\\".to_string(),
+			45 | 189 | 390 => "-".to_string(),
+			61 | 187 => "=".to_string(),
+			59 | 186 => ";".to_string(),
+			39 | 222 => "'".to_string(),
+			96 | 192 => "`".to_string(),
+			_ => return None,
+		};
+		Some(Self { ctrl, raw_ctrl: false, alt, shift, key: key_name })
+	}
+
+	pub fn matches(&self, key_code: i32, ctrl: bool, alt: bool, shift: bool) -> bool {
+		let self_ctrl = self.ctrl || self.raw_ctrl;
+		if self_ctrl != ctrl || self.alt != alt || self.shift != shift {
+			return false;
+		}
+		let key_str = self.key.as_str();
+		if key_str.eq_ignore_ascii_case("Enter") {
+			key_code == 13 || key_code == 370
+		} else if key_str.eq_ignore_ascii_case("Tab") {
+			key_code == 9
+		} else if key_str.eq_ignore_ascii_case("Space") {
+			key_code == 32
+		} else if key_str.eq_ignore_ascii_case("Backspace") {
+			key_code == 8
+		} else if key_str.eq_ignore_ascii_case("Delete") {
+			key_code == 127 || key_code == 308 || key_code == 386
+		} else if key_str.eq_ignore_ascii_case("Escape") {
+			key_code == 27
+		} else if key_str.eq_ignore_ascii_case("Home") {
+			key_code == 313 || key_code == 377
+		} else if key_str.eq_ignore_ascii_case("End") {
+			key_code == 312 || key_code == 379
+		} else if key_str.eq_ignore_ascii_case("PageUp") {
+			key_code == 366 || key_code == 376
+		} else if key_str.eq_ignore_ascii_case("PageDown") {
+			key_code == 367 || key_code == 381
+		} else if key_str.eq_ignore_ascii_case("Left") {
+			key_code == 314 || key_code == 378
+		} else if key_str.eq_ignore_ascii_case("Right") {
+			key_code == 316 || key_code == 380
+		} else if key_str.eq_ignore_ascii_case("Up") {
+			key_code == 315 || key_code == 382
+		} else if key_str.eq_ignore_ascii_case("Down") {
+			key_code == 317 || key_code == 383
+		} else if key_str.starts_with(['F', 'f'])
+			&& let Ok(num) = key_str[1..].parse::<i32>()
+			&& (1..=24).contains(&num)
+		{
+			key_code == 340 + num - 1
+		} else if key_str.len() == 1 {
+			let ch = key_str.chars().next().unwrap();
+			if ch.is_ascii_alphabetic() {
+				let upper = ch.to_ascii_uppercase() as i32;
+				key_code == upper || key_code == upper + 32
+			} else if ch.is_ascii_digit() {
+				key_code == ch as i32 || key_code == (ch as i32 - 48 + 324)
+			} else {
+				match ch {
+					',' => key_code == 44 || key_code == 188,
+					'.' => key_code == 46 || key_code == 190 || key_code == 387,
+					'/' => key_code == 47 || key_code == 191 || key_code == 388,
+					'\\' => key_code == 92 || key_code == 220,
+					'[' => key_code == 91 || key_code == 219,
+					']' => key_code == 93 || key_code == 221,
+					'-' => key_code == 45 || key_code == 189 || key_code == 390,
+					'=' => key_code == 61 || key_code == 187,
+					';' => key_code == 59 || key_code == 186,
+					'\'' => key_code == 39 || key_code == 222,
+					'`' => key_code == 96 || key_code == 192,
+					_ => key_code == ch as i32,
+				}
+			}
+		} else {
+			false
+		}
+	}
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub struct ShortcutsConfig {
+	#[serde(default)]
+	pub bindings: HashMap<ActionId, Option<String>>,
+}
+
+impl ShortcutsConfig {
+	pub fn get_chord(&self, action: ActionId) -> Option<KeyChord> {
+		if let Some(entry) = self.bindings.get(&action) {
+			match entry {
+				Some(s) => KeyChord::parse(s),
+				None => None,
+			}
+		} else {
+			action.default_chord()
+		}
+	}
+
+	pub fn get_display_str(&self, action: ActionId) -> String {
+		self.get_chord(action).map_or_else(|| "None".to_string(), |c| c.to_shortcut_string())
+	}
+
+	pub fn get_menu_str(&self, action: ActionId) -> String {
+		self.get_chord(action).map_or_else(String::new, |c| c.to_shortcut_string())
+	}
+
+	pub fn set_chord(&mut self, action: ActionId, chord: Option<KeyChord>) {
+		self.bindings.insert(action, chord.map(|c| c.to_shortcut_string()));
+	}
+
+	pub fn reset_action(&mut self, action: ActionId) {
+		self.bindings.remove(&action);
+	}
+
+	pub fn reset_category(&mut self, category: ShortcutCategory) {
+		for action in category.actions() {
+			self.bindings.remove(&action);
+		}
+	}
+
+	pub fn reset_all(&mut self) {
+		self.bindings.clear();
+	}
+
+	pub fn find_action(&self, key_code: i32, ctrl: bool, alt: bool, shift: bool) -> Option<ActionId> {
+		for &action in ActionId::all() {
+			if let Some(chord) = self.get_chord(action)
+				&& chord.matches(key_code, ctrl, alt, shift)
+			{
+				return Some(action);
+			}
+		}
+		None
+	}
+}
+
 const fn default_true() -> bool {
 	true
 }
@@ -164,6 +1012,8 @@ pub struct AppSettings {
 	pub line_spacing: i64,
 	#[serde(default)]
 	pub hotkey: HotkeyConfig,
+	#[serde(default)]
+	pub shortcuts: ShortcutsConfig,
 	/// Pass-through storage for host-specific settings (e.g. desktop UI preferences).
 	/// Keys written here are preserved on read/write so host consumers can store their
 	/// own fields alongside the generic ones without conflict.
@@ -197,6 +1047,7 @@ impl Default for AppSettings {
 			paragraph_spacing: 0,
 			line_spacing: 0,
 			hotkey: HotkeyConfig::default(),
+			shortcuts: ShortcutsConfig::default(),
 			extra: HashMap::new(),
 		}
 	}
@@ -213,6 +1064,8 @@ pub struct DocumentConfig {
 	pub navigation_history_index: usize,
 	#[serde(default)]
 	pub bookmarks: Vec<StoredBookmark>,
+	#[serde(default, skip_serializing_if = "Option::is_none")]
+	pub temporary_bookmark: Option<i64>,
 	#[serde(default, skip_serializing_if = "String::is_empty")]
 	pub format: String,
 	#[serde(default, skip_serializing_if = "String::is_empty")]
@@ -229,6 +1082,8 @@ struct SidecarData {
 	format: Option<String>,
 	#[serde(default, skip_serializing_if = "Vec::is_empty")]
 	bookmarks: Vec<StoredBookmark>,
+	#[serde(default, skip_serializing_if = "Option::is_none")]
+	temporary_bookmark: Option<i64>,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
@@ -625,6 +1480,29 @@ impl ConfigManager {
 		self.dirty.set(true);
 	}
 
+	pub fn get_shortcuts(&self) -> ShortcutsConfig {
+		if !self.initialized {
+			return ShortcutsConfig::default();
+		}
+		self.data.borrow().app.shortcuts.clone()
+	}
+
+	pub fn set_shortcuts(&self, shortcuts: &ShortcutsConfig) {
+		if !self.initialized {
+			return;
+		}
+		self.data.borrow_mut().app.shortcuts = shortcuts.clone();
+		self.dirty.set(true);
+	}
+
+	pub fn get_shortcut_chord(&self, action: ActionId) -> Option<KeyChord> {
+		self.get_shortcuts().get_chord(action)
+	}
+
+	pub fn get_shortcut_menu_str(&self, action: ActionId) -> String {
+		self.get_shortcuts().get_menu_str(action)
+	}
+
 	pub fn add_recent_document(&self, path: &str) {
 		if !self.initialized {
 			return;
@@ -755,6 +1633,28 @@ impl ConfigManager {
 	pub fn get_validated_document_position(&self, path: &str, max_position: i64) -> i64 {
 		let saved = self.get_document_position(path);
 		if saved > 0 && saved <= max_position { saved } else { -1 }
+	}
+
+	/// Sets the single per-document temporary bookmark position (`None` clears it).
+	pub fn set_temporary_bookmark(&self, path: &str, position: Option<i64>) {
+		if !self.initialized {
+			return;
+		}
+		{
+			let key = self.get_doc_key(path);
+			let mut data = self.data.borrow_mut();
+			Self::doc_entry_mut(&mut data, key, path).temporary_bookmark = position;
+		}
+		self.dirty.set(true);
+	}
+
+	#[must_use]
+	pub fn get_temporary_bookmark(&self, path: &str) -> Option<i64> {
+		if !self.initialized {
+			return None;
+		}
+		let key = self.get_doc_key(path);
+		self.data.borrow().documents.get(&key).and_then(|d| d.temporary_bookmark)
 	}
 
 	pub fn set_navigation_history(&self, path: &str, history: &[i64], history_index: usize) {
@@ -975,6 +1875,9 @@ impl ConfigManager {
 		if let Some(format) = sidecar.format {
 			self.set_document_format(doc_path, &format);
 		}
+		if let Some(position) = sidecar.temporary_bookmark {
+			self.set_temporary_bookmark(doc_path, Some(position));
+		}
 		if !sidecar.bookmarks.is_empty() {
 			let key = self.get_doc_key(doc_path);
 			let mut data = self.data.borrow_mut();
@@ -995,6 +1898,7 @@ impl ConfigManager {
 			last_position: doc.map(|d| d.last_position).filter(|&p| p > 0),
 			format: doc.and_then(|d| if d.format.is_empty() { None } else { Some(d.format.clone()) }),
 			bookmarks: doc.map(|d| d.bookmarks.clone()).unwrap_or_default(),
+			temporary_bookmark: doc.and_then(|d| d.temporary_bookmark),
 		};
 		if let Ok(s) = toml::to_string_pretty(&sidecar) {
 			let _ = fs::write(export_path, s);
@@ -1152,6 +2056,87 @@ mod tests {
 		assert!(!config.get_app_bool("render_tables_inline", true));
 		config.set_app_bool("render_tables_inline", true);
 		assert!(config.get_app_bool("render_tables_inline", true));
+	}
+
+	#[test]
+	fn temporary_bookmark_set_get_overwrite_clear() {
+		let mut config = ConfigManager::new();
+		config.initialized = true;
+		let path = "book.epub";
+		assert_eq!(config.get_temporary_bookmark(path), None);
+		config.set_temporary_bookmark(path, Some(42_000));
+		assert_eq!(config.get_temporary_bookmark(path), Some(42_000));
+		config.set_temporary_bookmark(path, Some(43_000));
+		assert_eq!(config.get_temporary_bookmark(path), Some(43_000));
+		config.set_temporary_bookmark(path, None);
+		assert_eq!(config.get_temporary_bookmark(path), None);
+	}
+
+	#[test]
+	fn temporary_bookmark_serializes_and_loads() {
+		let doc =
+			DocumentConfig { path: "book.epub".into(), temporary_bookmark: Some(12_345), ..DocumentConfig::default() };
+		let serialized = toml::to_string(&doc).unwrap();
+		let parsed: DocumentConfig = toml::from_str(&serialized).unwrap();
+		assert_eq!(parsed.temporary_bookmark, Some(12_345));
+	}
+
+	#[test]
+	fn temporary_bookmark_defaults_to_none_when_missing() {
+		// Old config files without the field must load as None.
+		let parsed: DocumentConfig = toml::from_str("path = \"book.epub\"\n").unwrap();
+		assert_eq!(parsed.temporary_bookmark, None);
+	}
+
+	#[test]
+	fn key_chord_parse_and_to_string() {
+		let chord = KeyChord::parse("Ctrl+Shift+O").unwrap();
+		assert!(chord.ctrl);
+		assert!(chord.shift);
+		assert!(!chord.alt);
+		assert_eq!(chord.key, "O");
+		assert_eq!(chord.to_shortcut_string(), "Ctrl+Shift+O");
+
+		let single = KeyChord::parse("H").unwrap();
+		assert!(!single.ctrl);
+		assert!(!single.shift);
+		assert!(!single.alt);
+		assert_eq!(single.key, "H");
+		assert_eq!(single.to_shortcut_string(), "H");
+
+		assert_eq!(KeyChord::parse("none"), None);
+		assert_eq!(KeyChord::parse(""), None);
+	}
+
+	#[test]
+	fn shortcuts_config_set_reset_and_find() {
+		let mut sc = ShortcutsConfig::default();
+		let default_open = sc.get_chord(ActionId::Open);
+		assert!(default_open.is_some());
+
+		let new_chord = KeyChord::new(true, true, false, "K");
+		sc.set_chord(ActionId::Open, Some(new_chord.clone()));
+		assert_eq!(sc.get_chord(ActionId::Open), Some(new_chord));
+
+		let matched = sc.find_action(75, true, true, false);
+		assert_eq!(matched, Some(ActionId::Open));
+
+		sc.reset_action(ActionId::Open);
+		assert_eq!(sc.get_chord(ActionId::Open), default_open);
+	}
+
+	#[test]
+	fn shortcut_category_actions_coverage() {
+		let mut total_actions = 0;
+		for cat in ShortcutCategory::all() {
+			let actions = cat.actions();
+			assert!(!actions.is_empty());
+			for action in &actions {
+				assert_eq!(action.category(), *cat);
+			}
+			total_actions += actions.len();
+		}
+		assert_eq!(total_actions, ActionId::all().len());
 	}
 
 	#[test]

--- a/crates/paperback-core/src/config.rs
+++ b/crates/paperback-core/src/config.rs
@@ -10,7 +10,7 @@ use base64::{Engine, engine::general_purpose::URL_SAFE_NO_PAD};
 use serde::{Deserialize, Serialize};
 use sha1::{Digest, Sha1};
 
-use crate::types::DocumentListItem;
+use crate::types::{DocumentListItem, DocumentListStatus};
 
 const CONFIG_VERSION: u32 = 4;
 const DEFAULT_RECENT_DOCUMENTS_TO_SHOW: i64 = 25;
@@ -97,854 +97,6 @@ impl Default for HotkeyConfig {
 	}
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
-#[serde(rename_all = "snake_case")]
-pub enum ShortcutCategory {
-	File,
-	Go,
-	Tools,
-	Help,
-}
-
-impl ShortcutCategory {
-	pub const fn all() -> &'static [Self] {
-		&[Self::File, Self::Go, Self::Tools, Self::Help]
-	}
-
-	pub const fn display_name(self) -> &'static str {
-		match self {
-			Self::File => "File",
-			Self::Go => "Go",
-			Self::Tools => "Tools",
-			Self::Help => "Help",
-		}
-	}
-
-	pub fn actions(self) -> Vec<ActionId> {
-		ActionId::all().iter().copied().filter(|a| a.category() == self).collect()
-	}
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
-#[serde(rename_all = "snake_case")]
-pub enum ActionId {
-	Open,
-	Close,
-	CloseAll,
-	ReopenLastClosed,
-	ShowAllRecentDocuments,
-	Exit,
-	Find,
-	FindNext,
-	FindPrevious,
-	GoToLine,
-	GoToPercent,
-	GoToPage,
-	GoBack,
-	GoForward,
-	AnnouncePercent,
-	SetTemporaryBookmark,
-	JumpToTemporaryBookmark,
-	PreviousSection,
-	NextSection,
-	PreviousHeading,
-	NextHeading,
-	PreviousHeading1,
-	NextHeading1,
-	PreviousHeading2,
-	NextHeading2,
-	PreviousHeading3,
-	NextHeading3,
-	PreviousHeading4,
-	NextHeading4,
-	PreviousHeading5,
-	NextHeading5,
-	PreviousHeading6,
-	NextHeading6,
-	PreviousPage,
-	NextPage,
-	PreviousBookmark,
-	NextBookmark,
-	PreviousNote,
-	NextNote,
-	JumpToAllBookmarks,
-	JumpToBookmarksOnly,
-	JumpToNotesOnly,
-	ViewNoteText,
-	PreviousLink,
-	NextLink,
-	PreviousImage,
-	NextImage,
-	PreviousFigure,
-	NextFigure,
-	PreviousTable,
-	NextTable,
-	PreviousSeparator,
-	NextSeparator,
-	PreviousList,
-	NextList,
-	PreviousListItem,
-	NextListItem,
-	ContainerStart,
-	ContainerEnd,
-	WordCount,
-	DocumentInfo,
-	TableOfContents,
-	ElementsList,
-	RevealFileInFolder,
-	OpenInWebView,
-	ViewSource,
-	ToggleBookmark,
-	BookmarkWithNote,
-	ToggleWordWrap,
-	ToggleFullScreen,
-	Options,
-	SleepTimer,
-	CustomizeShortcuts,
-	ImportDocumentData,
-	ExportDocumentData,
-	ExportToPlainText,
-	ExportToHtml,
-	ExportToMarkdown,
-	About,
-	ViewHelpBrowser,
-	ViewHelpPaperback,
-	CheckForUpdates,
-	Donate,
-}
-
-impl ActionId {
-	pub const fn all() -> &'static [Self] {
-		&[
-			Self::Open,
-			Self::Close,
-			Self::CloseAll,
-			Self::ReopenLastClosed,
-			Self::ShowAllRecentDocuments,
-			Self::Exit,
-			Self::Find,
-			Self::FindNext,
-			Self::FindPrevious,
-			Self::GoToLine,
-			Self::GoToPercent,
-			Self::GoToPage,
-			Self::GoBack,
-			Self::GoForward,
-			Self::AnnouncePercent,
-			Self::SetTemporaryBookmark,
-			Self::JumpToTemporaryBookmark,
-			Self::PreviousSection,
-			Self::NextSection,
-			Self::PreviousHeading,
-			Self::NextHeading,
-			Self::PreviousHeading1,
-			Self::NextHeading1,
-			Self::PreviousHeading2,
-			Self::NextHeading2,
-			Self::PreviousHeading3,
-			Self::NextHeading3,
-			Self::PreviousHeading4,
-			Self::NextHeading4,
-			Self::PreviousHeading5,
-			Self::NextHeading5,
-			Self::PreviousHeading6,
-			Self::NextHeading6,
-			Self::PreviousPage,
-			Self::NextPage,
-			Self::PreviousBookmark,
-			Self::NextBookmark,
-			Self::PreviousNote,
-			Self::NextNote,
-			Self::JumpToAllBookmarks,
-			Self::JumpToBookmarksOnly,
-			Self::JumpToNotesOnly,
-			Self::ViewNoteText,
-			Self::PreviousLink,
-			Self::NextLink,
-			Self::PreviousImage,
-			Self::NextImage,
-			Self::PreviousFigure,
-			Self::NextFigure,
-			Self::PreviousTable,
-			Self::NextTable,
-			Self::PreviousSeparator,
-			Self::NextSeparator,
-			Self::PreviousList,
-			Self::NextList,
-			Self::PreviousListItem,
-			Self::NextListItem,
-			Self::ContainerStart,
-			Self::ContainerEnd,
-			Self::WordCount,
-			Self::DocumentInfo,
-			Self::TableOfContents,
-			Self::ElementsList,
-			Self::RevealFileInFolder,
-			Self::OpenInWebView,
-			Self::ViewSource,
-			Self::ToggleBookmark,
-			Self::BookmarkWithNote,
-			Self::ToggleWordWrap,
-			Self::ToggleFullScreen,
-			Self::Options,
-			Self::SleepTimer,
-			Self::CustomizeShortcuts,
-			Self::ImportDocumentData,
-			Self::ExportDocumentData,
-			Self::ExportToPlainText,
-			Self::ExportToHtml,
-			Self::ExportToMarkdown,
-			Self::About,
-			Self::ViewHelpBrowser,
-			Self::ViewHelpPaperback,
-			Self::CheckForUpdates,
-			Self::Donate,
-		]
-	}
-
-	pub const fn category(self) -> ShortcutCategory {
-		match self {
-			Self::Open
-			| Self::Close
-			| Self::CloseAll
-			| Self::ReopenLastClosed
-			| Self::ShowAllRecentDocuments
-			| Self::Exit => ShortcutCategory::File,
-			Self::Find
-			| Self::FindNext
-			| Self::FindPrevious
-			| Self::GoToLine
-			| Self::GoToPercent
-			| Self::GoToPage
-			| Self::GoBack
-			| Self::GoForward
-			| Self::AnnouncePercent
-			| Self::SetTemporaryBookmark
-			| Self::JumpToTemporaryBookmark
-			| Self::PreviousSection
-			| Self::NextSection
-			| Self::PreviousHeading
-			| Self::NextHeading
-			| Self::PreviousHeading1
-			| Self::NextHeading1
-			| Self::PreviousHeading2
-			| Self::NextHeading2
-			| Self::PreviousHeading3
-			| Self::NextHeading3
-			| Self::PreviousHeading4
-			| Self::NextHeading4
-			| Self::PreviousHeading5
-			| Self::NextHeading5
-			| Self::PreviousHeading6
-			| Self::NextHeading6
-			| Self::PreviousPage
-			| Self::NextPage
-			| Self::PreviousBookmark
-			| Self::NextBookmark
-			| Self::PreviousNote
-			| Self::NextNote
-			| Self::JumpToAllBookmarks
-			| Self::JumpToBookmarksOnly
-			| Self::JumpToNotesOnly
-			| Self::ViewNoteText
-			| Self::PreviousLink
-			| Self::NextLink
-			| Self::PreviousImage
-			| Self::NextImage
-			| Self::PreviousFigure
-			| Self::NextFigure
-			| Self::PreviousTable
-			| Self::NextTable
-			| Self::PreviousSeparator
-			| Self::NextSeparator
-			| Self::PreviousList
-			| Self::NextList
-			| Self::PreviousListItem
-			| Self::NextListItem
-			| Self::ContainerStart
-			| Self::ContainerEnd => ShortcutCategory::Go,
-			Self::WordCount
-			| Self::DocumentInfo
-			| Self::TableOfContents
-			| Self::ElementsList
-			| Self::RevealFileInFolder
-			| Self::OpenInWebView
-			| Self::ViewSource
-			| Self::ToggleBookmark
-			| Self::BookmarkWithNote
-			| Self::ToggleWordWrap
-			| Self::ToggleFullScreen
-			| Self::Options
-			| Self::SleepTimer
-			| Self::CustomizeShortcuts
-			| Self::ImportDocumentData
-			| Self::ExportDocumentData
-			| Self::ExportToPlainText
-			| Self::ExportToHtml
-			| Self::ExportToMarkdown => ShortcutCategory::Tools,
-			Self::About | Self::ViewHelpBrowser | Self::ViewHelpPaperback | Self::CheckForUpdates | Self::Donate => {
-				ShortcutCategory::Help
-			}
-		}
-	}
-
-	pub const fn display_name(self) -> &'static str {
-		match self {
-			Self::Open => "Open...",
-			Self::Close => "Close",
-			Self::CloseAll => "Close All",
-			Self::ReopenLastClosed => "Reopen Last Closed",
-			Self::ShowAllRecentDocuments => "Show All Recent Documents...",
-			Self::Exit => "Exit",
-			Self::Find => "Find...",
-			Self::FindNext => "Find Next",
-			Self::FindPrevious => "Find Previous",
-			Self::GoToLine => "Go to Line...",
-			Self::GoToPercent => "Go to Percent...",
-			Self::GoToPage => "Go to Page...",
-			Self::GoBack => "Go Back",
-			Self::GoForward => "Go Forward",
-			Self::AnnouncePercent => "Announce Percentage",
-			Self::SetTemporaryBookmark => "Set Temporary Bookmark",
-			Self::JumpToTemporaryBookmark => "Jump to Temporary Bookmark",
-			Self::PreviousSection => "Previous Section",
-			Self::NextSection => "Next Section",
-			Self::PreviousHeading => "Previous Heading",
-			Self::NextHeading => "Next Heading",
-			Self::PreviousHeading1 => "Previous Heading Level 1",
-			Self::NextHeading1 => "Next Heading Level 1",
-			Self::PreviousHeading2 => "Previous Heading Level 2",
-			Self::NextHeading2 => "Next Heading Level 2",
-			Self::PreviousHeading3 => "Previous Heading Level 3",
-			Self::NextHeading3 => "Next Heading Level 3",
-			Self::PreviousHeading4 => "Previous Heading Level 4",
-			Self::NextHeading4 => "Next Heading Level 4",
-			Self::PreviousHeading5 => "Previous Heading Level 5",
-			Self::NextHeading5 => "Next Heading Level 5",
-			Self::PreviousHeading6 => "Previous Heading Level 6",
-			Self::NextHeading6 => "Next Heading Level 6",
-			Self::PreviousPage => "Previous Page",
-			Self::NextPage => "Next Page",
-			Self::PreviousBookmark => "Previous Bookmark",
-			Self::NextBookmark => "Next Bookmark",
-			Self::PreviousNote => "Previous Note",
-			Self::NextNote => "Next Note",
-			Self::JumpToAllBookmarks => "Jump to All Bookmarks...",
-			Self::JumpToBookmarksOnly => "Jump to Bookmarks Only...",
-			Self::JumpToNotesOnly => "Jump to Notes Only...",
-			Self::ViewNoteText => "View Note Text",
-			Self::PreviousLink => "Previous Link",
-			Self::NextLink => "Next Link",
-			Self::PreviousImage => "Previous Image",
-			Self::NextImage => "Next Image",
-			Self::PreviousFigure => "Previous Figure",
-			Self::NextFigure => "Next Figure",
-			Self::PreviousTable => "Previous Table",
-			Self::NextTable => "Next Table",
-			Self::PreviousSeparator => "Previous Separator",
-			Self::NextSeparator => "Next Separator",
-			Self::PreviousList => "Previous List",
-			Self::NextList => "Next List",
-			Self::PreviousListItem => "Previous List Item",
-			Self::NextListItem => "Next List Item",
-			Self::ContainerStart => "Container Start",
-			Self::ContainerEnd => "Past Container End",
-			Self::WordCount => "Word Count",
-			Self::DocumentInfo => "Document Info",
-			Self::TableOfContents => "Table of Contents",
-			Self::ElementsList => "Elements List...",
-			Self::RevealFileInFolder => "Reveal File in Folder",
-			Self::OpenInWebView => "Open in Web View",
-			Self::ViewSource => "View Source",
-			Self::ToggleBookmark => "Toggle Bookmark",
-			Self::BookmarkWithNote => "Bookmark with Note",
-			Self::ToggleWordWrap => "Toggle Word Wrap",
-			Self::ToggleFullScreen => "Full Screen",
-			Self::Options => "Options...",
-			Self::SleepTimer => "Sleep Timer...",
-			Self::CustomizeShortcuts => "Customize Keyboard Shortcuts...",
-			Self::ImportDocumentData => "Import Document Data...",
-			Self::ExportDocumentData => "Export Document Data...",
-			Self::ExportToPlainText => "Export to Plain Text...",
-			Self::ExportToHtml => "Export to HTML...",
-			Self::ExportToMarkdown => "Export to Markdown...",
-			Self::About => "About Paperback",
-			Self::ViewHelpBrowser => "View Help in Browser",
-			Self::ViewHelpPaperback => "View Help in Paperback",
-			Self::CheckForUpdates => "Check for Updates",
-			Self::Donate => "Donate",
-		}
-	}
-
-	pub fn default_chord(self) -> Option<KeyChord> {
-		#[cfg(target_os = "macos")]
-		match self {
-			Self::Open => Some(KeyChord::new(true, false, false, "O")),
-			Self::Close => Some(KeyChord::new(true, false, false, "W")),
-			Self::CloseAll => Some(KeyChord::new(true, false, true, "W")),
-			Self::ReopenLastClosed => Some(KeyChord::new(true, false, true, "T")),
-			Self::ShowAllRecentDocuments => Some(KeyChord::new(true, false, false, "R")),
-			Self::Exit => None,
-			Self::Find => Some(KeyChord::new(true, false, false, "F")),
-			Self::FindNext => Some(KeyChord::new(true, false, false, "G")),
-			Self::FindPrevious => Some(KeyChord::new(true, false, true, "G")),
-			Self::GoToLine => Some(KeyChord::new(true, false, false, "L")),
-			Self::GoToPercent => Some(KeyChord::new(true, false, true, "L")),
-			Self::GoToPage => Some(KeyChord::new(true, false, false, "P")),
-			Self::GoBack => Some(KeyChord::new(true, false, false, "[")),
-			Self::GoForward => Some(KeyChord::new(true, false, false, "]")),
-			Self::AnnouncePercent => Some(KeyChord::new(false, false, false, "=")),
-			Self::SetTemporaryBookmark => Some(KeyChord::new(false, false, false, "/")),
-			Self::JumpToTemporaryBookmark => Some(KeyChord::new(false, false, false, "\\")),
-			Self::PreviousSection => Some(KeyChord::new(false, false, false, "[")),
-			Self::NextSection => Some(KeyChord::new(false, false, false, "]")),
-			Self::PreviousHeading => Some(KeyChord::new(false, false, true, "H")),
-			Self::NextHeading => Some(KeyChord::new(false, false, false, "H")),
-			Self::PreviousHeading1 => Some(KeyChord::new(false, false, true, "1")),
-			Self::NextHeading1 => Some(KeyChord::new(false, false, false, "1")),
-			Self::PreviousHeading2 => Some(KeyChord::new(false, false, true, "2")),
-			Self::NextHeading2 => Some(KeyChord::new(false, false, false, "2")),
-			Self::PreviousHeading3 => Some(KeyChord::new(false, false, true, "3")),
-			Self::NextHeading3 => Some(KeyChord::new(false, false, false, "3")),
-			Self::PreviousHeading4 => Some(KeyChord::new(false, false, true, "4")),
-			Self::NextHeading4 => Some(KeyChord::new(false, false, false, "4")),
-			Self::PreviousHeading5 => Some(KeyChord::new(false, false, true, "5")),
-			Self::NextHeading5 => Some(KeyChord::new(false, false, false, "5")),
-			Self::PreviousHeading6 => Some(KeyChord::new(false, false, true, "6")),
-			Self::NextHeading6 => Some(KeyChord::new(false, false, false, "6")),
-			Self::PreviousPage => Some(KeyChord::new(false, false, true, "P")),
-			Self::NextPage => Some(KeyChord::new(false, false, false, "P")),
-			Self::PreviousBookmark => Some(KeyChord::new(false, false, true, "B")),
-			Self::NextBookmark => Some(KeyChord::new(false, false, false, "B")),
-			Self::PreviousNote => Some(KeyChord::new(false, false, true, "N")),
-			Self::NextNote => Some(KeyChord::new(false, false, false, "N")),
-			Self::JumpToAllBookmarks => Some(KeyChord::new(true, false, false, "B")),
-			Self::JumpToBookmarksOnly => Some(KeyChord::new(true, true, false, "B")),
-			Self::JumpToNotesOnly => Some(KeyChord::new(true, true, false, "M")),
-			Self::ViewNoteText => Some(KeyChord::new_raw_ctrl(true, false, true, "W")),
-			Self::PreviousLink => Some(KeyChord::new(false, false, true, "K")),
-			Self::NextLink => Some(KeyChord::new(false, false, false, "K")),
-			Self::PreviousImage => Some(KeyChord::new(false, false, true, "G")),
-			Self::NextImage => Some(KeyChord::new(false, false, false, "G")),
-			Self::PreviousFigure => Some(KeyChord::new(false, false, true, "F")),
-			Self::NextFigure => Some(KeyChord::new(false, false, false, "F")),
-			Self::PreviousTable => Some(KeyChord::new(false, false, true, "T")),
-			Self::NextTable => Some(KeyChord::new(false, false, false, "T")),
-			Self::PreviousSeparator => Some(KeyChord::new(false, false, true, "S")),
-			Self::NextSeparator => Some(KeyChord::new(false, false, false, "S")),
-			Self::PreviousList => Some(KeyChord::new(false, false, true, "L")),
-			Self::NextList => Some(KeyChord::new(false, false, false, "L")),
-			Self::PreviousListItem => Some(KeyChord::new(false, false, true, "I")),
-			Self::NextListItem => Some(KeyChord::new(false, false, false, "I")),
-			Self::ContainerStart => Some(KeyChord::new(false, false, true, ",")),
-			Self::ContainerEnd => Some(KeyChord::new(false, false, false, ",")),
-			Self::WordCount => Some(KeyChord::new_raw_ctrl(true, false, false, "W")),
-			Self::DocumentInfo => Some(KeyChord::new(true, false, false, "I")),
-			Self::TableOfContents => Some(KeyChord::new(true, false, false, "T")),
-			Self::ElementsList => Some(KeyChord::new(false, false, false, "F7")),
-			Self::RevealFileInFolder => Some(KeyChord::new(true, false, true, "C")),
-			Self::OpenInWebView => Some(KeyChord::new(true, false, true, "V")),
-			Self::ViewSource => Some(KeyChord::new(true, false, false, "U")),
-			Self::ToggleBookmark => Some(KeyChord::new(true, false, true, "B")),
-			Self::BookmarkWithNote => Some(KeyChord::new(true, false, true, "N")),
-			Self::ToggleWordWrap => Some(KeyChord::new(true, true, false, "W")),
-			// The conventional shortcut is Control+Command+F; RawCtrl forces the
-			// physical Control key while plain Ctrl auto-translates to Command on mac.
-			Self::ToggleFullScreen => {
-				Some(KeyChord { ctrl: true, raw_ctrl: true, alt: false, shift: false, key: "F".to_string() })
-			}
-			Self::Options => Some(KeyChord::new(true, false, false, ",")),
-			Self::SleepTimer => Some(KeyChord::new(true, false, true, "S")),
-			Self::CustomizeShortcuts => None,
-			Self::ImportDocumentData => Some(KeyChord::new(true, false, true, "I")),
-			Self::ExportDocumentData => Some(KeyChord::new(true, false, true, "E")),
-			Self::ExportToPlainText => Some(KeyChord::new(true, false, false, "E")),
-			Self::ExportToHtml => None,
-			Self::ExportToMarkdown => None,
-			Self::About => Some(KeyChord::new(true, false, false, "F1")),
-			Self::ViewHelpBrowser => Some(KeyChord::new(false, false, false, "F1")),
-			Self::ViewHelpPaperback => Some(KeyChord::new(false, false, true, "F1")),
-			Self::CheckForUpdates => Some(KeyChord::new(true, false, true, "U")),
-			Self::Donate => Some(KeyChord::new(true, false, false, "D")),
-		}
-
-		#[cfg(not(target_os = "macos"))]
-		match self {
-			Self::Open => Some(KeyChord::new(true, false, false, "O")),
-			Self::Close => Some(KeyChord::new(true, false, false, "F4")),
-			Self::CloseAll => Some(KeyChord::new(true, false, true, "F4")),
-			Self::ReopenLastClosed => Some(KeyChord::new(true, false, true, "T")),
-			Self::ShowAllRecentDocuments => Some(KeyChord::new(true, false, false, "R")),
-			Self::Exit => Some(KeyChord::new(true, false, false, "Q")),
-			Self::Find => Some(KeyChord::new(true, false, false, "F")),
-			Self::FindNext => Some(KeyChord::new(false, false, false, "F3")),
-			Self::FindPrevious => Some(KeyChord::new(false, false, true, "F3")),
-			Self::GoToLine => Some(KeyChord::new(true, false, false, "G")),
-			Self::GoToPercent => Some(KeyChord::new(true, false, true, "G")),
-			Self::GoToPage => Some(KeyChord::new(true, false, false, "P")),
-			Self::GoBack => Some(KeyChord::new(false, true, false, "Left")),
-			Self::GoForward => Some(KeyChord::new(false, true, false, "Right")),
-			Self::AnnouncePercent => Some(KeyChord::new(false, false, false, "=")),
-			Self::SetTemporaryBookmark => Some(KeyChord::new(false, false, false, "/")),
-			Self::JumpToTemporaryBookmark => Some(KeyChord::new(false, false, false, "\\")),
-			Self::PreviousSection => Some(KeyChord::new(false, false, false, "[")),
-			Self::NextSection => Some(KeyChord::new(false, false, false, "]")),
-			Self::PreviousHeading => Some(KeyChord::new(false, false, true, "H")),
-			Self::NextHeading => Some(KeyChord::new(false, false, false, "H")),
-			Self::PreviousHeading1 => Some(KeyChord::new(false, false, true, "1")),
-			Self::NextHeading1 => Some(KeyChord::new(false, false, false, "1")),
-			Self::PreviousHeading2 => Some(KeyChord::new(false, false, true, "2")),
-			Self::NextHeading2 => Some(KeyChord::new(false, false, false, "2")),
-			Self::PreviousHeading3 => Some(KeyChord::new(false, false, true, "3")),
-			Self::NextHeading3 => Some(KeyChord::new(false, false, false, "3")),
-			Self::PreviousHeading4 => Some(KeyChord::new(false, false, true, "4")),
-			Self::NextHeading4 => Some(KeyChord::new(false, false, false, "4")),
-			Self::PreviousHeading5 => Some(KeyChord::new(false, false, true, "5")),
-			Self::NextHeading5 => Some(KeyChord::new(false, false, false, "5")),
-			Self::PreviousHeading6 => Some(KeyChord::new(false, false, true, "6")),
-			Self::NextHeading6 => Some(KeyChord::new(false, false, false, "6")),
-			Self::PreviousPage => Some(KeyChord::new(false, false, true, "P")),
-			Self::NextPage => Some(KeyChord::new(false, false, false, "P")),
-			Self::PreviousBookmark => Some(KeyChord::new(false, false, true, "B")),
-			Self::NextBookmark => Some(KeyChord::new(false, false, false, "B")),
-			Self::PreviousNote => Some(KeyChord::new(false, false, true, "N")),
-			Self::NextNote => Some(KeyChord::new(false, false, false, "N")),
-			Self::JumpToAllBookmarks => Some(KeyChord::new(true, false, false, "B")),
-			Self::JumpToBookmarksOnly => Some(KeyChord::new(true, true, false, "B")),
-			Self::JumpToNotesOnly => Some(KeyChord::new(true, true, false, "M")),
-			Self::ViewNoteText => Some(KeyChord::new(true, false, true, "W")),
-			Self::PreviousLink => Some(KeyChord::new(false, false, true, "K")),
-			Self::NextLink => Some(KeyChord::new(false, false, false, "K")),
-			Self::PreviousImage => Some(KeyChord::new(false, false, true, "G")),
-			Self::NextImage => Some(KeyChord::new(false, false, false, "G")),
-			Self::PreviousFigure => Some(KeyChord::new(false, false, true, "F")),
-			Self::NextFigure => Some(KeyChord::new(false, false, false, "F")),
-			Self::PreviousTable => Some(KeyChord::new(false, false, true, "T")),
-			Self::NextTable => Some(KeyChord::new(false, false, false, "T")),
-			Self::PreviousSeparator => Some(KeyChord::new(false, false, true, "S")),
-			Self::NextSeparator => Some(KeyChord::new(false, false, false, "S")),
-			Self::PreviousList => Some(KeyChord::new(false, false, true, "L")),
-			Self::NextList => Some(KeyChord::new(false, false, false, "L")),
-			Self::PreviousListItem => Some(KeyChord::new(false, false, true, "I")),
-			Self::NextListItem => Some(KeyChord::new(false, false, false, "I")),
-			Self::ContainerStart => Some(KeyChord::new(false, false, true, ",")),
-			Self::ContainerEnd => Some(KeyChord::new(false, false, false, ",")),
-			Self::WordCount => Some(KeyChord::new(true, false, false, "W")),
-			Self::DocumentInfo => Some(KeyChord::new(true, false, false, "I")),
-			Self::TableOfContents => Some(KeyChord::new(true, false, false, "T")),
-			Self::ElementsList => Some(KeyChord::new(false, false, false, "F7")),
-			Self::RevealFileInFolder => Some(KeyChord::new(true, false, true, "C")),
-			Self::OpenInWebView => Some(KeyChord::new(true, false, true, "V")),
-			Self::ViewSource => Some(KeyChord::new(true, false, false, "U")),
-			Self::ToggleBookmark => Some(KeyChord::new(true, false, true, "B")),
-			Self::BookmarkWithNote => Some(KeyChord::new(true, false, true, "N")),
-			Self::ToggleWordWrap => Some(KeyChord::new(true, true, false, "W")),
-			Self::ToggleFullScreen => Some(KeyChord::new(false, false, false, "F11")),
-			Self::Options => Some(KeyChord::new(true, false, false, ",")),
-			Self::SleepTimer => Some(KeyChord::new(true, false, true, "S")),
-			Self::CustomizeShortcuts => None,
-			Self::ImportDocumentData => Some(KeyChord::new(true, false, true, "I")),
-			Self::ExportDocumentData => Some(KeyChord::new(true, false, true, "E")),
-			Self::ExportToPlainText => Some(KeyChord::new(true, false, false, "E")),
-			Self::ExportToHtml => None,
-			Self::ExportToMarkdown => None,
-			Self::About => Some(KeyChord::new(true, false, false, "F1")),
-			Self::ViewHelpBrowser => Some(KeyChord::new(false, false, false, "F1")),
-			Self::ViewHelpPaperback => Some(KeyChord::new(false, false, true, "F1")),
-			Self::CheckForUpdates => Some(KeyChord::new(true, false, true, "U")),
-			Self::Donate => Some(KeyChord::new(true, false, false, "D")),
-		}
-	}
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
-pub struct KeyChord {
-	pub ctrl: bool,
-	#[serde(default)]
-	pub raw_ctrl: bool,
-	pub alt: bool,
-	pub shift: bool,
-	pub key: String,
-}
-
-impl KeyChord {
-	pub fn new(ctrl: bool, alt: bool, shift: bool, key: impl Into<String>) -> Self {
-		let key_str = key.into();
-		let normalized = Self::normalize_key_name(&key_str);
-		Self { ctrl, raw_ctrl: false, alt, shift, key: normalized }
-	}
-
-	pub fn new_raw_ctrl(raw_ctrl: bool, alt: bool, shift: bool, key: impl Into<String>) -> Self {
-		let key_str = key.into();
-		let normalized = Self::normalize_key_name(&key_str);
-		Self { ctrl: false, raw_ctrl, alt, shift, key: normalized }
-	}
-
-	pub fn normalize_key_name(key: &str) -> String {
-		let trimmed = key.trim();
-		if trimmed.eq_ignore_ascii_case("return") || trimmed.eq_ignore_ascii_case("enter") {
-			"Enter".to_string()
-		} else if trimmed.eq_ignore_ascii_case("space") {
-			"Space".to_string()
-		} else if trimmed.eq_ignore_ascii_case("tab") {
-			"Tab".to_string()
-		} else if trimmed.eq_ignore_ascii_case("backspace") || trimmed.eq_ignore_ascii_case("back") {
-			"Backspace".to_string()
-		} else if trimmed.eq_ignore_ascii_case("delete") || trimmed.eq_ignore_ascii_case("del") {
-			"Delete".to_string()
-		} else if trimmed.eq_ignore_ascii_case("escape") || trimmed.eq_ignore_ascii_case("esc") {
-			"Escape".to_string()
-		} else if trimmed.eq_ignore_ascii_case("home") {
-			"Home".to_string()
-		} else if trimmed.eq_ignore_ascii_case("end") {
-			"End".to_string()
-		} else if trimmed.eq_ignore_ascii_case("pageup")
-			|| trimmed.eq_ignore_ascii_case("page up")
-			|| trimmed.eq_ignore_ascii_case("pgup")
-		{
-			"PageUp".to_string()
-		} else if trimmed.eq_ignore_ascii_case("pagedown")
-			|| trimmed.eq_ignore_ascii_case("page down")
-			|| trimmed.eq_ignore_ascii_case("pgdn")
-		{
-			"PageDown".to_string()
-		} else if trimmed.eq_ignore_ascii_case("left") || trimmed.eq_ignore_ascii_case("left arrow") {
-			"Left".to_string()
-		} else if trimmed.eq_ignore_ascii_case("right") || trimmed.eq_ignore_ascii_case("right arrow") {
-			"Right".to_string()
-		} else if trimmed.eq_ignore_ascii_case("up") || trimmed.eq_ignore_ascii_case("up arrow") {
-			"Up".to_string()
-		} else if trimmed.eq_ignore_ascii_case("down") || trimmed.eq_ignore_ascii_case("down arrow") {
-			"Down".to_string()
-		} else if trimmed.len() >= 2
-			&& trimmed.starts_with(['F', 'f'])
-			&& trimmed[1..].chars().all(|c| c.is_ascii_digit())
-		{
-			format!("F{}", &trimmed[1..])
-		} else if trimmed.len() == 1 {
-			let ch = trimmed.chars().next().unwrap();
-			if ch.is_ascii_alphabetic() { ch.to_ascii_uppercase().to_string() } else { trimmed.to_string() }
-		} else {
-			trimmed.to_string()
-		}
-	}
-
-	pub fn to_shortcut_string(&self) -> String {
-		let mut parts = Vec::new();
-		if self.raw_ctrl {
-			parts.push("RawCtrl");
-		}
-		if self.ctrl {
-			parts.push("Ctrl");
-		}
-		if self.alt {
-			parts.push("Alt");
-		}
-		if self.shift {
-			parts.push("Shift");
-		}
-		parts.push(&self.key);
-		parts.join("+")
-	}
-
-	pub fn parse(input: &str) -> Option<Self> {
-		let trimmed = input.trim();
-		if trimmed.is_empty() || trimmed.eq_ignore_ascii_case("none") {
-			return None;
-		}
-		let mut ctrl = false;
-		let mut raw_ctrl = false;
-		let mut alt = false;
-		let mut shift = false;
-		let mut remaining = trimmed;
-
-		while let Some(plus_idx) = remaining.find('+') {
-			let prefix = &remaining[..plus_idx];
-			if prefix.eq_ignore_ascii_case("rawctrl") {
-				raw_ctrl = true;
-				remaining = &remaining[plus_idx + 1..];
-			} else if prefix.eq_ignore_ascii_case("ctrl") || prefix.eq_ignore_ascii_case("control") {
-				ctrl = true;
-				remaining = &remaining[plus_idx + 1..];
-			} else if prefix.eq_ignore_ascii_case("alt") {
-				alt = true;
-				remaining = &remaining[plus_idx + 1..];
-			} else if prefix.eq_ignore_ascii_case("shift") {
-				shift = true;
-				remaining = &remaining[plus_idx + 1..];
-			} else {
-				break;
-			}
-		}
-		let key = remaining.to_string();
-		if key.is_empty() {
-			return None;
-		}
-		let normalized = Self::normalize_key_name(&key);
-		Some(Self { ctrl, raw_ctrl, alt, shift, key: normalized })
-	}
-
-	pub fn from_key_code(key_code: i32, ctrl: bool, alt: bool, shift: bool) -> Option<Self> {
-		let key_name = match key_code {
-			13 | 370 => "Enter".to_string(),
-			9 => "Tab".to_string(),
-			32 => "Space".to_string(),
-			8 => "Backspace".to_string(),
-			127 | 308 | 386 => "Delete".to_string(),
-			27 => "Escape".to_string(),
-			313 | 377 => "Home".to_string(),
-			312 | 379 => "End".to_string(),
-			366 | 376 => "PageUp".to_string(),
-			367 | 381 => "PageDown".to_string(),
-			314 | 378 => "Left".to_string(),
-			316 | 380 => "Right".to_string(),
-			315 | 382 => "Up".to_string(),
-			317 | 383 => "Down".to_string(),
-			340..=363 => format!("F{}", key_code - 340 + 1),
-			65..=90 => (char::from_u32(key_code as u32)?).to_string(),
-			97..=122 => (char::from_u32((key_code - 32) as u32)?).to_string(),
-			48..=57 => (char::from_u32(key_code as u32)?).to_string(),
-			324..=333 => (char::from_u32((key_code - 324 + 48) as u32)?).to_string(),
-			44 | 188 => ",".to_string(),
-			46 | 190 | 387 => ".".to_string(),
-			47 | 191 | 388 => "/".to_string(),
-			91 | 219 => "[".to_string(),
-			93 | 221 => "]".to_string(),
-			92 | 220 => "\\".to_string(),
-			45 | 189 | 390 => "-".to_string(),
-			61 | 187 => "=".to_string(),
-			59 | 186 => ";".to_string(),
-			39 | 222 => "'".to_string(),
-			96 | 192 => "`".to_string(),
-			_ => return None,
-		};
-		Some(Self { ctrl, raw_ctrl: false, alt, shift, key: key_name })
-	}
-
-	pub fn matches(&self, key_code: i32, ctrl: bool, alt: bool, shift: bool) -> bool {
-		let self_ctrl = self.ctrl || self.raw_ctrl;
-		if self_ctrl != ctrl || self.alt != alt || self.shift != shift {
-			return false;
-		}
-		let key_str = self.key.as_str();
-		if key_str.eq_ignore_ascii_case("Enter") {
-			key_code == 13 || key_code == 370
-		} else if key_str.eq_ignore_ascii_case("Tab") {
-			key_code == 9
-		} else if key_str.eq_ignore_ascii_case("Space") {
-			key_code == 32
-		} else if key_str.eq_ignore_ascii_case("Backspace") {
-			key_code == 8
-		} else if key_str.eq_ignore_ascii_case("Delete") {
-			key_code == 127 || key_code == 308 || key_code == 386
-		} else if key_str.eq_ignore_ascii_case("Escape") {
-			key_code == 27
-		} else if key_str.eq_ignore_ascii_case("Home") {
-			key_code == 313 || key_code == 377
-		} else if key_str.eq_ignore_ascii_case("End") {
-			key_code == 312 || key_code == 379
-		} else if key_str.eq_ignore_ascii_case("PageUp") {
-			key_code == 366 || key_code == 376
-		} else if key_str.eq_ignore_ascii_case("PageDown") {
-			key_code == 367 || key_code == 381
-		} else if key_str.eq_ignore_ascii_case("Left") {
-			key_code == 314 || key_code == 378
-		} else if key_str.eq_ignore_ascii_case("Right") {
-			key_code == 316 || key_code == 380
-		} else if key_str.eq_ignore_ascii_case("Up") {
-			key_code == 315 || key_code == 382
-		} else if key_str.eq_ignore_ascii_case("Down") {
-			key_code == 317 || key_code == 383
-		} else if key_str.starts_with(['F', 'f'])
-			&& let Ok(num) = key_str[1..].parse::<i32>()
-			&& (1..=24).contains(&num)
-		{
-			key_code == 340 + num - 1
-		} else if key_str.len() == 1 {
-			let ch = key_str.chars().next().unwrap();
-			if ch.is_ascii_alphabetic() {
-				let upper = ch.to_ascii_uppercase() as i32;
-				key_code == upper || key_code == upper + 32
-			} else if ch.is_ascii_digit() {
-				key_code == ch as i32 || key_code == (ch as i32 - 48 + 324)
-			} else {
-				match ch {
-					',' => key_code == 44 || key_code == 188,
-					'.' => key_code == 46 || key_code == 190 || key_code == 387,
-					'/' => key_code == 47 || key_code == 191 || key_code == 388,
-					'\\' => key_code == 92 || key_code == 220,
-					'[' => key_code == 91 || key_code == 219,
-					']' => key_code == 93 || key_code == 221,
-					'-' => key_code == 45 || key_code == 189 || key_code == 390,
-					'=' => key_code == 61 || key_code == 187,
-					';' => key_code == 59 || key_code == 186,
-					'\'' => key_code == 39 || key_code == 222,
-					'`' => key_code == 96 || key_code == 192,
-					_ => key_code == ch as i32,
-				}
-			}
-		} else {
-			false
-		}
-	}
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
-pub struct ShortcutsConfig {
-	#[serde(default)]
-	pub bindings: HashMap<ActionId, Option<String>>,
-}
-
-impl ShortcutsConfig {
-	pub fn get_chord(&self, action: ActionId) -> Option<KeyChord> {
-		if let Some(entry) = self.bindings.get(&action) {
-			match entry {
-				Some(s) => KeyChord::parse(s),
-				None => None,
-			}
-		} else {
-			action.default_chord()
-		}
-	}
-
-	pub fn get_display_str(&self, action: ActionId) -> String {
-		self.get_chord(action).map_or_else(|| "None".to_string(), |c| c.to_shortcut_string())
-	}
-
-	pub fn get_menu_str(&self, action: ActionId) -> String {
-		self.get_chord(action).map_or_else(String::new, |c| c.to_shortcut_string())
-	}
-
-	pub fn set_chord(&mut self, action: ActionId, chord: Option<KeyChord>) {
-		self.bindings.insert(action, chord.map(|c| c.to_shortcut_string()));
-	}
-
-	pub fn reset_action(&mut self, action: ActionId) {
-		self.bindings.remove(&action);
-	}
-
-	pub fn reset_category(&mut self, category: ShortcutCategory) {
-		for action in category.actions() {
-			self.bindings.remove(&action);
-		}
-	}
-
-	pub fn reset_all(&mut self) {
-		self.bindings.clear();
-	}
-
-	pub fn find_action(&self, key_code: i32, ctrl: bool, alt: bool, shift: bool) -> Option<ActionId> {
-		for &action in ActionId::all() {
-			if let Some(chord) = self.get_chord(action)
-				&& chord.matches(key_code, ctrl, alt, shift)
-			{
-				return Some(action);
-			}
-		}
-		None
-	}
-}
-
 const fn default_true() -> bool {
 	true
 }
@@ -1012,8 +164,6 @@ pub struct AppSettings {
 	pub line_spacing: i64,
 	#[serde(default)]
 	pub hotkey: HotkeyConfig,
-	#[serde(default)]
-	pub shortcuts: ShortcutsConfig,
 	/// Pass-through storage for host-specific settings (e.g. desktop UI preferences).
 	/// Keys written here are preserved on read/write so host consumers can store their
 	/// own fields alongside the generic ones without conflict.
@@ -1047,7 +197,6 @@ impl Default for AppSettings {
 			paragraph_spacing: 0,
 			line_spacing: 0,
 			hotkey: HotkeyConfig::default(),
-			shortcuts: ShortcutsConfig::default(),
 			extra: HashMap::new(),
 		}
 	}
@@ -1064,8 +213,6 @@ pub struct DocumentConfig {
 	pub navigation_history_index: usize,
 	#[serde(default)]
 	pub bookmarks: Vec<StoredBookmark>,
-	#[serde(default, skip_serializing_if = "Option::is_none")]
-	pub temporary_bookmark: Option<i64>,
 	#[serde(default, skip_serializing_if = "String::is_empty")]
 	pub format: String,
 	#[serde(default, skip_serializing_if = "String::is_empty")]
@@ -1082,8 +229,6 @@ struct SidecarData {
 	format: Option<String>,
 	#[serde(default, skip_serializing_if = "Vec::is_empty")]
 	bookmarks: Vec<StoredBookmark>,
-	#[serde(default, skip_serializing_if = "Option::is_none")]
-	temporary_bookmark: Option<i64>,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
@@ -1480,29 +625,6 @@ impl ConfigManager {
 		self.dirty.set(true);
 	}
 
-	pub fn get_shortcuts(&self) -> ShortcutsConfig {
-		if !self.initialized {
-			return ShortcutsConfig::default();
-		}
-		self.data.borrow().app.shortcuts.clone()
-	}
-
-	pub fn set_shortcuts(&self, shortcuts: &ShortcutsConfig) {
-		if !self.initialized {
-			return;
-		}
-		self.data.borrow_mut().app.shortcuts = shortcuts.clone();
-		self.dirty.set(true);
-	}
-
-	pub fn get_shortcut_chord(&self, action: ActionId) -> Option<KeyChord> {
-		self.get_shortcuts().get_chord(action)
-	}
-
-	pub fn get_shortcut_menu_str(&self, action: ActionId) -> String {
-		self.get_shortcuts().get_menu_str(action)
-	}
-
 	pub fn add_recent_document(&self, path: &str) {
 		if !self.initialized {
 			return;
@@ -1633,28 +755,6 @@ impl ConfigManager {
 	pub fn get_validated_document_position(&self, path: &str, max_position: i64) -> i64 {
 		let saved = self.get_document_position(path);
 		if saved > 0 && saved <= max_position { saved } else { -1 }
-	}
-
-	/// Sets the single per-document temporary bookmark position (`None` clears it).
-	pub fn set_temporary_bookmark(&self, path: &str, position: Option<i64>) {
-		if !self.initialized {
-			return;
-		}
-		{
-			let key = self.get_doc_key(path);
-			let mut data = self.data.borrow_mut();
-			Self::doc_entry_mut(&mut data, key, path).temporary_bookmark = position;
-		}
-		self.dirty.set(true);
-	}
-
-	#[must_use]
-	pub fn get_temporary_bookmark(&self, path: &str) -> Option<i64> {
-		if !self.initialized {
-			return None;
-		}
-		let key = self.get_doc_key(path);
-		self.data.borrow().documents.get(&key).and_then(|d| d.temporary_bookmark)
 	}
 
 	pub fn set_navigation_history(&self, path: &str, history: &[i64], history_index: usize) {
@@ -1875,9 +975,6 @@ impl ConfigManager {
 		if let Some(format) = sidecar.format {
 			self.set_document_format(doc_path, &format);
 		}
-		if let Some(position) = sidecar.temporary_bookmark {
-			self.set_temporary_bookmark(doc_path, Some(position));
-		}
 		if !sidecar.bookmarks.is_empty() {
 			let key = self.get_doc_key(doc_path);
 			let mut data = self.data.borrow_mut();
@@ -1898,7 +995,6 @@ impl ConfigManager {
 			last_position: doc.map(|d| d.last_position).filter(|&p| p > 0),
 			format: doc.and_then(|d| if d.format.is_empty() { None } else { Some(d.format.clone()) }),
 			bookmarks: doc.map(|d| d.bookmarks.clone()).unwrap_or_default(),
-			temporary_bookmark: doc.and_then(|d| d.temporary_bookmark),
 		};
 		if let Ok(s) = toml::to_string_pretty(&sidecar) {
 			let _ = fs::write(export_path, s);
@@ -1923,9 +1019,12 @@ impl Drop for ConfigManager {
 	}
 }
 
-pub fn get_sorted_document_list(config: &ConfigManager, open_paths: &[String], filter: &str) -> Vec<DocumentListItem> {
-	use crate::types::{DocumentListItem, DocumentListStatus};
-
+pub fn get_sorted_document_list(
+	config: &ConfigManager,
+	open_paths: &[String],
+	filter: &str,
+	status_filter: Option<DocumentListStatus>,
+) -> Vec<DocumentListItem> {
 	let recent_docs = config.get_recent_documents();
 	let all_docs = config.get_all_documents();
 	let mut doc_paths: Vec<String> = Vec::new();
@@ -1963,6 +1062,9 @@ pub fn get_sorted_document_list(config: &ConfigManager, open_paths: &[String], f
 			} else {
 				DocumentListStatus::Closed
 			};
+			if status_filter.is_some_and(|wanted| wanted != status) {
+				return None;
+			}
 			Some(DocumentListItem { path, filename, status })
 		})
 		.collect()
@@ -2053,83 +1155,30 @@ mod tests {
 	}
 
 	#[test]
-	fn temporary_bookmark_set_get_overwrite_clear() {
+	fn get_sorted_document_list_filters_by_status() {
+		use crate::util::test_support::TempDir;
+
+		let dir = TempDir::new("document-list-status-filter");
+		let open_path = dir.write_str("open.txt", "content");
+		let closed_path = dir.write_str("closed.txt", "content");
+		let missing_path = dir.join_str("missing.txt");
 		let mut config = ConfigManager::new();
 		config.initialized = true;
-		let path = "book.epub";
-		assert_eq!(config.get_temporary_bookmark(path), None);
-		config.set_temporary_bookmark(path, Some(42_000));
-		assert_eq!(config.get_temporary_bookmark(path), Some(42_000));
-		config.set_temporary_bookmark(path, Some(43_000));
-		assert_eq!(config.get_temporary_bookmark(path), Some(43_000));
-		config.set_temporary_bookmark(path, None);
-		assert_eq!(config.get_temporary_bookmark(path), None);
-	}
-
-	#[test]
-	fn temporary_bookmark_serializes_and_loads() {
-		let doc =
-			DocumentConfig { path: "book.epub".into(), temporary_bookmark: Some(12_345), ..DocumentConfig::default() };
-		let serialized = toml::to_string(&doc).unwrap();
-		let parsed: DocumentConfig = toml::from_str(&serialized).unwrap();
-		assert_eq!(parsed.temporary_bookmark, Some(12_345));
-	}
-
-	#[test]
-	fn temporary_bookmark_defaults_to_none_when_missing() {
-		// Old config files without the field must load as None.
-		let parsed: DocumentConfig = toml::from_str("path = \"book.epub\"\n").unwrap();
-		assert_eq!(parsed.temporary_bookmark, None);
-	}
-
-	#[test]
-	fn key_chord_parse_and_to_string() {
-		let chord = KeyChord::parse("Ctrl+Shift+O").unwrap();
-		assert!(chord.ctrl);
-		assert!(chord.shift);
-		assert!(!chord.alt);
-		assert_eq!(chord.key, "O");
-		assert_eq!(chord.to_shortcut_string(), "Ctrl+Shift+O");
-
-		let single = KeyChord::parse("H").unwrap();
-		assert!(!single.ctrl);
-		assert!(!single.shift);
-		assert!(!single.alt);
-		assert_eq!(single.key, "H");
-		assert_eq!(single.to_shortcut_string(), "H");
-
-		assert_eq!(KeyChord::parse("none"), None);
-		assert_eq!(KeyChord::parse(""), None);
-	}
-
-	#[test]
-	fn shortcuts_config_set_reset_and_find() {
-		let mut sc = ShortcutsConfig::default();
-		let default_open = sc.get_chord(ActionId::Open);
-		assert!(default_open.is_some());
-
-		let new_chord = KeyChord::new(true, true, false, "K");
-		sc.set_chord(ActionId::Open, Some(new_chord.clone()));
-		assert_eq!(sc.get_chord(ActionId::Open), Some(new_chord));
-
-		let matched = sc.find_action(75, true, true, false);
-		assert_eq!(matched, Some(ActionId::Open));
-
-		sc.reset_action(ActionId::Open);
-		assert_eq!(sc.get_chord(ActionId::Open), default_open);
-	}
-
-	#[test]
-	fn shortcut_category_actions_coverage() {
-		let mut total_actions = 0;
-		for cat in ShortcutCategory::all() {
-			let actions = cat.actions();
-			assert!(!actions.is_empty());
-			for action in &actions {
-				assert_eq!(action.category(), *cat);
-			}
-			total_actions += actions.len();
+		for path in [&open_path, &closed_path, &missing_path] {
+			config.add_recent_document(path);
 		}
-		assert_eq!(total_actions, ActionId::all().len());
+		let open_paths = vec![open_path.clone()];
+
+		let all = get_sorted_document_list(&config, &open_paths, "", None);
+		assert_eq!(all.len(), 3);
+
+		let open_only = get_sorted_document_list(&config, &open_paths, "", Some(DocumentListStatus::Open));
+		assert_eq!(open_only.iter().map(|item| &item.path).collect::<Vec<_>>(), vec![&open_path]);
+
+		let closed_only = get_sorted_document_list(&config, &open_paths, "", Some(DocumentListStatus::Closed));
+		assert_eq!(closed_only.iter().map(|item| &item.path).collect::<Vec<_>>(), vec![&closed_path]);
+
+		let missing_only = get_sorted_document_list(&config, &open_paths, "", Some(DocumentListStatus::Missing));
+		assert_eq!(missing_only.iter().map(|item| &item.path).collect::<Vec<_>>(), vec![&missing_path]);
 	}
 }

--- a/crates/paperback/src/ui/dialogs/all_documents.rs
+++ b/crates/paperback/src/ui/dialogs/all_documents.rs
@@ -1,8 +1,8 @@
-use std::{path::Path, rc::Rc, sync::Mutex};
+use std::{cell::Cell, path::Path, rc::Rc, sync::Mutex};
 
 use paperback_core::{config::ConfigManager, parser::build_file_filter_string, types::DocumentListStatus};
 use patois::t;
-use wxdragon::prelude::*;
+use wxdragon::{ffi, prelude::*, timer::Timer, window::FromWindowWithClassName};
 
 use super::{DIALOG_PADDING, KEY_DELETE, KEY_NUMPAD_DELETE, KEY_NUMPAD_ENTER, KEY_RETURN};
 
@@ -11,10 +11,36 @@ const RECENT_DOCS_LIST_HEIGHT: i32 = 600;
 const RECENT_DOCS_FILENAME_WIDTH: i32 = 250;
 const RECENT_DOCS_STATUS_WIDTH: i32 = 100;
 const RECENT_DOCS_PATH_WIDTH: i32 = 450;
+const STATUS_BAR_DEBOUNCE_MS: i32 = 10;
 
 pub struct AllDocumentsResult {
 	pub open: Option<String>,
 	pub paths_to_close: Vec<String>,
+}
+
+#[derive(Copy, Clone)]
+struct AllDocumentsWidgets {
+	list: ListCtrl,
+	open_button: Button,
+	locate_button: Button,
+	remove_button: Button,
+	clear_all_button: Button,
+	status_choice: Choice,
+	status_bar: StatusBar,
+}
+
+#[derive(Clone)]
+struct StatusBarDebounce {
+	timer: Rc<Timer<Dialog>>,
+	suppress: Rc<Cell<bool>>,
+}
+
+impl StatusBarDebounce {
+	fn request_update(&self) {
+		if !self.suppress.get() {
+			self.timer.start(STATUS_BAR_DEBOUNCE_MS, true);
+		}
+	}
 }
 
 pub fn show_all_documents_dialog(
@@ -31,86 +57,79 @@ pub fn show_all_documents_dialog(
 	// TRANSLATORS: Label for the search input field in the All Documents dialog
 	let search_label = StaticText::builder(&dialog).with_label(&t("&search")).build();
 	let search_ctrl = TextCtrl::builder(&dialog).with_size(Size::new(300, -1)).build();
-	let doc_list = build_all_documents_list(dialog);
+	let (status_label, status_choice) = build_all_documents_status_choice(dialog);
+	let list = build_all_documents_list(dialog);
+	let status_bar = build_all_documents_status_bar(dialog);
 	let (open_button, locate_button, remove_button, clear_all_button, ok_button) = build_all_documents_buttons(dialog);
-	dialog.set_escape_id(ID_CANCEL);
-	populate_document_list(&DocumentListParams {
-		list: doc_list,
+	let widgets = AllDocumentsWidgets {
+		list,
 		open_button,
 		locate_button,
 		remove_button,
 		clear_all_button,
+		status_choice,
+		status_bar,
+	};
+	dialog.set_escape_id(ID_CANCEL);
+	let status_debounce =
+		StatusBarDebounce { timer: Rc::new(Timer::new(&dialog)), suppress: Rc::new(Cell::new(false)) };
+	status_debounce.timer.on_tick(move |_event| {
+		update_document_status_bar(widgets.list, widgets.status_bar);
+	});
+	populate_document_list(&DocumentListParams {
+		widgets,
 		config,
 		open_paths: open_paths.as_ref(),
 		filter: "",
+		status_filter: None,
 		selection: None,
+		status_debounce: &status_debounce,
 	});
-	bind_all_documents_selection(doc_list, open_button, locate_button);
-	let open_action = make_all_documents_open_action(dialog, doc_list, Rc::clone(&selected_path));
-	bind_all_documents_open(doc_list, open_button, &open_action);
+	bind_all_documents_selection(widgets, status_debounce.clone());
+	let open_action = make_all_documents_open_action(dialog, widgets.list, Rc::clone(&selected_path));
+	bind_all_documents_open(widgets.list, widgets.open_button, &open_action);
 	let remove_action = make_all_documents_remove_action(
 		dialog,
-		doc_list,
+		widgets,
 		search_ctrl,
-		open_button,
-		locate_button,
-		remove_button,
-		clear_all_button,
 		Rc::clone(config),
 		Rc::clone(&open_paths),
 		Rc::clone(&paths_to_close),
+		status_debounce.clone(),
 	);
-	remove_button.on_click({
+	widgets.remove_button.on_click({
 		let remove_action = Rc::clone(&remove_action);
 		move |_| remove_action()
 	});
 	bind_all_documents_locate(
 		dialog,
-		doc_list,
+		widgets,
 		search_ctrl,
-		open_button,
-		locate_button,
-		remove_button,
-		clear_all_button,
 		Rc::clone(config),
 		Rc::clone(&open_paths),
-		locate_button,
+		status_debounce.clone(),
 	);
 	bind_all_documents_clear(
 		dialog,
-		doc_list,
+		widgets,
 		search_ctrl,
-		open_button,
-		locate_button,
-		remove_button,
-		clear_all_button,
 		Rc::clone(config),
 		Rc::clone(&open_paths),
 		Rc::clone(&paths_to_close),
+		status_debounce.clone(),
 	);
-	bind_all_documents_search(
+	bind_all_documents_search(search_ctrl, widgets, Rc::clone(config), Rc::clone(&open_paths), status_debounce.clone());
+	bind_all_documents_status_choice(
+		widgets,
 		search_ctrl,
-		doc_list,
-		open_button,
-		locate_button,
-		remove_button,
-		clear_all_button,
 		Rc::clone(config),
 		Rc::clone(&open_paths),
+		status_debounce.clone(),
 	);
-	bind_all_documents_keys(doc_list, &open_action, &remove_action);
+	bind_all_documents_keys(widgets, &open_action, &remove_action, status_debounce);
 	bind_all_documents_layout(
 		dialog,
-		AllDocumentsLayout {
-			search_label,
-			search_ctrl,
-			doc_list,
-			open_button,
-			locate_button,
-			remove_button,
-			clear_all_button,
-			ok_button,
-		},
+		AllDocumentsLayout { search_label, search_ctrl, status_label, widgets, ok_button },
 	);
 	dialog.show_modal();
 	AllDocumentsResult {
@@ -158,6 +177,30 @@ fn build_all_documents_list(dialog: Dialog) -> ListCtrl {
 	doc_list
 }
 
+fn build_all_documents_status_choice(dialog: Dialog) -> (StaticText, Choice) {
+	// TRANSLATORS: Label for the status filter dropdown in the All Documents dialog
+	let status_label_text = t("&Status:");
+	let status_label = StaticText::builder(&dialog).with_label(&status_label_text).build();
+	let status_choice = Choice::builder(&dialog).build();
+	// TRANSLATORS: Option in the All Documents status filter to show documents of every status
+	status_choice.append(&t("All"));
+	// TRANSLATORS: Status of a document that is currently open in a tab
+	status_choice.append(&t("Open"));
+	// TRANSLATORS: Status of a document that was previously opened but is currently closed
+	status_choice.append(&t("Closed"));
+	// TRANSLATORS: Status of a document whose file could not be found on disk
+	status_choice.append(&t("Missing"));
+	status_choice.set_selection(0);
+	#[cfg(target_os = "macos")]
+	status_choice.set_accessibility_label(status_label_text.replace('&', "").trim_end_matches(':').trim());
+	(status_label, status_choice)
+}
+
+fn build_all_documents_status_bar(dialog: Dialog) -> StatusBar {
+	let raw = unsafe { ffi::wxd_StatusBar_Create(dialog.handle_ptr(), ffi::wxd_Id::try_from(ID_ANY).unwrap_or(-1), 0) };
+	unsafe { StatusBar::from_ptr(raw.cast::<ffi::wxd_Window_t>()) }
+}
+
 fn build_all_documents_buttons(dialog: Dialog) -> (Button, Button, Button, Button, Button) {
 	// TRANSLATORS: Button label to open the selected document
 	let open_button = Button::builder(&dialog).with_label(&t("&Open")).build();
@@ -173,25 +216,31 @@ fn build_all_documents_buttons(dialog: Dialog) -> (Button, Button, Button, Butto
 	(open_button, locate_button, remove_button, clear_all_button, ok_button)
 }
 
-fn bind_all_documents_selection(list: ListCtrl, open_button: Button, locate_button: Button) {
+fn bind_all_documents_selection(widgets: AllDocumentsWidgets, status_debounce: StatusBarDebounce) {
+	let AllDocumentsWidgets { list, open_button, locate_button, .. } = widgets;
 	let list_for_select = list;
 	let open_button_for_select = open_button;
+	let status_debounce_for_select = status_debounce.clone();
 	list.on_item_selected(move |event| {
 		let index = event.get_item_index();
 		update_open_button_for_index(list_for_select, open_button_for_select, index);
 		update_locate_button(list_for_select, locate_button);
+		status_debounce_for_select.request_update();
 	});
 	let list_for_focus = list;
 	let open_button_for_focus = open_button;
+	let status_debounce_for_focus = status_debounce.clone();
 	list.on_item_focused(move |event| {
 		let index = event.get_item_index();
 		if index >= 0 {
 			update_open_button_for_index(list_for_focus, open_button_for_focus, index);
 			update_locate_button(list_for_focus, locate_button);
+			status_debounce_for_focus.request_update();
 		}
 	});
 	list.on_item_deselected(move |_| {
 		update_locate_button(list, locate_button);
+		status_debounce.request_update();
 	});
 }
 
@@ -225,18 +274,15 @@ fn bind_all_documents_open(list: ListCtrl, open_button: Button, open_action: &Rc
 
 fn make_all_documents_remove_action(
 	dialog: Dialog,
-	list: ListCtrl,
+	widgets: AllDocumentsWidgets,
 	search_ctrl: TextCtrl,
-	open_button: Button,
-	locate_button: Button,
-	remove_button: Button,
-	clear_button: Button,
 	config: Rc<Mutex<ConfigManager>>,
 	open_paths: Rc<Vec<String>>,
 	paths_to_close: Rc<Mutex<Vec<String>>>,
+	status_debounce: StatusBarDebounce,
 ) -> Rc<dyn Fn()> {
 	Rc::new(move || {
-		let indices = get_selected_indices(list);
+		let indices = get_selected_indices(widgets.list);
 		if indices.is_empty() {
 			return;
 		}
@@ -256,7 +302,8 @@ fn make_all_documents_remove_action(
 		if !show_yes_no_dialog(&dialog, &confirm_message, &t("Confirm")) {
 			return;
 		}
-		let paths_to_remove: Vec<String> = indices.iter().filter_map(|&i| get_path_for_index(list, i)).collect();
+		let paths_to_remove: Vec<String> =
+			indices.iter().filter_map(|&i| get_path_for_index(widgets.list, i)).collect();
 		{
 			let cfg = config.lock().unwrap();
 			for path in &paths_to_remove {
@@ -275,33 +322,28 @@ fn make_all_documents_remove_action(
 		let new_selection = indices.iter().copied().max();
 		let filter = search_ctrl.get_value();
 		populate_document_list(&DocumentListParams {
-			list,
-			open_button,
-			locate_button,
-			remove_button,
-			clear_all_button: clear_button,
+			widgets,
 			config: &config,
 			open_paths: open_paths.as_ref(),
 			filter: &filter,
+			status_filter: status_filter_from_choice(widgets.status_choice),
 			selection: new_selection,
+			status_debounce: &status_debounce,
 		});
 	})
 }
 
 fn bind_all_documents_clear(
 	dialog: Dialog,
-	list: ListCtrl,
+	widgets: AllDocumentsWidgets,
 	search_ctrl: TextCtrl,
-	open_button: Button,
-	locate_button: Button,
-	remove_button: Button,
-	clear_button: Button,
 	config: Rc<Mutex<ConfigManager>>,
 	open_paths: Rc<Vec<String>>,
 	paths_to_close: Rc<Mutex<Vec<String>>>,
+	status_debounce: StatusBarDebounce,
 ) {
-	clear_button.on_click(move |_| {
-		if list.get_item_count() == 0 {
+	widgets.clear_all_button.on_click(move |_| {
+		if widgets.list.get_item_count() == 0 {
 			return;
 		}
 		if !show_yes_no_dialog(
@@ -331,50 +373,69 @@ fn bind_all_documents_clear(
 		}
 		search_ctrl.set_value("");
 		populate_document_list(&DocumentListParams {
-			list,
-			open_button,
-			locate_button,
-			remove_button,
-			clear_all_button: clear_button,
+			widgets,
 			config: &config,
 			open_paths: open_paths.as_ref(),
 			filter: "",
+			status_filter: status_filter_from_choice(widgets.status_choice),
 			selection: None,
+			status_debounce: &status_debounce,
 		});
 	});
 }
 
 fn bind_all_documents_search(
 	search_ctrl: TextCtrl,
-	list: ListCtrl,
-	open_button: Button,
-	locate_button: Button,
-	remove_button: Button,
-	clear_button: Button,
+	widgets: AllDocumentsWidgets,
 	config: Rc<Mutex<ConfigManager>>,
 	open_paths: Rc<Vec<String>>,
+	status_debounce: StatusBarDebounce,
 ) {
 	search_ctrl.on_text_updated(move |_event| {
 		let filter = search_ctrl.get_value();
 		populate_document_list(&DocumentListParams {
-			list,
-			open_button,
-			locate_button,
-			remove_button,
-			clear_all_button: clear_button,
+			widgets,
 			config: &config,
 			open_paths: open_paths.as_ref(),
 			filter: &filter,
+			status_filter: status_filter_from_choice(widgets.status_choice),
 			selection: None,
+			status_debounce: &status_debounce,
 		});
 	});
 }
 
-fn bind_all_documents_keys(list: ListCtrl, open_action: &Rc<dyn Fn()>, remove_action: &Rc<dyn Fn()>) {
+fn bind_all_documents_status_choice(
+	widgets: AllDocumentsWidgets,
+	search_ctrl: TextCtrl,
+	config: Rc<Mutex<ConfigManager>>,
+	open_paths: Rc<Vec<String>>,
+	status_debounce: StatusBarDebounce,
+) {
+	widgets.status_choice.on_selection_changed(move |_event| {
+		let filter = search_ctrl.get_value();
+		populate_document_list(&DocumentListParams {
+			widgets,
+			config: &config,
+			open_paths: open_paths.as_ref(),
+			filter: &filter,
+			status_filter: status_filter_from_choice(widgets.status_choice),
+			selection: None,
+			status_debounce: &status_debounce,
+		});
+	});
+}
+
+fn bind_all_documents_keys(
+	widgets: AllDocumentsWidgets,
+	open_action: &Rc<dyn Fn()>,
+	remove_action: &Rc<dyn Fn()>,
+	status_debounce: StatusBarDebounce,
+) {
 	let remove_action_for_keys = Rc::clone(remove_action);
 	let open_action_for_keys = Rc::clone(open_action);
-	let list_for_keys = list;
-	list.bind_internal(EventType::KEY_DOWN, move |event| {
+	let list_for_keys = widgets.list;
+	widgets.list.bind_internal(EventType::KEY_DOWN, move |event| {
 		if let Some(key) = event.get_key_code() {
 			if key == KEY_DELETE || key == KEY_NUMPAD_DELETE {
 				remove_action_for_keys();
@@ -387,7 +448,12 @@ fn bind_all_documents_keys(list: ListCtrl, open_action: &Rc<dyn Fn()>, remove_ac
 				return;
 			}
 			if key == i32::from(b'A') && event.control_down() {
-				list_for_keys.set_item_state(-1, ListItemState::Selected, ListItemState::Selected);
+				if event.shift_down() {
+					list_for_keys.set_item_state(-1, ListItemState::default(), ListItemState::Selected);
+				} else {
+					list_for_keys.set_item_state(-1, ListItemState::Selected, ListItemState::Selected);
+				}
+				status_debounce.request_update();
 				event.skip(false);
 				return;
 			}
@@ -395,7 +461,7 @@ fn bind_all_documents_keys(list: ListCtrl, open_action: &Rc<dyn Fn()>, remove_ac
 		event.skip(true);
 	});
 	let open_action_for_char = Rc::clone(open_action);
-	list.bind_internal(EventType::CHAR, move |event| {
+	widgets.list.bind_internal(EventType::CHAR, move |event| {
 		if let Some(key) = event.get_key_code()
 			&& (key == KEY_RETURN || key == KEY_NUMPAD_ENTER)
 		{
@@ -411,25 +477,22 @@ fn bind_all_documents_keys(list: ListCtrl, open_action: &Rc<dyn Fn()>, remove_ac
 struct AllDocumentsLayout {
 	search_label: StaticText,
 	search_ctrl: TextCtrl,
-	doc_list: ListCtrl,
-	open_button: Button,
-	locate_button: Button,
-	remove_button: Button,
-	clear_all_button: Button,
+	status_label: StaticText,
+	widgets: AllDocumentsWidgets,
 	ok_button: Button,
 }
 
 fn bind_all_documents_layout(dialog: Dialog, layout: AllDocumentsLayout) {
-	let AllDocumentsLayout {
-		search_label,
-		search_ctrl,
-		doc_list,
+	let AllDocumentsLayout { search_label, search_ctrl, status_label, widgets, ok_button } = layout;
+	let AllDocumentsWidgets {
+		list,
 		open_button,
 		locate_button,
 		remove_button,
 		clear_all_button,
-		ok_button,
-	} = layout;
+		status_choice,
+		status_bar,
+	} = widgets;
 	let dialog_for_ok = dialog;
 	ok_button.on_click(move |_| {
 		dialog_for_ok.end_modal(ID_OK);
@@ -438,9 +501,11 @@ fn bind_all_documents_layout(dialog: Dialog, layout: AllDocumentsLayout) {
 	let search_sizer = BoxSizer::builder(Orientation::Horizontal).build();
 	search_sizer.add(&search_label, 0, SizerFlag::AlignCenterVertical | SizerFlag::Right, DIALOG_PADDING);
 	search_sizer.add(&search_ctrl, 1, SizerFlag::AlignCenterVertical | SizerFlag::Right, DIALOG_PADDING / 2);
+	search_sizer.add(&status_label, 0, SizerFlag::AlignCenterVertical | SizerFlag::Right, DIALOG_PADDING);
+	search_sizer.add(&status_choice, 0, SizerFlag::AlignCenterVertical, 0);
 	content_sizer.add_sizer(&search_sizer, 0, SizerFlag::Expand | SizerFlag::All, DIALOG_PADDING);
-	content_sizer.add(&doc_list, 1, SizerFlag::Expand | SizerFlag::All, DIALOG_PADDING);
-	doc_list.set_focus();
+	content_sizer.add(&list, 1, SizerFlag::Expand | SizerFlag::All, DIALOG_PADDING);
+	list.set_focus();
 	let action_sizer = BoxSizer::builder(Orientation::Horizontal).build();
 	action_sizer.add(&open_button, 0, SizerFlag::Right, DIALOG_PADDING);
 	action_sizer.add(&locate_button, 0, SizerFlag::Right, DIALOG_PADDING);
@@ -456,39 +521,36 @@ fn bind_all_documents_layout(dialog: Dialog, layout: AllDocumentsLayout) {
 	ok_sizer.add_stretch_spacer(1);
 	ok_sizer.add(&ok_button, 0, SizerFlag::All, DIALOG_PADDING);
 	content_sizer.add_sizer(&ok_sizer, 0, SizerFlag::Expand, 0);
+	content_sizer.add(
+		&status_bar,
+		0,
+		SizerFlag::Expand | SizerFlag::Left | SizerFlag::Right | SizerFlag::Bottom,
+		DIALOG_PADDING,
+	);
 	dialog.set_sizer_and_fit(content_sizer, true);
 	dialog.centre();
 }
 
 struct DocumentListParams<'a> {
-	list: ListCtrl,
-	open_button: Button,
-	locate_button: Button,
-	remove_button: Button,
-	clear_all_button: Button,
+	widgets: AllDocumentsWidgets,
 	config: &'a Rc<Mutex<ConfigManager>>,
 	open_paths: &'a [String],
 	filter: &'a str,
+	status_filter: Option<DocumentListStatus>,
 	selection: Option<i32>,
+	status_debounce: &'a StatusBarDebounce,
 }
 
 fn populate_document_list(params: &DocumentListParams<'_>) {
-	let DocumentListParams {
-		list,
-		open_button,
-		locate_button,
-		remove_button,
-		clear_all_button,
-		config,
-		open_paths,
-		filter,
-		selection,
-	} = *params;
+	let DocumentListParams { widgets, config, open_paths, filter, status_filter, selection, status_debounce } = *params;
+	let AllDocumentsWidgets { list, open_button, locate_button, remove_button, clear_all_button, status_bar, .. } =
+		widgets;
+	status_debounce.suppress.set(true);
 	list.cleanup_all_custom_data();
 	list.delete_all_items();
 	let items = {
 		let cfg = config.lock().unwrap();
-		paperback_core::config::get_sorted_document_list(&cfg, open_paths, filter)
+		paperback_core::config::get_sorted_document_list(&cfg, open_paths, filter, status_filter)
 	};
 	for item in items {
 		let index = i64::from(list.get_item_count());
@@ -528,6 +590,48 @@ fn populate_document_list(params: &DocumentListParams<'_>) {
 		remove_button.enable(false);
 		clear_all_button.enable(false);
 	}
+	status_debounce.suppress.set(false);
+	update_document_status_bar(list, status_bar);
+}
+
+fn status_filter_from_choice(status_choice: Choice) -> Option<DocumentListStatus> {
+	match status_choice.get_selection().unwrap_or(0) {
+		1 => Some(DocumentListStatus::Open),
+		2 => Some(DocumentListStatus::Closed),
+		3 => Some(DocumentListStatus::Missing),
+		_ => None,
+	}
+}
+
+fn update_document_status_bar(list: ListCtrl, status_bar: StatusBar) {
+	let total = list.get_item_count();
+	let selected = get_selected_indices(list).len();
+	let formatted = format_document_status_text(total, selected);
+	status_bar.set_status_text(&formatted, 0);
+}
+
+fn format_document_status_text(total: i32, selected: usize) -> String {
+	if selected == 0 {
+		if total == 0 {
+			// TRANSLATORS: Status bar text in the All Documents dialog when the list is empty
+			t("No documents.")
+		} else if total == 1 {
+			// TRANSLATORS: Status bar text in the All Documents dialog when the list contains exactly one document and none are selected
+			t("1 document.")
+		} else {
+			// TRANSLATORS: Status bar text in the All Documents dialog showing the total number of documents in the list. The %d placeholder is replaced with the count.
+			t("%d documents.").replacen("%d", &total.to_string(), 1)
+		}
+	} else if total == 1 {
+		// TRANSLATORS: Status bar text in the All Documents dialog when the single document in the list is selected
+		t("1 of 1 document selected.")
+	} else if usize::try_from(total).is_ok_and(|total| total == selected) {
+		// TRANSLATORS: Status bar text in the All Documents dialog when every document in the list is selected. The %d placeholder is replaced with the total count.
+		t("All %d documents selected.").replacen("%d", &total.to_string(), 1)
+	} else {
+		// TRANSLATORS: Status bar text in the All Documents dialog showing how many of the total documents are selected. The first %d is the selected count, the second %d is the total count.
+		t("%d of %d documents selected.").replacen("%d", &selected.to_string(), 1).replacen("%d", &total.to_string(), 1)
+	}
 }
 
 fn update_open_button_for_index(list: ListCtrl, open_button: Button, index: i32) {
@@ -547,18 +651,14 @@ fn update_locate_button(list: ListCtrl, locate_button: Button) {
 
 fn bind_all_documents_locate(
 	dialog: Dialog,
-	list: ListCtrl,
+	widgets: AllDocumentsWidgets,
 	search_ctrl: TextCtrl,
-	open_button: Button,
-	locate_button: Button,
-	remove_button: Button,
-	clear_all_button: Button,
 	config: Rc<Mutex<ConfigManager>>,
 	open_paths: Rc<Vec<String>>,
-	locate_button_widget: Button,
+	status_debounce: StatusBarDebounce,
 ) {
-	locate_button_widget.on_click(move |_| {
-		let Some(old_path) = get_selected_path(list) else { return };
+	widgets.locate_button.on_click(move |_| {
+		let Some(old_path) = get_selected_path(widgets.list) else { return };
 		let filename = Path::new(&old_path).file_name().map(|n| n.to_string_lossy().into_owned()).unwrap_or_default();
 		let wildcard = build_file_filter_string();
 		let file_dialog = FileDialog::builder(&dialog)
@@ -578,17 +678,15 @@ fn bind_all_documents_locate(
 			cfg.flush();
 		}
 		let filter = search_ctrl.get_value();
-		let selected_index = get_selected_index(list);
+		let selected_index = get_selected_index(widgets.list);
 		populate_document_list(&DocumentListParams {
-			list,
-			open_button,
-			locate_button,
-			remove_button,
-			clear_all_button,
+			widgets,
 			config: &config,
 			open_paths: open_paths.as_ref(),
 			filter: &filter,
+			status_filter: status_filter_from_choice(widgets.status_choice),
 			selection: if selected_index >= 0 { Some(selected_index) } else { None },
+			status_debounce: &status_debounce,
 		});
 	});
 }

--- a/doc/readme.md
+++ b/doc/readme.md
@@ -196,8 +196,8 @@ Note: I consider a public GitHub sponsor grounds for automatic inclusion in this
 * Added a CLI tool, called pb, to quickly convert any of Paperback's supported formats to HTML, Markdown, or plain text.
 * Added a Configurable keyboard shortcut to Restore Paperback from the system tray.
 * Added a locate button to the all documents dialog to locate missing books that just changed their path.
-* Added the = key to read your current percentage through a book.
-* Added an option to move your text cursor to the start of the line when navigating, similar to browse mode in some screen readers.
+* Added a status filter and status bar to the all documents dialog, so you can filter by document status and see how many documents are shown and selected.
+* Added the `Ctrl+Shift+A` shortcut to deselect all documents in the all documents dialog.
 * Added a readability tab to the options dialog, with the following options:
     * Word wrap (moved from general);
     * Render tables inline (new in this release, see below);
@@ -209,7 +209,6 @@ Note: I consider a public GitHub sponsor grounds for automatic inclusion in this
     * Text alignment.
 * Added a toggle to determine how you want tables displayed, and unified how tables are displayed across documents.
 * added a View Source option to open a document's source in a new tab, useful for editing Markdown for example.
-* Added a word wrap menu item and subsequent hotkey.
 * Added estimated reading time to the word count dialog, as well as the ability to set your reading speed to make this metric actually useful.
 * Added ARM64 Windows support!
 * Added Android support!
@@ -218,10 +217,9 @@ Note: I consider a public GitHub sponsor grounds for automatic inclusion in this
 * Added new languages: Dutch, Finish, and Polish.
 * Added support for navigating by container.
 * Added support for lists, list items, figures, and images in CHM documents.
-* Added temperary bookmarks: press slash to set one, backslash to jump to it.
+* Added a word wrap menu item and subsequent hotkey.
 * Bookmark/note sounds should now properly play exclusively when you navigate over a word containing one.
 * Documents encoded in legacy CJK encodings, such as GBK, Big5, and Shift_JIS, will now render properly instead of as a bunch of mojibake.
-* Documents who's contents change on disk can now optionally be automagically reloaded with the new content.
 * Expanded the export menu item to allow exporting to HTML and Markdown in addition to plain text.
 * Fixed applying word wrap shooting you to the start of your document.
 * Fix daisy books showing incorrect  info in the status bar.
@@ -232,7 +230,7 @@ Note: I consider a public GitHub sponsor grounds for automatic inclusion in this
 * Fixed links in legacy mobi books.
 * Fixed loading DAISY books with bogus encoding declarations.
 * Fixed page navigation announcing incorrect line text in some situations.
-* Fixed parsing RTF documents with non-Latin characters and \uN? unicode escapes in them.
+* Fixed parsing RTF documents with non-Latin characters in them.
 * Fixed "Reopen last closed" attempting to reopen the bundled readme.
 * Fixed the title bar not updating after closing a document from the all documents dialog.
 * Fix the webview dialog not being resizable and popping up at a very small initial size.


### PR DESCRIPTION
## Summary

Adds a status filter dropdown, a status bar, and deselect all shortcut (`Ctrl+Shift+A`) to the "All Documents" dialog.

## Files changed

* `crates/paperback-core/src/config.rs`: Added a `status_filter` parameter to `get_sorted_document_list` so the list can be filtered by document status, plus a new test.
* `crates/paperback/src/ui/dialogs/all_documents.rs`: Added the status filter dropdown, a status bar with selection/total counts, and the `Ctrl+Shift+A` deselect all shortcut.
* `doc/readme.md`: Added changelog entries for the status filter/status bar and the deselect-all shortcut.
