### PR TITLE
Restore screen-reader focus to book text after Alt+Tab

### DIFF
--- a/crates/paperback/src/ui/main_window.rs
+++ b/crates/paperback/src/ui/main_window.rs
@@ -46,8 +46,6 @@ use hotkey::{HotkeyHandle, re_register_hotkey, start_hotkey_listener};
 /// The main window's starting size, in device-independent pixels (see `ui::dpi`).
 const DEFAULT_WINDOW_WIDTH: i32 = 800;
 const DEFAULT_WINDOW_HEIGHT: i32 = 600;
-/// Delay before restoring screen-reader focus after window activation (see `focus_restore_timer`).
-const FOCUS_RESTORE_DELAY_MS: i32 = 100;
 
 pub static SLEEP_TIMER_START_MS: AtomicI64 = AtomicI64::new(0);
 pub static SLEEP_TIMER_DURATION_MINUTES: AtomicI32 = AtomicI32::new(0);
@@ -126,28 +124,6 @@ impl MainWindow {
 		);
 		let frame_copy = frame;
 		let notebook = *doc_manager.lock().unwrap().notebook();
-		// One-shot timer that restores screen-reader focus after window activation. On Windows the
-		// read-only Richedit does not emit its own focus event when the window is re-activated, so
-		// screen readers keep announcing the frame ("pane") instead of the book text. Defer past
-		// Windows' own activation/focus processing, restore focus to the text control, then fire the
-		// MSAA focus event explicitly so screen readers re-sync. Owned by the notebook so its events
-		// don't cross-fire with the frame-owned sleep/status timers.
-		let focus_restore_timer = Rc::new(Timer::new(&notebook));
-		{
-			let dm_for_focus_timer = Rc::clone(&doc_manager);
-			focus_restore_timer.on_tick(move |_| {
-				let dm = dm_for_focus_timer.lock().unwrap();
-				dm.restore_focus();
-				#[cfg(target_os = "windows")]
-				if let Some(tab) = dm.active_tab() {
-					let hwnd = windows::Win32::Foundation::HWND(tab.text_ctrl.get_handle());
-					// EVENT_OBJECT_FOCUS = 0x8005, OBJID_CLIENT = -4, CHILDID_SELF = 0
-					unsafe {
-						windows::Win32::UI::Accessibility::NotifyWinEvent(0x8005, hwnd, -4, 0);
-					}
-				}
-			});
-		}
 		let dm = Rc::clone(&doc_manager);
 		notebook.on_page_changing(move |event| {
 			let Ok(dm_ref) = dm.try_lock() else {
@@ -185,15 +161,26 @@ impl MainWindow {
 		let dm_for_activate = Rc::clone(&doc_manager);
 		let activate_reload_guard = Rc::clone(&reload_guard);
 		let frame_for_activate = frame;
-		let focus_timer = Rc::clone(&focus_restore_timer);
 		frame.on_activate(move |event| {
 			event.skip(true);
 			if let WindowEventData::Activate(activate) = &event
 				&& activate.is_active()
 			{
-				// Defer focus restoration past Windows' own activation/focus processing so screen
-				// readers land back on the book text (see focus_restore_timer above).
-				focus_timer.start(FOCUS_RESTORE_DELAY_MS, true);
+				// On Windows the read-only Richedit does not emit its own focus event when the
+				// window is re-activated, so screen readers keep announcing the frame ("pane")
+				// instead of the book text. Restore focus to the text control and fire the MSAA
+				// focus event explicitly so screen readers re-sync.
+				#[cfg(target_os = "windows")]
+				if let Ok(dm) = dm_for_activate.try_lock() {
+					dm.restore_focus();
+					if let Some(tab) = dm.active_tab() {
+						let hwnd = windows::Win32::Foundation::HWND(tab.text_ctrl.get_handle());
+						// EVENT_OBJECT_FOCUS = 0x8005, OBJID_CLIENT = -4, CHILDID_SELF = 0
+						unsafe {
+							windows::Win32::UI::Accessibility::NotifyWinEvent(0x8005, hwnd, -4, 0);
+						}
+					}
+				}
 			}
 			if let WindowEventData::Activate(activate) = &event
 				&& activate.is_active()

--- a/crates/paperback/src/ui/main_window.rs
+++ b/crates/paperback/src/ui/main_window.rs
@@ -46,6 +46,8 @@ use hotkey::{HotkeyHandle, re_register_hotkey, start_hotkey_listener};
 /// The main window's starting size, in device-independent pixels (see `ui::dpi`).
 const DEFAULT_WINDOW_WIDTH: i32 = 800;
 const DEFAULT_WINDOW_HEIGHT: i32 = 600;
+/// Delay before restoring screen-reader focus after window activation (see `focus_restore_timer`).
+const FOCUS_RESTORE_DELAY_MS: i32 = 100;
 
 pub static SLEEP_TIMER_START_MS: AtomicI64 = AtomicI64::new(0);
 pub static SLEEP_TIMER_DURATION_MINUTES: AtomicI32 = AtomicI32::new(0);
@@ -124,6 +126,28 @@ impl MainWindow {
 		);
 		let frame_copy = frame;
 		let notebook = *doc_manager.lock().unwrap().notebook();
+		// One-shot timer that restores screen-reader focus after window activation. On Windows the
+		// read-only Richedit does not emit its own focus event when the window is re-activated, so
+		// screen readers keep announcing the frame ("pane") instead of the book text. Defer past
+		// Windows' own activation/focus processing, restore focus to the text control, then fire the
+		// MSAA focus event explicitly so screen readers re-sync. Owned by the notebook so its events
+		// don't cross-fire with the frame-owned sleep/status timers.
+		let focus_restore_timer = Rc::new(Timer::new(&notebook));
+		{
+			let dm_for_focus_timer = Rc::clone(&doc_manager);
+			focus_restore_timer.on_tick(move |_| {
+				let dm = dm_for_focus_timer.lock().unwrap();
+				dm.restore_focus();
+				#[cfg(target_os = "windows")]
+				if let Some(tab) = dm.active_tab() {
+					let hwnd = windows::Win32::Foundation::HWND(tab.text_ctrl.get_handle());
+					// EVENT_OBJECT_FOCUS = 0x8005, OBJID_CLIENT = -4, CHILDID_SELF = 0
+					unsafe {
+						windows::Win32::UI::Accessibility::NotifyWinEvent(0x8005, hwnd, -4, 0);
+					}
+				}
+			});
+		}
 		let dm = Rc::clone(&doc_manager);
 		notebook.on_page_changing(move |event| {
 			let Ok(dm_ref) = dm.try_lock() else {
@@ -161,8 +185,16 @@ impl MainWindow {
 		let dm_for_activate = Rc::clone(&doc_manager);
 		let activate_reload_guard = Rc::clone(&reload_guard);
 		let frame_for_activate = frame;
+		let focus_timer = Rc::clone(&focus_restore_timer);
 		frame.on_activate(move |event| {
 			event.skip(true);
+			if let WindowEventData::Activate(activate) = &event
+				&& activate.is_active()
+			{
+				// Defer focus restoration past Windows' own activation/focus processing so screen
+				// readers land back on the book text (see focus_restore_timer above).
+				focus_timer.start(FOCUS_RESTORE_DELAY_MS, true);
+			}
 			if let WindowEventData::Activate(activate) = &event
 				&& activate.is_active()
 				&& !activate_reload_guard.get()


### PR DESCRIPTION
## Summary

Fixes the screen reader losing focus on the book text after Alt+Tabbing back into Paperback (issue #438): NVDA would lose the fact that we were in an edit box, and would not announce any text until tabbing around Paperback's interface back to the edit box.

## Root cause

On Windows, the read-only Richedit doesn't emit its own focus event when the window is re-activated, so NVDA never learns focus moved back into the text control and keeps announcing the frame. A previous attempt (commit `6f471d1`) called `set_focus()` deferred past activation, but a focus call alone doesn't surface an accessibility event — and the later auto-reload PR (#628) removed even that call.

## The fix

On window activation:
1. Restore focus to the active tab's text control
2. Fire `NotifyWinEvent(EVENT_OBJECT_FOCUS, …)` on the control's HWND, explicitly telling screen readers where focus is

(An earlier draft deferred this with a one-shot timer, but testing showed no deferral is needed — Windows' own focus processing doesn't fight the explicit focus event.)

Validated in a minimal reproduction app (a bare read-only Richedit window, same control style as the reader): before the fix, focus was lost on every Alt+Tab; after, it's reliably restored.

## Testing

- `cargo +nightly fmt --check`, `cargo clippy --workspace --all-targets --release`, and the release build all pass.
- Manually tested with NVDA on Windows: repeated Alt+Tab into a book consistently lands on the text.
- I can only test on Windows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
