### PR TITLE
Use `gettext` plural forms for counted strings

### DIFF
--- a/crates/paperback/src/ui/dialogs/all_documents.rs
+++ b/crates/paperback/src/ui/dialogs/all_documents.rs
@@ -1,7 +1,7 @@
 use std::{cell::Cell, path::Path, rc::Rc, sync::Mutex};
 
 use paperback_core::{config::ConfigManager, parser::build_file_filter_string, types::DocumentListStatus};
-use patois::t;
+use patois::{nt, t};
 use wxdragon::{ffi, prelude::*, timer::Timer, window::FromWindowWithClassName};
 
 use super::DIALOG_PADDING;
@@ -676,22 +676,22 @@ fn format_document_status_text(total: i32, selected: usize) -> String {
 		if total == 0 {
 			// TRANSLATORS: Status bar text in the All Documents dialog when the list is empty
 			t("No documents.")
-		} else if total == 1 {
-			// TRANSLATORS: Status bar text in the All Documents dialog when the list contains exactly one document and none are selected
-			t("1 document.")
 		} else {
-			// TRANSLATORS: Status bar text in the All Documents dialog showing the total number of documents in the list. The %d placeholder is replaced with the count.
-			t("%d documents.").replacen("%d", &total.to_string(), 1)
+			// TRANSLATORS: Status bar text in the All Documents dialog showing the total number of documents in the list. The %d placeholder is replaced with the count. Plural form is chosen by that count.
+			nt("%d document.", "%d documents.", u64::try_from(total).unwrap_or(0)).replacen("%d", &total.to_string(), 1)
 		}
 	} else if total == 1 {
 		// TRANSLATORS: Status bar text in the All Documents dialog when the single document in the list is selected
 		t("1 of 1 document selected.")
 	} else if usize::try_from(total).is_ok_and(|total| total == selected) {
-		// TRANSLATORS: Status bar text in the All Documents dialog when every document in the list is selected. The %d placeholder is replaced with the total count.
-		t("All %d documents selected.").replacen("%d", &total.to_string(), 1)
+		// TRANSLATORS: Status bar text in the All Documents dialog when every document in the list is selected. The %d placeholder is replaced with the total count. Plural form is chosen by that count.
+		nt("All %d document selected.", "All %d documents selected.", u64::try_from(total).unwrap_or(0))
+			.replacen("%d", &total.to_string(), 1)
 	} else {
-		// TRANSLATORS: Status bar text in the All Documents dialog showing how many of the total documents are selected. The first %d is the selected count, the second %d is the total count.
-		t("%d of %d documents selected.").replacen("%d", &selected.to_string(), 1).replacen("%d", &total.to_string(), 1)
+		// TRANSLATORS: Status bar text in the All Documents dialog showing how many of the total documents are selected. The first %d is the selected count, the second %d is the total count. Plural form is chosen by the total count.
+		nt("%d of %d document selected.", "%d of %d documents selected.", u64::try_from(total).unwrap_or(0))
+			.replacen("%d", &selected.to_string(), 1)
+			.replacen("%d", &total.to_string(), 1)
 	}
 }
 

