### PR TITLE
fix(ui): fix broken MacOS build

### DIFF
--- a/crates/paperback/src/ui/dialogs.rs
+++ b/crates/paperback/src/ui/dialogs.rs
@@ -45,6 +45,8 @@ pub use toc::show_toc_dialog;
 mod view_note;
 pub use view_note::show_view_note_dialog;
 mod web_view;
-pub use web_view::{ACTIVE_WEB_VIEW, show_web_view_dialog};
+#[cfg(any(target_os = "linux", target_os = "windows"))]
+pub use web_view::ACTIVE_WEB_VIEW;
+pub use web_view::show_web_view_dialog;
 mod word_count;
 pub use word_count::show_word_count_dialog;

--- a/crates/paperback/src/ui/dialogs/options.rs
+++ b/crates/paperback/src/ui/dialogs/options.rs
@@ -7,6 +7,7 @@ use std::{
 
 use paperback_core::config::{ConfigManager, HotkeyConfig, ReadabilityFont, ShortcutsConfig};
 use patois::{t, ui::populate_language_choice};
+#[cfg(not(target_os = "macos"))]
 use wx_utils::dpi;
 #[cfg(target_os = "windows")]
 use wxdragon::accessible::AccRole;

--- a/crates/paperback/src/ui/main_window.rs
+++ b/crates/paperback/src/ui/main_window.rs
@@ -1,5 +1,3 @@
-#[cfg(target_os = "windows")]
-use std::cell::RefCell;
 use std::{
 	cell::Cell,
 	path::Path,
@@ -7,17 +5,20 @@ use std::{
 	rc::Rc,
 	sync::{
 		Mutex,
-		atomic::{AtomicI32, AtomicI64, AtomicIsize, Ordering},
+		atomic::{AtomicI32, AtomicI64, Ordering},
 	},
 	time::{SystemTime, UNIX_EPOCH},
 };
+#[cfg(target_os = "windows")]
+use std::{cell::RefCell, sync::atomic::AtomicIsize};
 
 use paperback_core::{config::ConfigManager, parser::build_file_filter_string, types::BookmarkFilterType};
 use patois::{nt, t};
-#[cfg(target_os = "windows")]
 use wx_utils::dpi;
 use wxdragon::{prelude::*, timer::Timer};
 
+#[cfg(target_os = "windows")]
+use super::tray;
 use super::{
 	dialogs,
 	document_manager::{DocumentManager, DocumentTab, build_font_from_readability, display_title},
@@ -25,7 +26,7 @@ use super::{
 	help::{self, MAIN_WINDOW_PTR},
 	icon, menu, menu_ids,
 	navigation::{self, MarkerNavTarget},
-	status, tray,
+	status,
 };
 use crate::config_ext::{UpdateChannel, get_update_channel};
 #[cfg(any(target_os = "linux", target_os = "windows"))]

--- a/crates/paperback/src/ui/main_window/menu_tools.rs
+++ b/crates/paperback/src/ui/main_window/menu_tools.rs
@@ -2,8 +2,10 @@
 //! source view, the Options dialog (and applying whatever changed), shortcut customization,
 //! sleep timer, and document import/export.
 
+#[cfg(target_os = "windows")]
+use std::cell::RefCell;
 use std::{
-	cell::{Cell, RefCell},
+	cell::Cell,
 	env,
 	path::Path,
 	rc::Rc,


### PR DESCRIPTION
The DPI refactor broke builds on MacOS due to incorrect gating of conditional imports.

Keep wx-utils DPI available wherever the main window is built, while gating Windows-only tray and type imports. Gate other platform-specific re-exports and imports so the macOS target compiles without unused-import warnings.