### PR TITLE
Preserve the focus target when restoring focus after Alt+Tab

### DIFF
--- a/crates/paperback/src/ui/document_manager.rs
+++ b/crates/paperback/src/ui/document_manager.rs
@@ -477,11 +477,7 @@ impl DocumentManager {
 	/// selected tab on its own (firing a whole-control event here would swallow that).
 	#[cfg(target_os = "windows")]
 	pub fn focus_target_handle(&self) -> Option<*mut std::ffi::c_void> {
-		if self.last_focus_in_text.get() {
-			self.active_tab().map(|tab| tab.text_ctrl.get_handle())
-		} else {
-			None
-		}
+		if self.last_focus_in_text.get() { self.active_tab().map(|tab| tab.text_ctrl.get_handle()) } else { None }
 	}
 
 	pub fn pop_recently_closed(&mut self) -> Option<PathBuf> {

--- a/crates/paperback/src/ui/document_manager.rs
+++ b/crates/paperback/src/ui/document_manager.rs
@@ -88,6 +88,7 @@ pub struct DocumentManager {
 	last_sound_position: Cell<Option<i64>>,
 	last_audio_seek_position: Cell<Option<i64>>,
 	preferred_column: Cell<Option<i64>>,
+	last_focus_in_text: Cell<bool>,
 	recently_closed: Vec<PathBuf>,
 }
 
@@ -108,6 +109,7 @@ impl DocumentManager {
 			last_sound_position: Cell::new(None),
 			last_audio_seek_position: Cell::new(None),
 			preferred_column: Cell::new(None),
+			last_focus_in_text: Cell::new(true),
 			recently_closed: Vec::new(),
 		}
 	}
@@ -443,11 +445,42 @@ impl DocumentManager {
 		self.tabs.iter().position(|tab| normalized_path_key(&tab.file_path) == target)
 	}
 
+	/// Restores focus to whichever control had it when the window was last active (the text
+	/// control or the notebook), falling back to the notebook when there's no active document.
 	pub fn restore_focus(&self) {
-		if let Some(tab) = self.active_tab() {
-			tab.text_ctrl.set_focus();
+		if self.last_focus_in_text.get() {
+			if let Some(tab) = self.active_tab() {
+				tab.text_ctrl.set_focus();
+			} else {
+				self.notebook.set_focus();
+			}
 		} else {
 			self.notebook.set_focus();
+		}
+	}
+
+	/// Records whether the text control or the notebook currently has focus, so focus can be
+	/// restored to the same place when the window is next activated. Only updates when one of
+	/// the two is confidently focused (a mid-focus-transition leaves the previous value).
+	pub fn record_focus_target(&self) {
+		if self.active_tab().is_some_and(|tab| tab.text_ctrl.has_focus()) {
+			self.last_focus_in_text.set(true);
+		} else if self.notebook.has_focus() {
+			self.last_focus_in_text.set(false);
+		}
+	}
+
+	/// Returns the native handle to fire an accessibility focus event on after `restore_focus`,
+	/// or `None` when the control emits its own focus event and no manual event is needed. On
+	/// Windows the read-only Richedit does not emit its own focus event on re-activation, so the
+	/// text control needs the explicit event; the notebook's native tab control announces its
+	/// selected tab on its own (firing a whole-control event here would swallow that).
+	#[cfg(target_os = "windows")]
+	pub fn focus_target_handle(&self) -> Option<*mut std::ffi::c_void> {
+		if self.last_focus_in_text.get() {
+			self.active_tab().map(|tab| tab.text_ctrl.get_handle())
+		} else {
+			None
 		}
 	}
 

--- a/crates/paperback/src/ui/main_window.rs
+++ b/crates/paperback/src/ui/main_window.rs
@@ -162,22 +162,30 @@ impl MainWindow {
 		let frame_for_activate = frame;
 		frame.on_activate(move |event| {
 			event.skip(true);
-			if let WindowEventData::Activate(activate) = &event
-				&& activate.is_active()
-			{
-				// On Windows the read-only Richedit does not emit its own focus event when the
-				// window is re-activated, so screen readers keep announcing the frame ("pane")
-				// instead of the book text. Restore focus to the text control and fire the MSAA
-				// focus event explicitly so screen readers re-sync.
-				#[cfg(target_os = "windows")]
-				if let Ok(dm) = dm_for_activate.try_lock() {
-					dm.restore_focus();
-					if let Some(tab) = dm.active_tab() {
-						let hwnd = windows::Win32::Foundation::HWND(tab.text_ctrl.get_handle());
-						// EVENT_OBJECT_FOCUS = 0x8005, OBJID_CLIENT = -4, CHILDID_SELF = 0
-						unsafe {
-							windows::Win32::UI::Accessibility::NotifyWinEvent(0x8005, hwnd, -4, 0);
+			if let WindowEventData::Activate(activate) = &event {
+				if activate.is_active() {
+					// On Windows the read-only Richedit does not emit its own focus event when the
+					// window is re-activated, so screen readers keep announcing the frame ("pane")
+					// instead of the book text. Restore focus to whichever control had it before we
+					// left (text control or tab strip) and fire the MSAA focus event explicitly so
+					// screen readers re-sync.
+					#[cfg(target_os = "windows")]
+					if let Ok(dm) = dm_for_activate.try_lock() {
+						dm.restore_focus();
+						if let Some(hwnd) = dm.focus_target_handle() {
+							let hwnd = windows::Win32::Foundation::HWND(hwnd);
+							// EVENT_OBJECT_FOCUS = 0x8005, OBJID_CLIENT = -4, CHILDID_SELF = 0
+							unsafe {
+								windows::Win32::UI::Accessibility::NotifyWinEvent(0x8005, hwnd, -4, 0);
+							}
 						}
+					}
+				} else {
+					// Deactivating: remember where focus was so we restore the same control (text
+					// control or tab strip) on the way back, rather than always forcing the text.
+					#[cfg(target_os = "windows")]
+					if let Ok(dm) = dm_for_activate.try_lock() {
+						dm.record_focus_target();
 					}
 				}
 			}


### PR DESCRIPTION
## Summary

Refines the Alt+Tab focus fix (#704) so it preserves where focus was when the window was deactivated, instead of always forcing it back into the book text. If you had the tab strip focused before Alt+Tabbing away, you now return to the tab strip (and NVDA announces the tab); if you were reading, you return to the text.

## Why

The previous fix always called `restore_focus()`, which targets the text control. So if a user had focused the open-files tab strip, Alt+Tabbing back yanked focus into the text. This preserves the user's actual focus location.

I think this new behavior is what we want.

## How

- On deactivation, `DocumentManager::record_focus_target()` records whether the text control or the tab had focus.
- On re-activation, `restore_focus()` returns focus to that same control.
- The `NotifyWinEvent(EVENT_OBJECT_FOCUS)` accessibility event is fired only on the text control — it's the one that needs it (the read-only Richedit doesn't emit its own focus event). The tab control announces its selected tab natively, so firing a whole-control event there actually suppressed that announcement (now avoided).

## Testing

- `cargo +nightly fmt --check`, `cargo clippy --workspace --all-targets --release`, and the release build all pass.
- Manually tested with NVDA on Windows: Alt+Tab back with the text focused lands in the text; with the tab strip focused, lands on the tabs and announces the tab.
- I can only test on Windows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