--- a/crates/paperback/src/ui/dialogs/all_documents.rs
+++ b/crates/paperback/src/ui/dialogs/all_documents.rs
@@ -685,8 +685,11 @@ fn format_document_status_text(total: i32, selected: usize) -> String {
 		t("1 of 1 document selected.")
 	} else if usize::try_from(total).is_ok_and(|total| total == selected) {
 		// TRANSLATORS: Status bar text in the All Documents dialog when every document in the list is selected. The %d placeholder is replaced with the total count. Plural form is chosen by that count.
-		nt("All %d document selected.", "All %d documents selected.", u64::try_from(total).unwrap_or(0))
-			.replacen("%d", &total.to_string(), 1)
+		nt("All %d document selected.", "All %d documents selected.", u64::try_from(total).unwrap_or(0)).replacen(
+			"%d",
+			&total.to_string(),
+			1,
+		)
 	} else {
 		// TRANSLATORS: Status bar text in the All Documents dialog showing how many of the total documents are selected. The first %d is the selected count, the second %d is the total count. Plural form is chosen by the total count.
 		nt("%d of %d document selected.", "%d of %d documents selected.", u64::try_from(total).unwrap_or(0))

--- a/crates/paperback/src/ui/dialogs/word_count.rs
+++ b/crates/paperback/src/ui/dialogs/word_count.rs
@@ -1,4 +1,4 @@
-use patois::t;
+use patois::{nt, t};
 use wxdragon::prelude::*;
 
 fn format_reading_time(word_count: usize, wpm: i32) -> String {
@@ -10,26 +10,17 @@ fn format_reading_time(word_count: usize, wpm: i32) -> String {
 	let minutes = (total_seconds % 3600) / 60;
 	let seconds = total_seconds % 60;
 	let mut parts: Vec<String> = Vec::new();
-	if hours == 1 {
-		// TRANSLATORS: Singular label for 1 hour duration
-		parts.push(t("1 hour"));
-	} else if hours > 1 {
-		// TRANSLATORS: Plural label for hours duration (e.g. "2 hours")
-		parts.push(format!("{} {}", hours, t("hours")));
+	if hours >= 1 {
+		// TRANSLATORS: Duration segment for hours in the estimated reading time (e.g. "1 hour" / "5 hours"). The %d placeholder is replaced with the count.
+		parts.push(nt("%d hour", "%d hours", hours).replacen("%d", &hours.to_string(), 1));
 	}
-	if minutes == 1 {
-		// TRANSLATORS: Singular label for 1 minute duration
-		parts.push(t("1 minute"));
-	} else if minutes > 1 {
-		// TRANSLATORS: Plural label for minutes duration (e.g. "2 minutes")
-		parts.push(format!("{} {}", minutes, t("minutes")));
+	if minutes >= 1 {
+		// TRANSLATORS: Duration segment for minutes in the estimated reading time (e.g. "1 minute" / "5 minutes"). The %d placeholder is replaced with the count.
+		parts.push(nt("%d minute", "%d minutes", minutes).replacen("%d", &minutes.to_string(), 1));
 	}
-	if seconds == 1 {
-		// TRANSLATORS: Singular label for 1 second duration
-		parts.push(t("1 second"));
-	} else if seconds > 1 || total_seconds == 0 {
-		// TRANSLATORS: Plural label for seconds duration (e.g. "2 seconds")
-		parts.push(format!("{} {}", seconds, t("seconds")));
+	if seconds >= 1 || total_seconds == 0 {
+		// TRANSLATORS: Duration segment for seconds in the estimated reading time (e.g. "1 second" / "5 seconds"). The %d placeholder is replaced with the count.
+		parts.push(nt("%d second", "%d seconds", seconds).replacen("%d", &seconds.to_string(), 1));
 	}
 	let time_str = parts.join(", ");
 	// TRANSLATORS: Prompt showing estimated reading time. The {} placeholder is replaced with a formatted duration like "1 hour, 5 minutes".
@@ -39,13 +30,13 @@ fn format_reading_time(word_count: usize, wpm: i32) -> String {
 
 pub fn show_word_count_dialog(parent: &Frame, word_count: usize, reading_speed_wpm: i32, is_selection: bool) {
 	let words_template = if is_selection {
-		// TRANSLATORS: Message template for selection word count. The {} placeholder is replaced with the number of words.
-		t("The selection contains {} words.")
+		// TRANSLATORS: Message template for selection word count. The %d placeholder is replaced with the number of words.
+		nt("The selection contains %d word.", "The selection contains %d words.", word_count as u64)
 	} else {
-		// TRANSLATORS: Message template for document word count. The {} placeholder is replaced with the number of words.
-		t("This document contains {} words.")
+		// TRANSLATORS: Message template for document word count. The %d placeholder is replaced with the number of words.
+		nt("This document contains %d word.", "This document contains %d words.", word_count as u64)
 	};
-	let mut msg = words_template.replace("{}", &word_count.to_string());
+	let mut msg = words_template.replacen("%d", &word_count.to_string(), 1);
 	let reading_time = format_reading_time(word_count, reading_speed_wpm);
 	if !reading_time.is_empty() {
 		msg.push('\n');

--- a/crates/paperback/src/ui/main_window.rs
+++ b/crates/paperback/src/ui/main_window.rs
@@ -18,7 +18,7 @@ use paperback_core::{
 	parser::{build_file_filter_string, parser_supports_extension},
 	types::BookmarkFilterType,
 };
-use patois::t;
+use patois::{nt, t};
 use wxdragon::{prelude::*, timer::Timer};
 
 #[cfg(target_os = "windows")]
@@ -466,9 +466,10 @@ impl MainWindow {
 			self.frame.set_title(&template.replace("{}", &display_title(tab)));
 			#[cfg(target_os = "macos")]
 			self.frame.set_represented_filename(&tab.file_path.to_string_lossy());
-			// TRANSLATORS: Status bar character count; {} is the number of characters
-			let chars_label = t("{} chars");
-			self.frame.set_status_text(&chars_label.replace("{}", &tab.session.content().len().to_string()), 0);
+			// TRANSLATORS: Status bar character count. The %d placeholder is replaced with the number of characters.
+			let char_count = tab.session.content().len();
+			let chars_label = nt("%d char", "%d chars", char_count as u64).replacen("%d", &char_count.to_string(), 1);
+			self.frame.set_status_text(&chars_label, 0);
 		}
 	}
 
@@ -1733,13 +1734,9 @@ impl MainWindow {
 						sleep_timer_duration_for_menu.set(duration);
 						SLEEP_TIMER_START_MS.store(now, Ordering::SeqCst);
 						SLEEP_TIMER_DURATION_MINUTES.store(duration, Ordering::SeqCst);
-						let msg = if duration == 1 {
-							// TRANSLATORS: Announcement when the sleep timer is set for exactly 1 minute
-							t("Sleep timer set for 1 minute.")
-						} else {
-							// TRANSLATORS: Announcement when the sleep timer is set; %d is the number of minutes (always 2 or more)
-							t("Sleep timer set for %d minutes.").replace("%d", &duration.to_string())
-						};
+						// TRANSLATORS: Announcement when the sleep timer is set. The %d placeholder is replaced with the number of minutes.
+						let msg = nt("Sleep timer set for %d minute.", "Sleep timer set for %d minutes.", u64::try_from(duration).unwrap_or(0))
+							.replacen("%d", &duration.to_string(), 1);
 						live_region::announce(live_region_label, &msg);
 					}
 				}

--- a/crates/paperback/src/ui/main_window.rs
+++ b/crates/paperback/src/ui/main_window.rs
@@ -1735,8 +1735,12 @@ impl MainWindow {
 						SLEEP_TIMER_START_MS.store(now, Ordering::SeqCst);
 						SLEEP_TIMER_DURATION_MINUTES.store(duration, Ordering::SeqCst);
 						// TRANSLATORS: Announcement when the sleep timer is set. The %d placeholder is replaced with the number of minutes.
-						let msg = nt("Sleep timer set for %d minute.", "Sleep timer set for %d minutes.", u64::try_from(duration).unwrap_or(0))
-							.replacen("%d", &duration.to_string(), 1);
+						let msg = nt(
+							"Sleep timer set for %d minute.",
+							"Sleep timer set for %d minutes.",
+							u64::try_from(duration).unwrap_or(0),
+						)
+						.replacen("%d", &duration.to_string(), 1);
 						live_region::announce(live_region_label, &msg);
 					}
 				}


### PR DESCRIPTION
Several status bar and dialog messages that include a count (document totals, sleep timer minutes, word and character counts, estimated reading time) hard-coded a single plural word or built the plural form by linking the number with plain text, which only works for English and breaks languages like Bosnian or Serbian that need three plural forms. This switches those messages to patois's existing `ngettext-style nt()` function.