### PR TITLE
Extract translatable strings from dependencies too

### DIFF
--- a/.github/workflows/auto-translate.yml
+++ b/.github/workflows/auto-translate.yml
@@ -5,6 +5,10 @@ on:
       - master
     paths:
       - 'crates/**/*.rs'
+      # Dependencies tagged translatable (ship-shape, wx-utils) contribute strings to
+      # paperback.pot too, so a version bump can add strings without touching any .rs
+      # file here. The lockfile moves for both a manifest bump and a plain cargo update.
+      - 'Cargo.lock'
       - 'android/app/src/main/kotlin/**/*.kt'
       - 'ios/Paperback/**/*.swift'
       - 'po/**/*.po'

--- a/crates/paperback/src/translation_manager.rs
+++ b/crates/paperback/src/translation_manager.rs
@@ -91,6 +91,26 @@ mod tests {
 		assert!(!manager.is_language_available("xx"));
 	}
 
+	/// The updater's dialogs (including their "&Yes"/"&No" buttons) live in the `ship-shape`
+	/// dependency rather than in this crate, and reach this app's catalog through
+	/// `patois::t` and the default domain. That path has broken twice: once when the app and
+	/// the dependency linked separate copies of patois, so the dependency saw no default
+	/// domain at all, and once when pot generation only scanned `crates/`, leaving every
+	/// dependency-owned string out of the catalog. Both look identical to a user: an
+	/// otherwise translated dialog with English buttons (issue #285).
+	#[test]
+	fn dependency_owned_strings_translate_through_the_app_catalog() {
+		patois::set_default_domain("paperback");
+		patois::set_locale("fr");
+		// "&Yes"/"&No" are also used by this crate's own confirmation dialog; "Downloading
+		// update..." exists only in ship-shape, so it fails if dependency strings stop being
+		// extracted into the pot even while the app's own strings keep working.
+		for msgid in ["&Yes", "&No", "Downloading update..."] {
+			assert_ne!(patois::t(msgid), msgid, "{msgid} is missing from the French catalog");
+		}
+		patois::set_locale("en");
+	}
+
 	/// Confirms `patois::embed_wx_translations!()` (invoked in `main.rs`) actually embedded
 	/// real wxstd catalogs restricted to paperback's own shipped languages, without needing
 	/// a visible window — mirrors the `wxdragon`/`patois` upstream headless test pattern.

