### PR TITLE
Fix native macOS termination handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3656,7 +3656,7 @@ dependencies = [
 [[package]]
 name = "wxdragon"
 version = "0.9.18"
-source = "git+https://github.com/AllenDang/wxDragon?branch=main#70e7fcb1df395f6f944b4aab937e43d44afad49b"
+source = "git+https://github.com/AllenDang/wxDragon?branch=main#4ebcb7e723cfab49cac21e7e0bc687ff68cf06e2"
 dependencies = [
  "bitflags",
  "log",
@@ -3668,7 +3668,7 @@ dependencies = [
 [[package]]
 name = "wxdragon-macros"
 version = "0.9.18"
-source = "git+https://github.com/AllenDang/wxDragon?branch=main#70e7fcb1df395f6f944b4aab937e43d44afad49b"
+source = "git+https://github.com/AllenDang/wxDragon?branch=main#4ebcb7e723cfab49cac21e7e0bc687ff68cf06e2"
 dependencies = [
  "proc-macro2",
  "quick-xml",
@@ -3679,7 +3679,7 @@ dependencies = [
 [[package]]
 name = "wxdragon-sys"
 version = "0.9.18"
-source = "git+https://github.com/AllenDang/wxDragon?branch=main#70e7fcb1df395f6f944b4aab937e43d44afad49b"
+source = "git+https://github.com/AllenDang/wxDragon?branch=main#4ebcb7e723cfab49cac21e7e0bc687ff68cf06e2"
 dependencies = [
  "bindgen",
  "cmake",

--- a/crates/paperback/src/ui/app.rs
+++ b/crates/paperback/src/ui/app.rs
@@ -68,6 +68,11 @@ impl PaperbackApp {
 		let pipe_server = start_pipe_server(&Rc::clone(&main_window));
 		main_window.show();
 		#[cfg(target_os = "macos")]
+		_app.on_should_terminate(|| {
+			tracing::debug!("allowing native macOS termination request");
+			true
+		});
+		#[cfg(target_os = "macos")]
 		_app.on_reopen_app(|| {
 			if let Some(window) = main_window_from_ptr() {
 				window.show_from_dock();

--- a/crates/paperback/src/ui/main_window.rs
+++ b/crates/paperback/src/ui/main_window.rs
@@ -204,13 +204,13 @@ impl MainWindow {
 				}
 				dm.save_all_positions();
 				#[cfg(target_os = "macos")]
-				if let WindowEventData::General(ref ev) = event {
-					if ev.can_veto() {
-						drop(dm);
-						ev.veto();
-						frame.show(false);
-						return;
-					}
+				if let WindowEventData::General(ref ev) = event
+					&& ev.can_veto()
+				{
+					drop(dm);
+					ev.veto();
+					frame.show(false);
+					return;
 				}
 				#[cfg(target_os = "windows")]
 				if let Some(state) = tray_for_close.lock().unwrap().as_ref() {


### PR DESCRIPTION
## Summary

- update the locked wxDragon revision to one containing its macOS termination lifecycle hooks
- approve native macOS termination requests through `AppEvents::on_should_terminate`
- preserve the existing behavior where an ordinary red-button window close hides Paperback

## Root cause

wxWidgets checks whether a macOS application may terminate by sending a vetoable close event to its top window. Paperback treated every vetoable macOS close as an ordinary window close, vetoed it, and hid the frame. This also cancelled shutdown/restart and Quit requests sent from the Dock or Application Switcher.

Current wxDragon `main` exposes `OSXOnShouldTerminate` through `on_should_terminate`, allowing Paperback to distinguish application termination without relying on Cocoa internals.

## Validation

- `cargo +nightly fmt --check`
- `cargo build -p paperback`
- `cargo check -p paperback --locked`
- `cargo test -p paperback` (40 passed)
- native macOS Apple Event termination smoke test; callback ran and the process exited with status 0