--- a/crates/xtask/src/main.rs
+++ b/crates/xtask/src/main.rs
@@ -58,7 +58,7 @@ fn gen_pot() -> Result<(), Box<dyn Error>> {
 	// runs on past them as "unterminated" literals, sometimes splicing unrelated strings
 	// together. Feed it sanitized copies of the source instead of the real files so those
 	// constructs can't confuse it; see sanitize_rust for why comments/strings stay untouched.
-	let translatable_dirs = translatable_crate_src_dirs(&root);
+	let translatable_dirs = translatable_crate_src_dirs(&root)?;
 	if translatable_dirs.is_empty() {
 		return Err("no translatable crates found — check [package.metadata.patois] translatable = true".into());
 	}
@@ -88,29 +88,40 @@ fn gen_pot() -> Result<(), Box<dyn Error>> {
 	Ok(())
 }
 
-/// Find `src/` directories of every crate under `crates/` tagged
-/// `[package.metadata.patois] translatable = true`.
-fn translatable_crate_src_dirs(root: &Path) -> Vec<PathBuf> {
-	let crates_dir = root.join("crates");
+/// Find the `src/` directory of every package in the build graph tagged
+/// `[package.metadata.patois] translatable = true`: Paperback's own crates plus
+/// dependencies like ship-shape and wx-utils, whose strings show up in Paperback's own
+/// dialogs and therefore have to live in Paperback's catalog. Scanning only `crates/`
+/// silently left every dependency string out of the pot, so anything a dependency added
+/// after it was vendored in stayed untranslated no matter what the po files said.
+fn translatable_crate_src_dirs(root: &Path) -> Result<Vec<PathBuf>, Box<dyn Error>> {
+	let cargo = env::var("CARGO").unwrap_or_else(|_| "cargo".to_string());
+	let output = Command::new(&cargo).args(["metadata", "--format-version", "1"]).current_dir(root).output()?;
+	if !output.status.success() {
+		return Err("cargo metadata failed".into());
+	}
+	let meta: serde_json::Value = serde_json::from_slice(&output.stdout)?;
+	let mut packages: Vec<&serde_json::Value> =
+		meta["packages"].as_array().ok_or("cargo metadata: missing packages")?.iter().collect();
+	// Order by name and version rather than by manifest path: a dependency's manifest lives
+	// under CARGO_HOME, whose absolute spelling differs per machine (`.cargo` vs `scoop`, say)
+	// and sorts differently from the workspace paths, which would reorder xgettext's input and
+	// churn the pot for whoever regenerates it next.
+	packages.sort_by_key(|pkg| {
+		(pkg["name"].as_str().unwrap_or_default().to_string(), pkg["version"].as_str().unwrap_or_default().to_string())
+	});
 	let mut dirs = Vec::new();
-	let Ok(entries) = fs::read_dir(&crates_dir) else {
-		return dirs;
-	};
-	for entry in entries.flatten() {
-		let path = entry.path();
-		if !path.is_dir() {
+	for pkg in packages {
+		if pkg["metadata"]["patois"]["translatable"] != true {
 			continue;
 		}
-		let manifest = path.join("Cargo.toml");
-		let Ok(content) = fs::read_to_string(&manifest) else {
-			continue;
-		};
-		if content.contains("[package.metadata.patois]") && content.contains("translatable = true") {
-			dirs.push(path.join("src"));
+		let manifest = pkg["manifest_path"].as_str().ok_or("cargo metadata: missing manifest_path")?;
+		let src = Path::new(manifest).parent().unwrap().join("src");
+		if src.is_dir() {
+			dirs.push(src);
 		}
 	}
-	dirs.sort();
-	dirs
+	Ok(dirs)
 }
 
 /// Resolve `package_name`'s version via `cargo metadata`, which correctly follows

--- a/po/paperback.pot
+++ b/po/paperback.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: paperback 0.9.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-28 23:02+0000\n"
+"POT-Creation-Date: 2026-08-29 03:56-0600\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -2310,6 +2310,65 @@ msgstr ""
 msgid "Password incorrect"
 msgstr ""
 
+msgid "Unknown update file format."
+msgstr ""
+
+msgid "Failed to open disk image"
+msgstr ""
+
+msgid "The update has been downloaded and its disk image opened. Quit %s and drag the new version into Applications to finish installing."
+msgstr ""
+
+msgid "Update Ready"
+msgstr ""
+
+msgid "Failed to get current exe path"
+msgstr ""
+
+msgid "Failed to launch installer script"
+msgstr ""
+
+msgid "Failed to launch update script"
+msgstr ""
+
+msgid "Update failed"
+msgstr ""
+
+msgid ""
+"Update downloaded to: %s\n"
+"Please install it manually."
+msgstr ""
+
+msgid "Update to %s"
+msgstr ""
+
+msgid "A new version of %s is available. Here's what's new:"
+msgstr ""
+
+msgid "No release notes provided."
+msgstr ""
+
+msgid "%s Update"
+msgstr ""
+
+msgid "Downloading update..."
+msgstr ""
+
+msgid "No updates available."
+msgstr ""
+
+msgid "No updates available. Latest version: %s"
+msgstr ""
+
+msgid "Info"
+msgstr ""
+
+msgid "Security verification failed. The update might have been tampered with: %s"
+msgstr ""
+
+msgid "Security Error"
+msgstr ""
+
 msgid "&Options"
 msgstr ""
 
@@ -2350,57 +2409,6 @@ msgid "Sleep timer set for 1 minute."
 msgstr ""
 
 msgid "Sleep timer set for %d minutes."
-msgstr ""
-
-msgid "Update to %s"
-msgstr ""
-
-msgid "A new version of %s is available. Here's what's new:"
-msgstr ""
-
-msgid "No release notes provided."
-msgstr ""
-
-msgid "%s Update"
-msgstr ""
-
-msgid "Downloading update..."
-msgstr ""
-
-msgid "No updates available."
-msgstr ""
-
-msgid "No updates available. Latest version: %s"
-msgstr ""
-
-msgid "Info"
-msgstr ""
-
-msgid "Security verification failed. The update might have been tampered with: %s"
-msgstr ""
-
-msgid "Security Error"
-msgstr ""
-
-msgid "Update failed"
-msgstr ""
-
-msgid "Update downloaded to: %s\nPlease install it manually."
-msgstr ""
-
-msgid "Update Ready"
-msgstr ""
-
-msgid "Failed to get current exe path"
-msgstr ""
-
-msgid "Failed to launch installer script"
-msgstr ""
-
-msgid "Failed to launch update script"
-msgstr ""
-
-msgid "Unknown update file format."
 msgstr ""
 
 msgid "Previous Section\t["


### PR DESCRIPTION
Closes #285.

The Yes/No wiring itself is fine — the update dialog lives in the `ship-shape` dependency and translates through patois' default domain, which has worked since 8ed69792 unified the app and the dependency onto a single patois instance (before that they linked separate copies, so `t()` inside ship-shape saw no default domain and returned raw English — that's the version the last report on the issue was testing).

What was still broken is extraction. `cargo xtask gen-pot`'s `translatable_crate_src_dirs` only scanned `crates/*` for `[package.metadata.patois] translatable = true`, so no dependency string was ever fed to xgettext. The updater strings only survived in `po/*.po` as leftovers from when the updater code still lived in this repo, and the two macOS install strings ship-shape 0.2 added in 1bcf32e8 never reached the pot, a translator, or the DeepL job.

- `translatable_crate_src_dirs` now walks `cargo metadata` over the whole build graph and picks every package tagged translatable (`ship-shape`, `wx-utils`), sorted by name and version rather than manifest path — a dependency's manifest lives under CARGO_HOME, whose spelling differs per machine and would otherwise reorder xgettext's input and churn the pot.
- Regenerated `po/paperback.pot`. The msgid diff is exactly +2/-0 ("Failed to open disk image" and the "…drag the new version into Applications…" string); no test strings leaked in from the dependency, and a second run is byte-identical.
- Regression test asserting `&Yes`, `&No` and `Downloading update...` (ship-shape-only) all translate under `fr` through the app catalog. Verified it fails on a string that isn't in the catalog, so it isn't vacuous.
- Added `Cargo.lock` to the auto-translate triggers: a dependency bump that adds strings touches no `.rs` file here, so the DeepL job would never have run for it.

The two new msgids are still blank in the po files — the auto-translate job fires on this diff and will msgmerge and fill the machine-maintained locales. The human-maintained ones (bs, cs, de, fi, ja, pl, sr) are skipped by that job by design, so those two macOS strings need translators either way.

`cargo test -p paperback --bin paperback` 68 passed, `-p xtask` 24 passed, fmt clean, no new clippy warnings.