### PR TITLE
Add Windows OCR for image-only PDF pages (per-page and batch)

### DIFF
--- a/crates/paperback-core/src/config/manager/document_state.rs
+++ b/crates/paperback-core/src/config/manager/document_state.rs
@@ -177,6 +177,12 @@ impl ConfigManager {
 	}
 }
 
+/// [`ReplaceOutcome::shift`] over the `i64` offsets the config stores.
+fn shift(outcome: &ReplaceOutcome, position: i64) -> i64 {
+	let shifted = outcome.shift(usize::try_from(position.max(0)).unwrap_or(0));
+	i64::try_from(shifted).unwrap_or(position)
+}
+
 #[cfg(test)]
 mod tests {
 	use super::*;
@@ -218,10 +224,4 @@ mod tests {
 		config.set_document_audio_time(path, None);
 		assert_eq!(config.get_document_audio_time(path), Some(5_000));
 	}
-}
-
-/// [`ReplaceOutcome::shift`] over the `i64` offsets the config stores.
-fn shift(outcome: &ReplaceOutcome, position: i64) -> i64 {
-	let shifted = outcome.shift(usize::try_from(position.max(0)).unwrap_or(0));
-	i64::try_from(shifted).unwrap_or(position)
 }

--- a/crates/paperback-core/src/config/manager/document_state.rs
+++ b/crates/paperback-core/src/config/manager/document_state.rs
@@ -2,9 +2,40 @@
 //! navigation history, and the detected format/password used to reopen it.
 
 use super::ConfigManager;
-use crate::config::settings::NavigationHistory;
+use crate::{config::settings::NavigationHistory, document::ReplaceOutcome};
 
 impl ConfigManager {
+	/// Remaps every stored position for `path` through `outcome`, after the document buffer was
+	/// edited in place. Covers the reading position, the navigation history, the temporary
+	/// bookmark, and every bookmark range.
+	///
+	/// Without this, editing the buffer silently drifts all of them: they are document-absolute
+	/// display offsets, so inserting OCR text on page 40 moves everything after it. OCR is the
+	/// only thing that mutates a parsed document today, and it goes through here.
+	pub fn shift_document_positions(&self, path: &str, outcome: &ReplaceOutcome) {
+		if !self.initialized || outcome.is_empty() {
+			return;
+		}
+		{
+			let key = self.get_doc_key(path);
+			let mut data = self.data.borrow_mut();
+			let doc = Self::doc_entry_mut(&mut data, key, path);
+			doc.last_position = shift(outcome, doc.last_position);
+			for position in &mut doc.navigation_history {
+				*position = shift(outcome, *position);
+			}
+			if let Some(position) = doc.temporary_bookmark.as_mut() {
+				*position = shift(outcome, *position);
+			}
+			for bookmark in &mut doc.bookmarks {
+				bookmark.start = shift(outcome, bookmark.start);
+				bookmark.end = shift(outcome, bookmark.end);
+			}
+			doc.bookmarks.sort_by_key(|bookmark| bookmark.start);
+		}
+		self.dirty.set(true);
+	}
+
 	pub fn set_document_position(&self, path: &str, position: i64) {
 		if !self.initialized {
 			return;
@@ -187,4 +218,10 @@ mod tests {
 		config.set_document_audio_time(path, None);
 		assert_eq!(config.get_document_audio_time(path), Some(5_000));
 	}
+}
+
+/// [`ReplaceOutcome::shift`] over the `i64` offsets the config stores.
+fn shift(outcome: &ReplaceOutcome, position: i64) -> i64 {
+	let shifted = outcome.shift(usize::try_from(position.max(0)).unwrap_or(0));
+	i64::try_from(shifted).unwrap_or(position)
 }

--- a/crates/paperback-core/src/config/shortcuts/action_id.rs
+++ b/crates/paperback-core/src/config/shortcuts/action_id.rs
@@ -83,6 +83,7 @@ pub enum ActionId {
 	ToggleFullScreen,
 	Options,
 	SleepTimer,
+	BatchOcr,
 	CustomizeShortcuts,
 	ImportDocumentData,
 	ExportDocumentData,
@@ -176,6 +177,7 @@ impl ActionId {
 			Self::ToggleFullScreen,
 			Self::Options,
 			Self::SleepTimer,
+			Self::BatchOcr,
 			Self::CustomizeShortcuts,
 			Self::ImportDocumentData,
 			Self::ExportDocumentData,
@@ -269,6 +271,7 @@ impl ActionId {
 			| Self::ToggleFullScreen
 			| Self::Options
 			| Self::SleepTimer
+			| Self::BatchOcr
 			| Self::CustomizeShortcuts
 			| Self::ImportDocumentData
 			| Self::ExportDocumentData
@@ -438,6 +441,8 @@ impl ActionId {
 			// TRANSLATORS: Name of this keyboard-shortcut action, shown in the Customize Keyboard Shortcuts dialog (its list of assignable actions, and the "Set Shortcut for {}" / conflict-reassignment prompts).
 			Self::SleepTimer => crate::t("Sleep Timer..."),
 			// TRANSLATORS: Name of this keyboard-shortcut action, shown in the Customize Keyboard Shortcuts dialog (its list of assignable actions, and the "Set Shortcut for {}" / conflict-reassignment prompts).
+			Self::BatchOcr => crate::t("Batch OCR..."),
+			// TRANSLATORS: Name of this keyboard-shortcut action, shown in the Customize Keyboard Shortcuts dialog (its list of assignable actions, and the "Set Shortcut for {}" / conflict-reassignment prompts).
 			Self::CustomizeShortcuts => crate::t("Customize Keyboard Shortcuts..."),
 			// TRANSLATORS: Name of this keyboard-shortcut action, shown in the Customize Keyboard Shortcuts dialog (its list of assignable actions, and the "Set Shortcut for {}" / conflict-reassignment prompts).
 			Self::ImportDocumentData => crate::t("Import Document Data..."),
@@ -546,6 +551,7 @@ impl ActionId {
 			}
 			Self::Options => Some(KeyChord::new(true, false, false, ",")),
 			Self::SleepTimer => Some(KeyChord::new(true, false, true, "S")),
+			Self::BatchOcr => Some(KeyChord::new(true, false, true, "O")),
 			Self::CustomizeShortcuts => None,
 			Self::ImportDocumentData => Some(KeyChord::new(true, false, true, "I")),
 			Self::ExportDocumentData => Some(KeyChord::new(true, false, true, "E")),
@@ -637,6 +643,7 @@ impl ActionId {
 			Self::ToggleFullScreen => Some(KeyChord::new(false, false, false, "F11")),
 			Self::Options => Some(KeyChord::new(true, false, false, ",")),
 			Self::SleepTimer => Some(KeyChord::new(true, false, true, "S")),
+			Self::BatchOcr => Some(KeyChord::new(true, false, true, "O")),
 			Self::CustomizeShortcuts => None,
 			Self::ImportDocumentData => Some(KeyChord::new(true, false, true, "I")),
 			Self::ExportDocumentData => Some(KeyChord::new(true, false, true, "E")),

--- a/crates/paperback-core/src/document.rs
+++ b/crates/paperback-core/src/document.rs
@@ -12,7 +12,7 @@ mod marker;
 mod stats;
 mod toc;
 
-pub use buffer::{DocumentBuffer, PartSpan};
+pub use buffer::{DocumentBuffer, Edit, PartSpan, ReplaceOutcome};
 pub use handle::DocumentHandle;
 pub(crate) use marker::format_marker_types;
 pub use marker::{ContainerSpan, Marker, MarkerType, is_container_marker, is_heading_marker};

--- a/crates/paperback-core/src/document/buffer.rs
+++ b/crates/paperback-core/src/document/buffer.rs
@@ -5,7 +5,7 @@
 
 use rayon::prelude::*;
 
-use super::marker::Marker;
+use super::marker::{Marker, MarkerType};
 use crate::util::text::{ch_width, display_len};
 
 #[derive(Debug, Clone)]
@@ -125,12 +125,29 @@ impl DocumentBuffer {
 
 	#[must_use]
 	pub fn with_content(content: String) -> Self {
+		let mut buffer = Self {
+			content,
+			markers: Vec::new(),
+			content_display_len: 0,
+			content_char_count: 0,
+			newline_char_positions: Vec::new(),
+			char_to_byte_map: Vec::new(),
+			display_len_at_char: Vec::new(),
+		};
+		buffer.rebuild_indexes();
+		buffer
+	}
+
+	/// Rebuilds every per-char index table from `self.content`, which is the single source of
+	/// truth for all of them. Called by [`Self::with_content`] and after any in-place content
+	/// mutation (currently only [`Self::replace_ranges`]).
+	fn rebuild_indexes(&mut self) {
 		let mut char_count = 0usize;
 		let mut display_count = 0usize;
 		let mut newline_char_positions = Vec::new();
-		let mut char_to_byte_map = Vec::with_capacity(content.len().min(1024));
-		let mut display_len_at_char = Vec::with_capacity(content.len().min(1024));
-		for (byte_idx, c) in content.char_indices() {
+		let mut char_to_byte_map = Vec::with_capacity(self.content.len().min(1024));
+		let mut display_len_at_char = Vec::with_capacity(self.content.len().min(1024));
+		for (byte_idx, c) in self.content.char_indices() {
 			char_to_byte_map.push(to_u32(byte_idx));
 			display_len_at_char.push(to_u32(display_count));
 			if c == '\n' {
@@ -139,18 +156,66 @@ impl DocumentBuffer {
 			char_count += 1;
 			display_count += ch_width(c);
 		}
-		char_to_byte_map.push(to_u32(content.len())); // append end boundary
+		char_to_byte_map.push(to_u32(self.content.len())); // append end boundary
 		display_len_at_char.push(to_u32(display_count));
-		debug_assert_eq!(display_count, display_len(&content));
-		Self {
-			content,
-			markers: Vec::new(),
-			content_display_len: display_count,
-			content_char_count: char_count,
-			newline_char_positions,
-			char_to_byte_map,
-			display_len_at_char,
+		debug_assert_eq!(display_count, display_len(&self.content));
+		self.content_display_len = display_count;
+		self.content_char_count = char_count;
+		self.newline_char_positions = newline_char_positions;
+		self.char_to_byte_map = char_to_byte_map;
+		self.display_len_at_char = display_len_at_char;
+	}
+
+	/// Replaces the text spanning `start..end` (display units) with `replacement`, in place.
+	/// A convenience wrapper over [`Self::replace_ranges`] for the single-edit case; see there
+	/// for the marker rules. Returns the delta (`new_len - old_len`) in display units.
+	pub fn replace_range(&mut self, start: usize, end: usize, replacement: &str) -> i64 {
+		self.replace_ranges(vec![Edit { start, end, text: replacement.to_string() }]).total_delta
+	}
+
+	/// Applies several replacements in one pass and rebuilds the per-char index tables **once**.
+	///
+	/// Rebuilding is linear in the whole document, so applying edits one at a time is quadratic in
+	/// the number of edits. Batch OCR of a long scan produces one edit per page, which is exactly
+	/// the case that made this necessary.
+	///
+	/// `edits` may arrive in any order but must not overlap; they are sorted here and applied back
+	/// to front so earlier byte offsets stay valid. Every `start`/`end` must land on a char
+	/// boundary (callers derive such offsets from [`Self::display_index_for_char`]).
+	///
+	/// Marker rules, applied against the pre-edit positions: a marker strictly inside a replaced
+	/// span is dropped, as is a [`MarkerType::ImageOnlyPage`] marker sitting exactly at a span's
+	/// start (the placeholder it tags is precisely what the edit consumes). Every other marker
+	/// survives and shifts by the total delta of the edits that end at or before it, so a page
+	/// break at the start of a replaced line keeps its position.
+	#[allow(clippy::cast_possible_wrap, clippy::cast_sign_loss)]
+	pub fn replace_ranges(&mut self, mut edits: Vec<Edit>) -> ReplaceOutcome {
+		edits.sort_by_key(|edit| edit.start);
+		debug_assert!(
+			edits.windows(2).all(|pair| pair[0].end <= pair[1].start),
+			"replace_ranges requires non-overlapping edits"
+		);
+		let mut deltas = Vec::with_capacity(edits.len());
+		for edit in &edits {
+			deltas.push(display_len(&edit.text) as i64 - (edit.end - edit.start) as i64);
 		}
+		for edit in edits.iter().rev() {
+			let start_byte = self.byte_index_for_display(edit.start);
+			let end_byte = self.byte_index_for_display(edit.end);
+			self.content.replace_range(start_byte..end_byte, &edit.text);
+		}
+		self.rebuild_indexes();
+		self.markers.retain_mut(|marker| shift_marker(marker, &edits, &deltas));
+		let total_delta = deltas.iter().sum();
+		// Running sums of the deltas, so callers can map a pre-edit position to its post-edit one
+		// the same way the markers were mapped.
+		let mut shifts = Vec::with_capacity(edits.len());
+		let mut running = 0i64;
+		for (edit, delta) in edits.iter().zip(&deltas) {
+			running += delta;
+			shifts.push((edit.end, running));
+		}
+		ReplaceOutcome { total_delta, shifts }
 	}
 
 	pub fn add_marker(&mut self, marker: Marker) {
@@ -379,11 +444,70 @@ impl Default for DocumentBuffer {
 	}
 }
 
+/// One replacement for [`DocumentBuffer::replace_ranges`]: the display-unit span `start..end`
+/// and the text that takes its place.
+#[derive(Debug, Clone)]
+pub struct Edit {
+	pub start: usize,
+	pub end: usize,
+	pub text: String,
+}
+
+/// What [`DocumentBuffer::replace_ranges`] changed: the net display-unit growth, plus the
+/// running shift after each edit so positions stored outside the buffer can be remapped.
+#[derive(Debug, Clone)]
+pub struct ReplaceOutcome {
+	pub total_delta: i64,
+	shifts: Vec<(usize, i64)>,
+}
+
+impl ReplaceOutcome {
+	/// Maps a pre-edit display position to its post-edit one. Positions inside a replaced span
+	/// have no exact answer; they collapse to the shifted end of that span.
+	#[must_use]
+	#[allow(clippy::cast_possible_wrap, clippy::cast_sign_loss)]
+	pub fn shift(&self, position: usize) -> usize {
+		let applied = self.shifts.partition_point(|(end, _)| *end <= position);
+		if applied == 0 {
+			return position;
+		}
+		(position as i64 + self.shifts[applied - 1].1).max(0) as usize
+	}
+
+	#[must_use]
+	pub fn is_empty(&self) -> bool {
+		self.shifts.is_empty()
+	}
+}
+
+/// Repositions `marker` for a batch of edits, or reports that it should be dropped. See the
+/// marker rules on [`DocumentBuffer::replace_ranges`].
+#[allow(clippy::cast_possible_wrap, clippy::cast_sign_loss)]
+fn shift_marker(marker: &mut Marker, edits: &[Edit], deltas: &[i64]) -> bool {
+	let mut shift = 0i64;
+	for (edit, delta) in edits.iter().zip(deltas) {
+		if edit.end <= marker.position {
+			shift += delta;
+			continue;
+		}
+		if marker.position > edit.start {
+			return false; // strictly inside the replaced span
+		}
+		if marker.position == edit.start && marker.mtype == MarkerType::ImageOnlyPage {
+			return false; // the placeholder this marker tags is what the edit consumes
+		}
+		break; // edits are sorted, so nothing later can affect this marker
+	}
+	marker.position = (marker.position as i64 + shift).max(0) as usize;
+	true
+}
+
 #[cfg(test)]
 mod tests {
 	use rstest::rstest;
 
 	use super::*;
+	use crate::document::marker::{Marker, MarkerType};
 
 	#[test]
 	fn document_buffer_append_updates_position() {
@@ -513,5 +637,129 @@ mod tests {
 			assert_eq!(naive.start, parallel.start, "part {i} start");
 			assert_eq!(naive.end, parallel.end, "part {i} end");
 		}
+	}
+
+	#[test]
+	fn replace_range_matches_sequential_build_and_shifts_markers() {
+		let mut buffer = DocumentBuffer::with_content("aaa\nbbb\nccc".to_string());
+		// Marker at the start of the "bbb" line (display 4) and of the "ccc" line (display 8),
+		// plus one strictly inside the span being replaced (display 5, should be dropped).
+		buffer.add_marker(Marker::new(MarkerType::Heading1, 4));
+		buffer.add_marker(Marker::new(MarkerType::Heading2, 5));
+		buffer.add_marker(Marker::new(MarkerType::Heading1, 8));
+		let delta = buffer.replace_range(4, 7, "XY");
+		assert_eq!(delta, -1); // 2 display units replacing 3
+		let expected = DocumentBuffer::with_content("aaa\nXY\nccc".to_string());
+		assert_buffers_equivalent(&buffer, &expected);
+		assert_eq!(buffer.content, "aaa\nXY\nccc");
+		// The "bbb"-start marker (== start) is kept; the inside marker is dropped; the "ccc"
+		// marker shifted from 8 to 7.
+		let positions: Vec<usize> = buffer.markers.iter().map(|m| m.position).collect();
+		assert_eq!(positions, vec![4, 7]);
+	}
+
+	#[test]
+	fn replace_range_can_insert_and_grow() {
+		let mut buffer = DocumentBuffer::with_content("aaa\nccc".to_string());
+		buffer.add_marker(Marker::new(MarkerType::PageBreak, 4));
+		let delta = buffer.replace_range(4, 4, "bbb\n"); // insert at start of the "ccc" line
+		assert_eq!(delta, 4); // "bbb\n" is 4 display units
+		let expected = DocumentBuffer::with_content("aaa\nbbb\nccc".to_string());
+		assert_buffers_equivalent(&buffer, &expected);
+		// The marker at 4 shifts forward by the inserted length.
+		assert_eq!(buffer.markers[0].position, 8);
+	}
+
+	#[cfg(any(windows, target_os = "macos"))]
+	#[test]
+	fn replace_range_preserves_surrogate_pair_display_units() {
+		// "a" then an astral emoji (1 char but 2 display units) before the replaced span, so the
+		// display/char conversion must stay correct through the mutation.
+		let mut buffer = DocumentBuffer::with_content("a\u{1F600}b\nXYZ\nc".to_string());
+		// display offsets: a=0, emoji=1..2, b=3, \n=4, X=5, Y=6, Z=7, \n=8, c=9 (len 10).
+		buffer.add_marker(Marker::new(MarkerType::PageBreak, 5));
+		buffer.add_marker(Marker::new(MarkerType::PageBreak, 9));
+		let delta = buffer.replace_range(5, 8, "Q");
+		assert_eq!(delta, -2);
+		let expected = DocumentBuffer::with_content("a\u{1F600}b\nQ\nc".to_string());
+		assert_buffers_equivalent(&buffer, &expected);
+		// The marker at 5 (== start) stays; the marker at 9 shifts by -2 to 7.
+		let positions: Vec<usize> = buffer.markers.iter().map(|m| m.position).collect();
+		assert_eq!(positions, vec![5, 7]);
+		assert_eq!(buffer.total_display_len(), 8);
+		assert_eq!(buffer.byte_index_for_display(5), 7);
+	}
+	#[test]
+	fn replace_ranges_applies_every_edit_in_one_pass() {
+		let mut buffer = DocumentBuffer::with_content(
+			"aaa
+bbb
+ccc
+ddd"
+			.to_string(),
+		);
+		// Replace the "bbb" line (4..7) and the "ddd" line (12..15) in one call.
+		buffer.add_marker(Marker::new(MarkerType::PageBreak, 4));
+		buffer.add_marker(Marker::new(MarkerType::PageBreak, 8));
+		buffer.add_marker(Marker::new(MarkerType::PageBreak, 12));
+		let outcome = buffer.replace_ranges(vec![
+			Edit { start: 12, end: 15, text: "WXYZ".to_string() },
+			Edit { start: 4, end: 7, text: "B".to_string() },
+		]);
+		assert_eq!(
+			buffer.content,
+			"aaa
+B
+ccc
+WXYZ"
+		);
+		let expected = DocumentBuffer::with_content(
+			"aaa
+B
+ccc
+WXYZ"
+				.to_string(),
+		);
+		assert_buffers_equivalent(&buffer, &expected);
+		assert_eq!(outcome.total_delta, -1); // -2 for the shrinking edit, +1 for the growing one
+		// The markers at each edit's start survive; the one after the first edit shifts by -2.
+		let positions: Vec<usize> = buffer.markers.iter().map(|m| m.position).collect();
+		assert_eq!(positions, vec![4, 6, 10]);
+	}
+
+	#[test]
+	fn replace_ranges_shifts_positions_the_way_it_shifts_markers() {
+		let mut buffer = DocumentBuffer::with_content(
+			"aaa
+bbb
+ccc
+ddd"
+			.to_string(),
+		);
+		let outcome = buffer.replace_ranges(vec![
+			Edit { start: 4, end: 7, text: "B".to_string() },
+			Edit { start: 12, end: 15, text: "WXYZ".to_string() },
+		]);
+		assert_eq!(outcome.shift(0), 0); // before every edit
+		assert_eq!(outcome.shift(8), 6); // after the first edit only
+		assert_eq!(outcome.shift(15), 14); // after both: the old end of a document that shrank by one
+	}
+
+	#[test]
+	fn replace_ranges_drops_the_image_only_marker_it_consumes() {
+		let mut buffer = DocumentBuffer::with_content(
+			"aaa
+bbb
+ccc"
+			.to_string(),
+		);
+		// A page break and an image-only marker share the placeholder line's start. The page
+		// break has to survive OCR; the image-only marker is exactly what OCR consumes.
+		buffer.add_marker(Marker::new(MarkerType::PageBreak, 4));
+		buffer.add_marker(Marker::new(MarkerType::ImageOnlyPage, 4));
+		buffer.replace_ranges(vec![Edit { start: 4, end: 7, text: "recognized".to_string() }]);
+		let kinds: Vec<MarkerType> = buffer.markers.iter().map(|m| m.mtype).collect();
+		assert_eq!(kinds, vec![MarkerType::PageBreak]);
+		assert_eq!(buffer.markers[0].position, 4);
 	}
 }

--- a/crates/paperback-core/src/document/handle.rs
+++ b/crates/paperback-core/src/document/handle.rs
@@ -6,6 +6,7 @@
 
 use super::{
 	Document,
+	buffer::{Edit, ReplaceOutcome},
 	marker::{ContainerSpan, Marker, MarkerType, is_container_marker, is_heading_marker},
 	toc::TocItem,
 };
@@ -26,6 +27,29 @@ impl DocumentHandle {
 	#[must_use]
 	pub const fn document(&self) -> &Document {
 		&self.doc
+	}
+
+	/// Replaces the text spanning `start..end` (display units) with `replacement`, keeping the
+	/// document's external position maps in sync. See [`Self::replace_ranges`], which this wraps.
+	pub fn replace_range(&mut self, start: usize, end: usize, replacement: &str) -> i64 {
+		self.replace_ranges(vec![Edit { start, end, text: replacement.to_string() }]).total_delta
+	}
+
+	/// Applies a batch of replacements to the buffer and keeps the document's external position
+	/// maps in sync: [`Document::id_positions`] shift the same way the buffer's markers do, and
+	/// markers are re-sorted once at the end to preserve the ordering invariant `new` establishes.
+	/// Returns the outcome so callers (the UI's sliding text window, the config's stored
+	/// positions) can remap positions of their own.
+	pub fn replace_ranges(&mut self, edits: Vec<Edit>) -> ReplaceOutcome {
+		let outcome = self.doc.buffer.replace_ranges(edits);
+		if outcome.is_empty() {
+			return outcome;
+		}
+		for position in self.doc.id_positions.values_mut() {
+			*position = outcome.shift(*position);
+		}
+		self.doc.buffer.markers.sort_by_key(|m| m.position);
+		outcome
 	}
 
 	fn markers_by_type(&self, marker_type: MarkerType) -> impl Iterator<Item = (usize, &Marker)> {

--- a/crates/paperback-core/src/document/marker.rs
+++ b/crates/paperback-core/src/document/marker.rs
@@ -25,6 +25,10 @@ pub enum MarkerType {
 	Bold = 16,
 	Italic = 17,
 	Underline = 18,
+	/// A PDF page that holds an image but no extractable text. Sits at the start of the page's
+	/// OCR placeholder line and is what the OCR flow matches on, so the feature never depends on
+	/// comparing against a translated string.
+	ImageOnlyPage = 19,
 }
 
 impl From<MarkerType> for i32 {
@@ -66,6 +70,7 @@ impl TryFrom<i32> for MarkerType {
 			16 => Ok(Self::Bold),
 			17 => Ok(Self::Italic),
 			18 => Ok(Self::Underline),
+			19 => Ok(Self::ImageOnlyPage),
 			_ => Err(()),
 		}
 	}
@@ -146,11 +151,11 @@ mod tests {
 
 	#[test]
 	fn marker_type_round_trip_for_all_known_values() {
-		for raw in 0..=18 {
+		for raw in 0..=19 {
 			let marker = MarkerType::try_from(raw).unwrap();
 			assert_eq!(i32::from(marker), raw);
 		}
-		assert!(MarkerType::try_from(19).is_err());
+		assert!(MarkerType::try_from(20).is_err());
 		assert!(MarkerType::try_from(-1).is_err());
 	}
 

--- a/crates/paperback-core/src/lib.rs
+++ b/crates/paperback-core/src/lib.rs
@@ -3,6 +3,7 @@ pub mod config;
 pub mod document;
 pub mod export;
 pub mod ffi_config;
+pub mod ocr;
 pub mod parser;
 pub mod reader_core;
 pub mod session;

--- a/crates/paperback-core/src/ocr.rs
+++ b/crates/paperback-core/src/ocr.rs
@@ -1,0 +1,127 @@
+//! Page rendering for OCR of image-only PDF pages.
+//!
+//! The PDF parser tags every page that has an image but no extractable text with a
+//! [`MarkerType::ImageOnlyPage`](crate::document::MarkerType::ImageOnlyPage) marker and an
+//! [`image_only_placeholder`] line. At runtime the desktop app renders those pages to RGBA
+//! bitmaps through [`PageRenderer`] and hands the pixels to the platform OCR engine
+//! (`Windows.Media.Ocr`, or Vision on macOS), which lives in the desktop crate so this one
+//! stays platform-neutral. The recognized text then replaces the placeholder in the buffer.
+
+use anyhow::Result;
+use pdfium::{PdfiumDocument, PdfiumRenderConfig};
+
+use crate::t;
+
+/// The placeholder line the PDF parser inserts for a page that has an image but no extractable
+/// text. Purely what the reader sees: the OCR flow locates these pages by their
+/// `ImageOnlyPage` marker, so this string is free to be translated and to change.
+///
+/// Written as literal [`t`] calls rather than a translated constant because the pot is built by
+/// `xgettext`, which only sees string literals; `t(SOME_CONST)` extracts nothing and the message
+/// silently stays untranslated in every language.
+///
+/// Builds with no OCR engine say less, because there is nothing for Enter to do there. The
+/// marker is emitted either way, so only the wording changes.
+#[must_use]
+pub fn image_only_placeholder() -> String {
+	#[cfg(any(target_os = "windows", target_os = "macos"))]
+	{
+		// TRANSLATORS: Line shown in place of a scanned PDF page with no text layer; Enter on it runs OCR
+		t("[Image only. Press enter to OCR.]")
+	}
+	#[cfg(not(any(target_os = "windows", target_os = "macos")))]
+	{
+		// TRANSLATORS: Line shown in place of a scanned PDF page with no text layer, where the system has no OCR engine
+		t("[Image only. This page has no text to read.]")
+	}
+}
+
+/// Dots per inch to render at. OCR engines want 200 to 300 DPI; below that, small type starts
+/// dropping characters. PDF user units are points (1/72 inch), which is what the ratio below
+/// converts from.
+const TARGET_DPI: f32 = 300.0;
+const POINTS_PER_INCH: f32 = 72.0;
+
+/// Fallback pixel width for a page whose reported size is unusable (zero or negative).
+const FALLBACK_WIDTH: i32 = 1800;
+
+/// An RGBA8 page render ready to hand to a platform OCR engine.
+#[derive(Debug)]
+pub struct RenderedPage {
+	pub width: u32,
+	pub height: u32,
+	pub rgba: Vec<u8>,
+}
+
+/// A PDF held open for repeated page rendering.
+///
+/// Batch OCR renders many pages from one file, so the document is opened once here rather than
+/// per page. Not `Send`: pdfium's handles are tied to the thread that made them, so a renderer
+/// is created and used on the same thread. That thread need not be the UI thread, because every
+/// call into pdfium takes the library's own global lock.
+pub struct PageRenderer {
+	document: PdfiumDocument,
+}
+
+impl PageRenderer {
+	/// Opens `file_path` for rendering.
+	///
+	/// # Errors
+	///
+	/// Returns an error if pdfium cannot open the file, including a wrong or missing password.
+	pub fn open(file_path: &str, password: Option<&str>) -> Result<Self> {
+		Ok(Self { document: PdfiumDocument::new_from_path(file_path, password)? })
+	}
+
+	/// Renders page `page_index` (0-based) to an RGBA8 bitmap at [`TARGET_DPI`], scaled down to
+	/// keep its longest side within `max_dimension` (engines silently downscale larger inputs
+	/// themselves, and doing it here keeps the buffer smaller).
+	///
+	/// # Errors
+	///
+	/// Returns an error if the page is out of range or pdfium fails to rasterize it.
+	pub fn render(&self, page_index: i32, max_dimension: u32) -> Result<RenderedPage> {
+		let page = self.document.page(page_index)?;
+		let width = pixel_width(page.width(), page.height(), max_dimension);
+		let bitmap = page.render(&PdfiumRenderConfig::new().with_width(width))?;
+		let (width, height) = (bitmap.width(), bitmap.height());
+		let rgba = bitmap.as_rgba_bytes()?;
+		Ok(RenderedPage { width: u32::try_from(width).unwrap_or(0), height: u32::try_from(height).unwrap_or(0), rgba })
+	}
+}
+
+/// The pixel width to rasterize a page of `width_pt` by `height_pt` at [`TARGET_DPI`], reduced
+/// so neither side exceeds `max_dimension`.
+#[allow(clippy::cast_possible_truncation, clippy::cast_precision_loss, clippy::cast_sign_loss)]
+fn pixel_width(width_pt: f32, height_pt: f32, max_dimension: u32) -> i32 {
+	if width_pt <= 0.0 || height_pt <= 0.0 {
+		return FALLBACK_WIDTH;
+	}
+	let scale = TARGET_DPI / POINTS_PER_INCH;
+	let longest = width_pt.max(height_pt) * scale;
+	let capped = if longest > max_dimension as f32 { max_dimension as f32 / longest } else { 1.0 };
+	((width_pt * scale * capped).round() as i32).max(1)
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn pixel_width_renders_letter_at_target_dpi() {
+		// 8.5 by 11 inches in points, comfortably inside the cap.
+		assert_eq!(pixel_width(612.0, 792.0, 4000), 2550);
+	}
+
+	#[test]
+	fn pixel_width_scales_down_to_the_cap() {
+		// The same page at a 2600 px cap: the 11 inch side is the one that binds.
+		assert_eq!(pixel_width(612.0, 792.0, 2600), 2009);
+	}
+
+	#[test]
+	fn pixel_width_falls_back_for_an_unusable_page_size() {
+		assert_eq!(pixel_width(0.0, 792.0, 2600), FALLBACK_WIDTH);
+		assert_eq!(pixel_width(612.0, -1.0, 2600), FALLBACK_WIDTH);
+	}
+}

--- a/crates/paperback-core/src/paperback.udl
+++ b/crates/paperback-core/src/paperback.udl
@@ -17,7 +17,7 @@ enum MarkerType {
 	"Heading1", "Heading2", "Heading3", "Heading4", "Heading5", "Heading6",
 	"PageBreak", "SectionBreak", "TocItem", "Link",
 	"List", "ListItem", "Table", "Separator", "Image", "Figure",
-	"Bold", "Italic", "Underline"
+	"Bold", "Italic", "Underline", "ImageOnlyPage"
 };
 
 dictionary LineMarker {

--- a/crates/paperback-core/src/parser/pdf.rs
+++ b/crates/paperback-core/src/parser/pdf.rs
@@ -7,7 +7,6 @@ use crate::{
 	document::{Document, DocumentBuffer, Marker, MarkerType, ParserContext, TocItem},
 	ocr::image_only_placeholder,
 	parser::{Parser, util::path::extract_title_from_path},
-	t,
 };
 
 mod links;

--- a/crates/paperback-core/src/parser/pdf.rs
+++ b/crates/paperback-core/src/parser/pdf.rs
@@ -5,6 +5,7 @@ use pdfium::{PdfiumDocument, lib};
 
 use crate::{
 	document::{Document, DocumentBuffer, Marker, MarkerType, ParserContext, TocItem},
+	ocr::image_only_placeholder,
 	parser::{Parser, util::path::extract_title_from_path},
 	t,
 };
@@ -95,29 +96,35 @@ impl Parser for PdfParser {
 					page_display_text.push('\n');
 				}
 			}
-			// Check for image objects on this page
-			if !has_any_images {
-				let obj_count = lib().FPDFPage_CountObjects(&page);
-				for i in 0..obj_count {
-					if let Ok(obj) = lib().FPDFPage_GetObject(&page, i)
-						&& lib().FPDFPageObj_GetType(&obj) == pdfium::pdfium_constants::FPDF_PAGEOBJ_IMAGE
-					{
-						has_any_images = true;
-						break;
-					}
+			// Check for image objects on this page. This runs per page (rather than stopping at
+			// the first image anywhere) so an image-only page can still get its OCR placeholder
+			// when earlier pages contributed text.
+			let mut page_has_image = false;
+			let obj_count = lib().FPDFPage_CountObjects(&page);
+			for i in 0..obj_count {
+				if let Ok(obj) = lib().FPDFPage_GetObject(&page, i)
+					&& lib().FPDFPageObj_GetType(&obj) == pdfium::pdfium_constants::FPDF_PAGEOBJ_IMAGE
+				{
+					page_has_image = true;
+					break;
 				}
+			}
+			if page_has_image {
+				has_any_images = true;
+			}
+			// A page with an image but no extractable text gets a placeholder the user can OCR
+			// from (Enter on it replaces it with the recognized text). The marker, not the text, is
+			// what the OCR flow matches on, so changing the UI language cannot strand a placeholder.
+			let page_has_text = buffer.current_position() > page_start_offset;
+			if !page_has_text && page_has_image {
+				let placeholder_position = buffer.current_position();
+				buffer.add_marker(Marker::new(MarkerType::ImageOnlyPage, placeholder_position));
+				buffer.append(&image_only_placeholder());
+				buffer.append("\n");
 			}
 			extract_web_links(&text_page, page_start_offset, &page_display_text, &mut buffer);
 			extract_annotation_links(&page, &text_page, &document, page_start_offset, &page_display_text, &mut buffer);
 			page_lines_info.push(current_lines_info);
-		}
-		if !has_any_text && has_any_images {
-			tracing::warn!(path = %context.file_path, "pdf has images but no extractable text, likely needs ocr");
-			let marker_position = buffer.current_position();
-			buffer.add_marker(Marker::new(MarkerType::PageBreak, marker_position).with_text(String::new()));
-			// TRANSLATORS: Notice inserted into the extracted text when a PDF has images but no text layer at all
-			buffer.append(&t("This PDF contains images only, with no extractable text. You may need to run it through OCR software to read its contents."));
-			buffer.append("\n");
 		}
 		let title = metadata_value(&document, "Title").unwrap_or_else(|| extract_title_from_path(&context.file_path));
 		let author = metadata_value(&document, "Author").unwrap_or_default();

--- a/crates/paperback-core/src/session.rs
+++ b/crates/paperback-core/src/session.rs
@@ -1,6 +1,6 @@
 use crate::{
 	audio::AudioTimeline,
-	document::{self, DocumentHandle, MarkerType, ParserContext, ParserFlags},
+	document::{self, DocumentHandle, Edit, MarkerType, ParserContext, ParserFlags, ReplaceOutcome},
 	parser,
 	reader_core::record_history_position,
 	types::{self as ffi},
@@ -306,6 +306,72 @@ impl DocumentSession {
 	#[must_use]
 	pub const fn handle(&self) -> &DocumentHandle {
 		&self.handle
+	}
+
+	/// Replaces the text spanning `start..end` (display units) with `text`, keeping the buffer
+	/// indexes, markers, and `id_positions` in sync. Returns the display-unit length delta so the
+	/// caller can adjust its sliding window. Used by the OCR flow to swap an image-only
+	/// placeholder line for recognized text.
+	pub fn replace_range(&mut self, start: i64, end: i64, text: &str) -> i64 {
+		let start = usize::try_from(start.max(0)).unwrap_or(0);
+		let end = usize::try_from(end.max(0)).unwrap_or(0);
+		self.handle.replace_range(start, end, text)
+	}
+
+	/// Every page still awaiting OCR, as `(1-based page number, placeholder offset)` pairs in
+	/// document order. Driven by the `ImageOnlyPage` markers the PDF parser leaves behind, which
+	/// [`Self::replace_image_only_pages`] removes as it consumes them, so a page already
+	/// recognized in this session never appears here twice.
+	#[must_use]
+	pub fn image_only_pages(&self) -> Vec<(i32, i64)> {
+		self.handle
+			.document()
+			.buffer
+			.markers
+			.iter()
+			.filter(|marker| marker.mtype == MarkerType::ImageOnlyPage)
+			.map(|marker| {
+				let offset = i64::try_from(marker.position).unwrap_or(0);
+				(self.current_page(offset), offset)
+			})
+			.collect()
+	}
+
+	/// The offset of the OCR placeholder on the line containing `position`, if that line is one.
+	/// This is what Enter keys off, so pressing it anywhere on the placeholder line works.
+	#[must_use]
+	pub fn image_only_page_at(&self, position: i64) -> Option<i64> {
+		let (start, end) = self.line_bounds_at(position)?;
+		self.handle
+			.document()
+			.buffer
+			.markers
+			.iter()
+			.find(|marker| {
+				marker.mtype == MarkerType::ImageOnlyPage
+					&& i64::try_from(marker.position).is_ok_and(|p| p >= start && p <= end)
+			})
+			.map(|marker| i64::try_from(marker.position).unwrap_or(start))
+	}
+
+	/// Swaps each `(placeholder offset, recognized text)` pair for the whole placeholder line,
+	/// in one pass. Offsets must be ones [`Self::image_only_pages`] or
+	/// [`Self::image_only_page_at`] reported and must still be placeholders; anything else is
+	/// skipped. Returns the outcome so callers can remap positions they hold themselves.
+	pub fn replace_image_only_pages(&mut self, pages: &[(i64, String)]) -> ReplaceOutcome {
+		let edits: Vec<Edit> = pages
+			.iter()
+			.filter(|(offset, _)| self.image_only_page_at(*offset).is_some())
+			.filter_map(|(offset, text)| {
+				let (start, end) = self.line_bounds_at(*offset)?;
+				Some(Edit {
+					start: usize::try_from(start.max(0)).unwrap_or(0),
+					end: usize::try_from(end.max(0)).unwrap_or(0),
+					text: text.clone(),
+				})
+			})
+			.collect();
+		self.handle.replace_ranges(edits)
 	}
 
 	/// This document's recorded audio, when it has any (DAISY audiobooks; text-only

--- a/crates/paperback-core/src/session/stats.rs
+++ b/crates/paperback-core/src/session/stats.rs
@@ -357,6 +357,44 @@ impl DocumentSession {
 		buf.content[start_byte..line_end_byte].to_string()
 	}
 
+	/// The display-unit `[start, end)` span of the line containing `position` (display units),
+	/// where `end` is the index of the line's terminating `\n` (exclusive of it). Unlike
+	/// [`Self::get_line_text`], which treats its argument as a *char* index, this converts via
+	/// [`DocumentBuffer::char_index_for_display`]/[`display_index_for_char`], so astral
+	/// characters before the caret (which occupy two display units) can't misalign the result.
+	/// Returns `None` for an empty document.
+	#[must_use]
+	pub fn line_bounds_at(&self, position: i64) -> Option<(i64, i64)> {
+		let buf = &self.handle.document().buffer;
+		let total_chars = buf.char_count();
+		if total_chars == 0 {
+			return None;
+		}
+		let pos = usize::try_from(position.max(0)).unwrap_or(0).min(buf.total_display_len());
+		let char_pos = buf.char_index_for_display(pos);
+		let newlines = buf.newline_positions();
+		let idx = newlines.partition_point(|&p| p < char_pos);
+		let line_start_char = if idx == 0 { 0 } else { newlines[idx - 1] + 1 };
+		let line_end_char = newlines.get(idx).copied().unwrap_or(total_chars);
+		Some((
+			i64::try_from(buf.display_index_for_char(line_start_char)).unwrap_or(0),
+			i64::try_from(buf.display_index_for_char(line_end_char)).unwrap_or(0),
+		))
+	}
+
+	/// The text of the line containing `position` (display units), using display-unit-correct
+	/// bounds (see [`Self::line_bounds_at`]); an empty string at the end of the document.
+	#[must_use]
+	pub fn line_text_at(&self, position: i64) -> String {
+		let Some((start, end)) = self.line_bounds_at(position) else {
+			return String::new();
+		};
+		let buf = &self.handle.document().buffer;
+		let start_char = buf.char_index_for_display(usize::try_from(start.max(0)).unwrap_or(0));
+		let end_char = buf.char_index_for_display(usize::try_from(end.max(0)).unwrap_or(0));
+		self.get_text_range(i64::try_from(start_char).unwrap_or(0), i64::try_from(end_char).unwrap_or(0))
+	}
+
 	/// Returns the first non-blank line of real content at or after `position`, skipping blank
 	/// lines and bare page-number headers (e.g. "27" or "Page 27"). Returns an empty string if
 	/// no such line exists. Used for page-navigation announcements so the page number isn't

--- a/crates/paperback-core/src/session/tests.rs
+++ b/crates/paperback-core/src/session/tests.rs
@@ -6,6 +6,7 @@ mod audio;
 mod find_all;
 mod links;
 mod navigation;
+mod ocr;
 mod webview;
 
 fn sample_session(parser_flags: ParserFlags) -> DocumentSession {

--- a/crates/paperback-core/src/session/tests/ocr.rs
+++ b/crates/paperback-core/src/session/tests/ocr.rs
@@ -1,0 +1,70 @@
+//! Locating and replacing the image-only page placeholders the PDF parser leaves behind.
+
+use super::*;
+use crate::ocr::image_only_placeholder;
+
+/// Two pages of text with an image-only page between them, shaped the way the PDF parser builds
+/// one: a page break at the start of each page, and an `ImageOnlyPage` marker sharing the
+/// placeholder line's start.
+fn session_with_image_only_page() -> DocumentSession {
+	let content = format!("page one\n{}\npage three\n", image_only_placeholder());
+	let mut buffer = DocumentBuffer::with_content(content);
+	buffer.add_marker(Marker::new(MarkerType::PageBreak, 0));
+	buffer.add_marker(Marker::new(MarkerType::PageBreak, 9));
+	buffer.add_marker(Marker::new(MarkerType::ImageOnlyPage, 9));
+	buffer.add_marker(Marker::new(MarkerType::PageBreak, 43));
+	session_from_buffer(buffer)
+}
+
+#[test]
+fn line_bounds_at_and_line_text_at_return_the_containing_line() {
+	let session = session_with_content("aaa\nbbb\nccc");
+	// (start, end) are display units; end excludes the line's trailing newline.
+	assert_eq!(session.line_bounds_at(0), Some((0, 3)));
+	assert_eq!(session.line_text_at(0), "aaa");
+	assert_eq!(session.line_bounds_at(5), Some((4, 7)));
+	assert_eq!(session.line_text_at(5), "bbb");
+	assert_eq!(session.line_bounds_at(11), Some((8, 11)));
+	assert_eq!(session.line_text_at(11), "ccc");
+}
+
+#[test]
+fn image_only_pages_reports_the_page_number_and_offset() {
+	let session = session_with_image_only_page();
+	assert_eq!(session.image_only_pages(), vec![(2, 9)]);
+}
+
+#[test]
+fn image_only_page_at_matches_anywhere_on_the_placeholder_line() {
+	let session = session_with_image_only_page();
+	assert_eq!(session.image_only_page_at(9), Some(9));
+	// Mid-line and at the line's end, since the caret can sit anywhere on it.
+	assert_eq!(session.image_only_page_at(20), Some(9));
+	assert_eq!(session.image_only_page_at(42), Some(9));
+	// The lines either side are ordinary text.
+	assert_eq!(session.image_only_page_at(0), None);
+	assert_eq!(session.image_only_page_at(45), None);
+}
+
+#[test]
+fn replace_image_only_pages_swaps_the_line_and_clears_the_marker() {
+	let mut session = session_with_image_only_page();
+	let outcome = session.replace_image_only_pages(&[(9, "recognized text".to_string())]);
+	assert_eq!(session.line_text_at(9), "recognized text");
+	// The marker is gone, so the page is not offered for OCR a second time.
+	assert!(session.image_only_pages().is_empty());
+	assert_eq!(session.image_only_page_at(9), None);
+	// The page after it moved by the length difference, and page navigation follows.
+	assert_eq!(outcome.total_delta, 15 - 33);
+	assert_eq!(session.page_offset(3), 43 + outcome.total_delta);
+	assert_eq!(session.line_text_at(session.page_offset(3)), "page three");
+}
+
+#[test]
+fn replace_image_only_pages_ignores_offsets_that_are_not_placeholders() {
+	let mut session = session_with_image_only_page();
+	let outcome = session.replace_image_only_pages(&[(0, "not a placeholder".to_string())]);
+	assert_eq!(outcome.total_delta, 0);
+	assert_eq!(session.line_text_at(0), "page one");
+	assert_eq!(session.image_only_pages(), vec![(2, 9)]);
+}

--- a/crates/paperback/Cargo.toml
+++ b/crates/paperback/Cargo.toml
@@ -31,7 +31,7 @@ wxdragon = { version = "0.9.21", features = ["webview", "media-ctrl"] }
 zip = { version = "9.0.0-pre3", default-features = false, features = ["deflate"] }
 
 [target.'cfg(windows)'.dependencies]
-windows = { version = "0.62.2", features = ["Win32_UI_Accessibility", "Win32_System_Com", "Win32_UI_WindowsAndMessaging", "Win32_Foundation", "Win32_System_Ole", "Win32_System_Variant", "Win32_UI_Controls_RichEdit", "Win32_Graphics_Gdi", "Win32_Security", "Win32_Storage_FileSystem", "Win32_System_IO", "Win32_System_Pipes", "Win32_UI_Input", "Win32_UI_Input_KeyboardAndMouse", "Win32_System_Threading", "Win32_UI_Shell"] }
+windows = { version = "0.62.2", features = ["Win32_UI_Accessibility", "Win32_System_Com", "Win32_UI_WindowsAndMessaging", "Win32_Foundation", "Win32_System_Ole", "Win32_System_Variant", "Win32_UI_Controls_RichEdit", "Win32_Graphics_Gdi", "Win32_Security", "Win32_Storage_FileSystem", "Win32_System_IO", "Win32_System_Pipes", "Win32_UI_Input", "Win32_UI_Input_KeyboardAndMouse", "Win32_System_Threading", "Win32_UI_Shell", "Win32_System_WinRT", "Foundation", "Media_Ocr", "Graphics_Imaging", "Globalization"] }
 
 [target.'cfg(target_os = "macos")'.dependencies]
 objc = "0.2.7"

--- a/crates/paperback/src/ui.rs
+++ b/crates/paperback/src/ui.rs
@@ -12,6 +12,8 @@ mod main_window;
 mod menu;
 mod menu_ids;
 mod navigation;
+#[cfg(any(target_os = "windows", target_os = "macos"))]
+mod ocr;
 mod readability;
 mod reader_input;
 #[cfg(any(target_os = "windows", test))]

--- a/crates/paperback/src/ui.rs
+++ b/crates/paperback/src/ui.rs
@@ -12,7 +12,6 @@ mod main_window;
 mod menu;
 mod menu_ids;
 mod navigation;
-#[cfg(any(target_os = "windows", target_os = "macos"))]
 mod ocr;
 mod readability;
 mod reader_input;

--- a/crates/paperback/src/ui/dialogs.rs
+++ b/crates/paperback/src/ui/dialogs.rs
@@ -15,6 +15,10 @@ pub(super) use wx_utils::{
 
 mod about;
 pub use about::show_about_dialog;
+#[cfg(any(target_os = "windows", target_os = "macos"))]
+mod batch_ocr;
+#[cfg(any(target_os = "windows", target_os = "macos"))]
+pub use batch_ocr::show_batch_ocr_dialog;
 mod all_documents;
 pub use all_documents::show_all_documents_dialog;
 mod bookmark;

--- a/crates/paperback/src/ui/dialogs/batch_ocr.rs
+++ b/crates/paperback/src/ui/dialogs/batch_ocr.rs
@@ -1,0 +1,49 @@
+use patois::t;
+use wxdragon::prelude::*;
+
+use super::{DIALOG_PADDING, add_ok_cancel_footer, bind_enter_confirms, build_ok_cancel_buttons};
+
+/// Dialog for choosing a page range to batch-OCR. Pre-fills the whole document
+/// (start = 1, end = last page) since "OCR everything" is the common case.
+pub fn show_batch_ocr_dialog(parent: &Frame, max_page: i32) -> Option<(i32, i32)> {
+	let max_page = max_page.max(1);
+	// TRANSLATORS: Title of the Batch OCR dialog
+	let dialog_title = t("Batch OCR");
+	let dialog = Dialog::builder(parent, &dialog_title).build();
+	// TRANSLATORS: Label for the starting page field of the Batch OCR range
+	let start_label = StaticText::builder(&dialog).with_label(&t("&Start page:")).build();
+	let start_ctrl = SpinCtrl::builder(&dialog)
+		.with_range(1, max_page)
+		.with_style(SpinCtrlStyle::Default | SpinCtrlStyle::ProcessEnter)
+		.build();
+	start_ctrl.set_value(1);
+	bind_enter_confirms(&dialog, start_ctrl);
+	// TRANSLATORS: Label for the ending page field of the Batch OCR range
+	let end_label = StaticText::builder(&dialog).with_label(&t("&End page:")).build();
+	let end_ctrl = SpinCtrl::builder(&dialog)
+		.with_range(1, max_page)
+		.with_style(SpinCtrlStyle::Default | SpinCtrlStyle::ProcessEnter)
+		.build();
+	end_ctrl.set_value(max_page);
+	bind_enter_confirms(&dialog, end_ctrl);
+	let start_sizer = BoxSizer::builder(Orientation::Horizontal).build();
+	start_sizer.add(&start_label, 0, SizerFlag::AlignCenterVertical | SizerFlag::Right, 5);
+	start_sizer.add(&start_ctrl, 1, SizerFlag::Expand, 0);
+	let end_sizer = BoxSizer::builder(Orientation::Horizontal).build();
+	end_sizer.add(&end_label, 0, SizerFlag::AlignCenterVertical | SizerFlag::Right, 5);
+	end_sizer.add(&end_ctrl, 1, SizerFlag::Expand, 0);
+	// TRANSLATORS: Label for the button that starts the batch OCR
+	let (ok_button, cancel_button) = build_ok_cancel_buttons(&dialog, &t("OCR"));
+	let content_sizer = BoxSizer::builder(Orientation::Vertical).build();
+	content_sizer.add_sizer(&start_sizer, 0, SizerFlag::Expand | SizerFlag::All, DIALOG_PADDING);
+	content_sizer.add_sizer(&end_sizer, 0, SizerFlag::Expand | SizerFlag::All, DIALOG_PADDING);
+	add_ok_cancel_footer(content_sizer, ok_button, cancel_button);
+	dialog.set_sizer_and_fit(content_sizer, true);
+	dialog.centre();
+	start_ctrl.set_focus();
+	if dialog.show_modal() == ID_OK {
+		Some((start_ctrl.value().clamp(1, max_page), end_ctrl.value().clamp(1, max_page)))
+	} else {
+		None
+	}
+}

--- a/crates/paperback/src/ui/document_manager.rs
+++ b/crates/paperback/src/ui/document_manager.rs
@@ -25,6 +25,7 @@ use super::{
 use crate::audio_player::AudioPlayer;
 
 mod audio;
+mod ocr;
 
 pub struct DocumentTab {
 	pub panel: Panel,
@@ -42,6 +43,8 @@ pub struct DocumentTab {
 	/// `ui::text_window` - for most documents this covers the whole thing, same as before
 	/// windowing existed; only huge documents actually get a partial window.
 	pub window: TextWindow,
+	/// The OCR job running for this tab, if one is. Written and read only on the UI thread.
+	ocr_job: Option<ocr::OcrJob>,
 }
 
 /// Change-detection stamp for an open document's file, compared on every frame activation and
@@ -273,6 +276,7 @@ impl DocumentManager {
 			disk_fingerprint: read_fingerprint(path),
 			preferred_column: Cell::new(None),
 			window,
+			ocr_job: None,
 		});
 		if !password.is_empty() {
 			config.set_document_password(&path_str, password);
@@ -554,6 +558,7 @@ impl DocumentManager {
 		})
 	}
 
+	/// Whether the caret is on an image-only PDF page's OCR placeholder line.
 	pub fn update_status_bar(&self) {
 		let sleep_start = sleep_timer::start_ms();
 		let sleep_duration = sleep_timer::duration_minutes();

--- a/crates/paperback/src/ui/document_manager/ocr.rs
+++ b/crates/paperback/src/ui/document_manager/ocr.rs
@@ -1,0 +1,317 @@
+//! Running the built-in OCR engine over image-only PDF pages, one page at a time or a range in
+//! bulk, and folding the recognized text back into the open document.
+//!
+//! Everything that touches a `DocumentTab` runs on the UI thread. The worker thread holds only
+//! the file path and a list of page numbers: it renders and recognizes, then hands text back
+//! through `wxdragon::call_after`. Pages are addressed by number rather than by offset for a
+//! reason. Applying one page's text moves every offset after it, so an offset captured before
+//! the job started would be stale by the time the worker's next result lands. Page numbers stay
+//! true, and the UI thread re-resolves each one's placeholder as it applies it.
+
+use std::{
+	path::{Path, PathBuf},
+	sync::{
+		Arc,
+		atomic::{AtomicBool, Ordering},
+	},
+	thread,
+};
+
+use paperback_core::ocr::PageRenderer;
+use patois::{nt, t};
+use wxdragon::prelude::*;
+
+use super::{DocumentManager, DocumentTab};
+use crate::ui::{
+	ocr::{self, OcrError},
+	text_render::reload_window_around,
+	text_window::TextWindow,
+};
+
+/// How many pages between spoken progress announcements during a batch OCR job.
+const BATCH_OCR_PROGRESS_EVERY: usize = 20;
+
+/// How many recognized pages to hold before folding them into the document together.
+///
+/// Every apply rebuilds the buffer's per-char index tables, which is linear in the whole
+/// document, so applying page by page would be quadratic over a long scan. Flushing in groups
+/// keeps that cost proportional to the document while still letting the reader reach the early
+/// pages long before a several-hundred-page job finishes. Matched to the progress interval so
+/// the text appears exactly when the progress announcement says it has.
+const BATCH_OCR_FLUSH_EVERY: usize = BATCH_OCR_PROGRESS_EVERY;
+
+/// A running OCR job, one per tab. Owned by the UI thread; the worker sees only `cancel`.
+pub(super) struct OcrJob {
+	/// Raised by the UI thread to stop a batch after the page it is working on.
+	cancel: Arc<AtomicBool>,
+	/// True for a range job, false for a single page. Only a batch is worth offering to cancel.
+	batch: bool,
+	/// Pages whose text has made it into the document so far, for the closing announcement.
+	recognized: usize,
+}
+
+/// One page's outcome, as the worker reports it.
+type PageResult = (i32, Result<String, OcrError>);
+
+impl DocumentManager {
+	/// The offset of the OCR placeholder the caret is sitting on, if it is on one.
+	pub fn image_only_page_at_caret(&self) -> Option<i64> {
+		let tab = self.active_tab()?;
+		let position = tab.window.to_doc(tab.text_ctrl.get_insertion_point());
+		tab.session.image_only_page_at(position)
+	}
+
+	/// Whether a batch OCR job is running for the active tab, and so worth offering to cancel.
+	pub fn batch_ocr_running(&self) -> bool {
+		self.active_tab().is_some_and(|tab| tab.ocr_job.as_ref().is_some_and(|job| job.batch))
+	}
+
+	/// Asks a running batch to stop after the page it is on. The completion path announces how
+	/// much was recognized before the stop, so there is nothing to announce here.
+	pub fn cancel_ocr(&mut self) {
+		if let Some(job) = self.active_tab().and_then(|tab| tab.ocr_job.as_ref()) {
+			job.cancel.store(true, Ordering::Relaxed);
+		}
+	}
+
+	/// Runs OCR on the image-only page the caret is on.
+	pub fn start_ocr_for_current_page(&mut self) {
+		let label = self.live_region_label;
+		let Some(offset) = self.image_only_page_at_caret() else {
+			return;
+		};
+		let Some(tab) = self.active_tab() else {
+			return;
+		};
+		if tab.ocr_job.is_some() {
+			// TRANSLATORS: Announced when Enter is pressed on an OCR placeholder while OCR is already running
+			live_region::announce(label, &t("OCR in progress."));
+			return;
+		}
+		let page = tab.session.current_page(offset);
+		self.spawn_ocr(vec![page], false);
+	}
+
+	/// Runs OCR on every image-only page in `start..=end` (1-based page numbers).
+	pub fn start_batch_ocr(&mut self, start: i32, end: i32) {
+		let label = self.live_region_label;
+		let Some(tab) = self.active_tab() else {
+			// TRANSLATORS: Announced when batch OCR is triggered with no document open
+			live_region::announce(label, &t("No document open."));
+			return;
+		};
+		if tab.ocr_job.is_some() {
+			// TRANSLATORS: Announced when batch OCR is started while another OCR job is running
+			live_region::announce(label, &t("OCR already in progress."));
+			return;
+		}
+		let (start, end) = if start <= end { (start, end) } else { (end, start) };
+		let pages: Vec<i32> = tab
+			.session
+			.image_only_pages()
+			.into_iter()
+			.filter_map(|(page, _)| (page >= start && page <= end).then_some(page))
+			.collect();
+		if pages.is_empty() {
+			// TRANSLATORS: Announced when the chosen batch OCR range contains no image-only pages
+			live_region::announce(label, &t("No image-only pages in the given range."));
+			return;
+		}
+		self.spawn_ocr(pages, true);
+	}
+
+	/// Starts the worker for `pages` and records the job on the active tab.
+	fn spawn_ocr(&mut self, pages: Vec<i32>, batch: bool) {
+		let label = self.live_region_label;
+		let Some(tab) = self.active_tab() else {
+			return;
+		};
+		let path = tab.file_path.clone();
+		let path_str = path.to_string_lossy().to_string();
+		let password = self.config.lock().unwrap().get_document_password(&path_str);
+		let password = (!password.is_empty()).then_some(password);
+		let cancel = Arc::new(AtomicBool::new(false));
+		let worker_cancel = Arc::clone(&cancel);
+		let worker = thread::Builder::new()
+			.name("paperback-ocr".into())
+			.spawn(move || run_ocr(&path_str, password.as_deref(), &pages, &path, &worker_cancel, batch));
+		match worker {
+			Ok(_) => {
+				if let Some(tab) = self.active_tab_mut() {
+					tab.ocr_job = Some(OcrJob { cancel, batch, recognized: 0 });
+				}
+			}
+			Err(err) => {
+				tracing::warn!(error = %err, "failed to spawn the ocr worker thread");
+				live_region::announce(label, &OcrError::Failed(err.to_string()).message());
+			}
+		}
+	}
+
+	/// Folds a group of recognized pages into the document. Called on the UI thread from the
+	/// worker, once per flush.
+	pub(crate) fn apply_ocr_results(&mut self, file_path: &Path, results: Vec<PageResult>) {
+		let label = self.live_region_label;
+		let Some(index) = self.tabs.iter().position(|tab| tab.file_path.as_path() == file_path) else {
+			return;
+		};
+		let is_active = self.active_tab_index() == Some(index);
+		let tab = &mut self.tabs[index];
+		// Placeholder offsets are resolved now, not when the worker captured the page: earlier
+		// applies in this same job have already moved everything after them.
+		let offsets = tab.session.image_only_pages();
+		let mut pages = Vec::with_capacity(results.len());
+		for (page, result) in results {
+			let text = match result {
+				Ok(text) => text,
+				Err(err) => {
+					tracing::warn!(page, error = %err, "ocr failed on page");
+					if matches!(err, OcrError::NoLanguage) {
+						live_region::announce(label, &err.message());
+					}
+					continue;
+				}
+			};
+			if text.trim().is_empty() {
+				continue;
+			}
+			if let Some((_, offset)) = offsets.iter().find(|(candidate, _)| *candidate == page) {
+				pages.push((*offset, text));
+			}
+		}
+		if pages.is_empty() {
+			return;
+		}
+		let caret = tab.window.to_doc(tab.text_ctrl.get_insertion_point());
+		let window = tab.window;
+		let outcome = tab.session.replace_image_only_pages(&pages);
+		if let Some(job) = tab.ocr_job.as_mut() {
+			job.recognized += pages.len();
+		}
+		let caret = i64::try_from(outcome.shift(usize::try_from(caret.max(0)).unwrap_or(0))).unwrap_or(caret);
+		refresh_after_ocr(tab, &pages, window, caret, is_active);
+		// The config stores document-absolute offsets (reading position, navigation history,
+		// bookmarks), every one of which the edits above just moved.
+		self.config.lock().unwrap().shift_document_positions(&file_path.to_string_lossy(), &outcome);
+	}
+
+	/// Announces batch progress. Called on the UI thread from the worker.
+	pub(crate) fn announce_ocr_progress(&self, done: usize, total: usize) {
+		// TRANSLATORS: Batch OCR progress announcement; the two %d placeholders are the pages done and the total pages
+		let message = t("OCR %d of %d.").replacen("%d", &done.to_string(), 1).replacen("%d", &total.to_string(), 1);
+		live_region::announce(self.live_region_label, &message);
+	}
+
+	/// Clears the job and announces the outcome. Called on the UI thread when the worker ends.
+	pub(crate) fn finish_ocr(&mut self, file_path: &Path, canceled: bool) {
+		let label = self.live_region_label;
+		let Some(tab) = self.tabs.iter_mut().find(|tab| tab.file_path.as_path() == file_path) else {
+			return;
+		};
+		let Some(job) = tab.ocr_job.take() else {
+			return;
+		};
+		if !job.batch {
+			let message = if job.recognized > 0 {
+				// TRANSLATORS: Announced after OCR replaces an image-only page with the recognized text
+				t("OCR complete.")
+			} else {
+				// TRANSLATORS: Announced when OCR runs on a page but finds no recognizable text
+				t("No text found.")
+			};
+			live_region::announce(label, &message);
+			return;
+		}
+		let count = u64::try_from(job.recognized).unwrap_or(0);
+		let message = if canceled {
+			// TRANSLATORS: Announced when batch OCR is stopped early; %d is the number of pages recognized before it stopped
+			nt("Batch OCR stopped. %d page recognized.", "Batch OCR stopped. %d pages recognized.", count)
+		} else {
+			// TRANSLATORS: Announced after batch OCR finishes; %d is the number of pages recognized
+			nt("Batch OCR complete. %d page recognized.", "Batch OCR complete. %d pages recognized.", count)
+		};
+		live_region::announce(label, &message.replacen("%d", &job.recognized.to_string(), 1));
+	}
+}
+
+/// Reloads the on-screen window when a replaced page was in or before it, so the recognized text
+/// appears and local offsets keep matching document ones.
+fn refresh_after_ocr(tab: &mut DocumentTab, pages: &[(i64, String)], window: TextWindow, caret: i64, is_active: bool) {
+	if !pages.iter().any(|(offset, _)| *offset < window.end()) {
+		return;
+	}
+	let caret = caret.clamp(0, tab.session.document_len());
+	reload_window_around(tab, caret, "ocr");
+	if is_active {
+		let local = tab.window.to_local(caret);
+		tab.text_ctrl.set_insertion_point(local);
+		tab.text_ctrl.show_position(local);
+	}
+}
+
+/// The worker thread: opens the PDF once, then renders and recognizes each page in turn, posting
+/// results back to the UI thread in flushes.
+fn run_ocr(path_str: &str, password: Option<&str>, pages: &[i32], file_path: &Path, cancel: &AtomicBool, batch: bool) {
+	let renderer = match PageRenderer::open(path_str, password) {
+		Ok(renderer) => renderer,
+		Err(err) => {
+			tracing::warn!(error = %err, "failed to open the pdf for ocr");
+			post_finish(file_path, false);
+			return;
+		}
+	};
+	let total = pages.len();
+	let max_dimension = ocr::max_image_dimension();
+	let mut pending: Vec<PageResult> = Vec::with_capacity(BATCH_OCR_FLUSH_EVERY);
+	let mut canceled = false;
+	for (done, page) in pages.iter().enumerate() {
+		if cancel.load(Ordering::Relaxed) {
+			canceled = true;
+			break;
+		}
+		// `render` takes a 0-based page index; the job list is 1-based.
+		let result = renderer
+			.render(page - 1, max_dimension)
+			.map_err(|err| OcrError::Failed(err.to_string()))
+			.and_then(|rendered| ocr::recognize_rgba(&rendered.rgba, rendered.width, rendered.height));
+		pending.push((*page, result));
+		let done = done + 1;
+		if pending.len() >= BATCH_OCR_FLUSH_EVERY && done != total {
+			post_apply(file_path, std::mem::take(&mut pending));
+		}
+		if batch && done % BATCH_OCR_PROGRESS_EVERY == 0 && done != total {
+			post_progress(done, total);
+		}
+	}
+	if !pending.is_empty() {
+		post_apply(file_path, pending);
+	}
+	post_finish(file_path, canceled);
+}
+
+fn post_apply(file_path: &Path, results: Vec<PageResult>) {
+	let path = file_path.to_path_buf();
+	run_on_ui_thread(move |manager| manager.apply_ocr_results(&path, results));
+}
+
+fn post_progress(done: usize, total: usize) {
+	run_on_ui_thread(move |manager| manager.announce_ocr_progress(done, total));
+}
+
+fn post_finish(file_path: &Path, canceled: bool) {
+	let path: PathBuf = file_path.to_path_buf();
+	run_on_ui_thread(move |manager| manager.finish_ocr(&path, canceled));
+}
+
+/// Queues `action` to run on the UI thread with the document manager locked. Every call lands in
+/// order behind the ones before it, which is what lets a flush rely on the previous flush having
+/// already moved the offsets it is about to resolve.
+fn run_on_ui_thread(action: impl FnOnce(&mut DocumentManager) + Send + 'static) {
+	wxdragon::call_after(Box::new(move || {
+		if let Some(window) = crate::ui::app::main_window_from_ptr() {
+			let mut manager = window.document_manager().lock().unwrap();
+			action(&mut manager);
+		}
+	}));
+	wxdragon::wake_up_idle();
+}

--- a/crates/paperback/src/ui/main_window.rs
+++ b/crates/paperback/src/ui/main_window.rs
@@ -63,6 +63,13 @@ pub struct MainWindow {
 static HIDDEN_POPUP: AtomicIsize = AtomicIsize::new(0);
 
 impl MainWindow {
+	/// Accessor for background callbacks (e.g. the OCR worker thread) that can't hold the app's
+	/// own `Rc<Mutex<DocumentManager>>` (an `Rc` is not `Send`); they reach the window via
+	/// [`crate::ui::app::main_window_from_ptr`] and then this method.
+	pub(crate) fn document_manager(&self) -> &Rc<Mutex<DocumentManager>> {
+		&self.doc_manager
+	}
+
 	pub fn new(config: Rc<Mutex<ConfigManager>>) -> Self {
 		// TRANSLATORS: Main window title when no document is open
 		let app_title = t("Paperback");
@@ -750,6 +757,10 @@ impl MainWindow {
 				}
 				menu_ids::SLEEP_TIMER => {
 					sleep_timer.toggle(&frame_copy, &dm, &config, live_region_label);
+				}
+				#[cfg(any(target_os = "windows", target_os = "macos"))]
+				menu_ids::BATCH_OCR => {
+					menu_tools::handle_batch_ocr(&frame_copy, &dm, live_region_label);
 				}
 				menu_ids::ABOUT => {
 					dialogs::show_about_dialog(&frame_copy);

--- a/crates/paperback/src/ui/main_window/menu_tools.rs
+++ b/crates/paperback/src/ui/main_window/menu_tools.rs
@@ -114,6 +114,40 @@ fn toc_announcement(session: &DocumentSession, offset: i64) -> String {
 	}
 }
 
+/// Opens the Batch OCR range dialog, or offers to stop the batch that is already running. One
+/// menu item covers both so there is nothing to enable and disable as a job starts and ends, and
+/// the answer to "how do I stop this" is the same item that started it.
+#[cfg(any(target_os = "windows", target_os = "macos"))]
+pub(super) fn handle_batch_ocr(frame: &Frame, dm: &Rc<Mutex<DocumentManager>>, live_region_label: StaticText) {
+	let (max_page, running) = {
+		let dm_ref = dm.lock().unwrap();
+		let Some(tab) = dm_ref.active_tab() else {
+			// TRANSLATORS: Announced when Batch OCR is chosen with no document open
+			live_region::announce(live_region_label, &t("No document open."));
+			return;
+		};
+		(i32::try_from(tab.session.page_count()).unwrap_or(i32::MAX), dm_ref.batch_ocr_running())
+	};
+	if running {
+		let confirm = MessageDialog::builder(
+			frame,
+			// TRANSLATORS: Confirmation asked when Batch OCR is chosen while a batch is already running
+			&t("Batch OCR is running. Stop it?"),
+			// TRANSLATORS: Title of the Batch OCR dialog
+			&t("Batch OCR"),
+		)
+		.with_style(MessageDialogStyle::YesNo | MessageDialogStyle::IconQuestion)
+		.build();
+		if confirm.show_modal() == ID_YES {
+			dm.lock().unwrap().cancel_ocr();
+		}
+		return;
+	}
+	if let Some((start, end)) = dialogs::show_batch_ocr_dialog(frame, max_page) {
+		dm.lock().unwrap().start_batch_ocr(start, end);
+	}
+}
+
 pub(super) fn handle_elements_list(
 	frame: &Frame,
 	dm: &Rc<Mutex<DocumentManager>>,

--- a/crates/paperback/src/ui/menu/tools_menu.rs
+++ b/crates/paperback/src/ui/menu/tools_menu.rs
@@ -116,6 +116,14 @@ pub fn create_tools_menu(config: &ConfigManager) -> Menu {
 	menu.append(options_id, &options_label, "", ItemKind::Normal);
 	menu.append(menu_ids::CUSTOMIZE_SHORTCUTS, &shortcuts_label, "", ItemKind::Normal);
 	menu.append(menu_ids::SLEEP_TIMER, &sleep_label, "", ItemKind::Normal);
+	// No OCR engine outside Windows and macOS, so there is nothing for the item to do there.
+	#[cfg(any(target_os = "windows", target_os = "macos"))]
+	{
+		menu.append_separator();
+		// TRANSLATORS: Tools menu item that opens the Batch OCR dialog for image-only PDF pages
+		let batch_ocr_label = format_menu_label(&t("&Batch OCR..."), ActionId::BatchOcr, config);
+		menu.append(menu_ids::BATCH_OCR, &batch_ocr_label, "", ItemKind::Normal);
+	}
 	menu
 }
 

--- a/crates/paperback/src/ui/menu_ids.rs
+++ b/crates/paperback/src/ui/menu_ids.rs
@@ -111,6 +111,9 @@ seq_ids!(BASE + 450 =>
 	INCREASE_AUDIO_SEEK_AMOUNT, DECREASE_AUDIO_SEEK_AMOUNT,
 );
 
+// Tools menu: OCR (BASE + 460..469)
+seq_ids!(BASE + 460 => BATCH_OCR);
+
 // Help menu (BASE + 500..599)
 seq_ids!(BASE + 500 => VIEW_HELP_BROWSER, VIEW_HELP_PAPERBACK, CHECK_FOR_UPDATES, DONATE);
 
@@ -197,6 +200,7 @@ pub const fn action_to_menu_id(action: paperback_core::config::ActionId) -> i32 
 		ActionId::ToggleFullScreen => TOGGLE_FULL_SCREEN,
 		ActionId::Options => OPTIONS,
 		ActionId::SleepTimer => SLEEP_TIMER,
+		ActionId::BatchOcr => BATCH_OCR,
 		ActionId::CustomizeShortcuts => CUSTOMIZE_SHORTCUTS,
 		ActionId::ImportDocumentData => IMPORT_DOCUMENT_DATA,
 		ActionId::ExportDocumentData => EXPORT_DOCUMENT_DATA,

--- a/crates/paperback/src/ui/ocr.rs
+++ b/crates/paperback/src/ui/ocr.rs
@@ -1,0 +1,87 @@
+//! The built-in OCR engine, for image-only PDF pages.
+//!
+//! One engine per platform, picked at compile time: `Windows.Media.Ocr` on Windows, Vision on
+//! macOS. There is no provider list and no engine picker. What the user chooses between is this
+//! (local, free, immediate, plain text) and Scribe (remote, paid, whole document, structured),
+//! which is a different feature on a different path rather than another entry here.
+//!
+//! [`recognize_rgba`] runs on a worker thread and the caller marshals the result back to the UI
+//! thread with `wxdragon::call_after`.
+
+use patois::t;
+
+#[cfg(target_os = "macos")]
+mod macos;
+#[cfg(not(any(target_os = "windows", target_os = "macos")))]
+mod unavailable;
+#[cfg(target_os = "windows")]
+mod windows;
+
+#[cfg(target_os = "macos")]
+use macos as engine;
+#[cfg(not(any(target_os = "windows", target_os = "macos")))]
+use unavailable as engine;
+#[cfg(target_os = "windows")]
+use windows as engine;
+
+/// Why an OCR attempt produced no text.
+#[derive(Debug)]
+pub enum OcrError {
+	/// The engine exists but has no recognizer for any of the user's languages. On Windows this
+	/// means no OCR language pack is installed, which is the single most likely failure for a
+	/// reader outside the English-speaking world, so it gets its own message rather than being
+	/// folded into a generic failure.
+	NoLanguage,
+	/// The engine refused the image, or failed while recognizing it.
+	Failed(String),
+	/// This build has no OCR engine (Linux, where neither Windows OCR nor Vision exists). The
+	/// paths that would reach it are compiled out, so this is a backstop, not a normal outcome,
+	/// and only the stub engine ever raises it.
+	#[allow(dead_code)]
+	Unavailable,
+}
+
+impl OcrError {
+	/// The message to announce for this failure.
+	pub fn message(&self) -> String {
+		match self {
+			// TRANSLATORS: Announced when OCR can't run because the system has no OCR language installed
+			Self::NoLanguage => t("No OCR language is installed. Add one in your system language settings."),
+			// TRANSLATORS: Announced when the OCR engine fails on a page
+			Self::Failed(_) => t("OCR failed."),
+			// TRANSLATORS: Announced when OCR is requested on a system that has no OCR engine
+			Self::Unavailable => t("OCR is not available on this system."),
+		}
+	}
+}
+
+impl std::fmt::Display for OcrError {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		match self {
+			Self::NoLanguage => write!(f, "no OCR language installed"),
+			Self::Failed(detail) => write!(f, "{detail}"),
+			Self::Unavailable => write!(f, "no OCR engine on this platform"),
+		}
+	}
+}
+
+/// The largest image side the engine accepts. Pages are rendered no larger than this, since
+/// anything bigger is downscaled by the engine anyway.
+pub fn max_image_dimension() -> u32 {
+	engine::max_image_dimension()
+}
+
+/// Recognizes text in an RGBA8 bitmap (4 bytes per pixel, row-major, `width * height * 4`
+/// bytes), returning the recognized lines joined with newlines.
+///
+/// # Errors
+///
+/// Returns [`OcrError::NoLanguage`] when the system has no usable OCR language, and
+/// [`OcrError::Failed`] when the engine rejects the image or fails to recognize it.
+pub fn recognize_rgba(rgba: &[u8], width: u32, height: u32) -> Result<String, OcrError> {
+	let expected = (width as usize) * (height as usize) * 4;
+	if rgba.len() != expected {
+		return Err(OcrError::Failed(format!("bitmap byte count mismatch (got {}, expected {expected})", rgba.len())));
+	}
+	engine::recognize_rgba(rgba, width, height)
+}

--- a/crates/paperback/src/ui/ocr/macos.rs
+++ b/crates/paperback/src/ui/ocr/macos.rs
@@ -1,0 +1,198 @@
+//! The macOS OCR engine (Vision's text recognition), reached through raw Objective-C messaging.
+//!
+//! Vision ships its recognition languages with the OS, so unlike Windows there is no language
+//! pack to install and no `NoLanguage` case to report in practice. The framework calls are
+//! declared here rather than pulled in as crates: this is the only place in the app that needs
+//! CoreGraphics, and one small extern block is less to carry than three more dependencies.
+
+use std::{
+	ffi::{CStr, c_void},
+	ptr,
+};
+
+use objc::{class, msg_send, rc::autoreleasepool, runtime::Object, sel, sel_impl};
+
+use super::OcrError;
+
+type CFTypeRef = *const c_void;
+type CFDataRef = *const c_void;
+type CGColorSpaceRef = *mut c_void;
+type CGDataProviderRef = *mut c_void;
+type CGImageRef = *mut c_void;
+
+/// RGBA8, alpha last and not premultiplied, which is what pdfium hands us.
+const K_CG_IMAGE_ALPHA_LAST: u32 = 3;
+const K_CG_RENDERING_INTENT_DEFAULT: i32 = 0;
+/// `VNRequestTextRecognitionLevelAccurate`. Slower than the fast level and worth it: the fast
+/// level is built for short strings in camera frames, not pages of body text.
+const RECOGNITION_LEVEL_ACCURATE: isize = 0;
+
+#[link(name = "CoreFoundation", kind = "framework")]
+unsafe extern "C" {
+	fn CFDataCreate(allocator: CFTypeRef, bytes: *const u8, length: isize) -> CFDataRef;
+	fn CFRelease(cf: CFTypeRef);
+}
+
+#[link(name = "CoreGraphics", kind = "framework")]
+unsafe extern "C" {
+	fn CGColorSpaceCreateDeviceRGB() -> CGColorSpaceRef;
+	fn CGColorSpaceRelease(space: CGColorSpaceRef);
+	fn CGDataProviderCreateWithCFData(data: CFDataRef) -> CGDataProviderRef;
+	fn CGDataProviderRelease(provider: CGDataProviderRef);
+	#[allow(clippy::too_many_arguments)]
+	fn CGImageCreate(
+		width: usize,
+		height: usize,
+		bits_per_component: usize,
+		bits_per_pixel: usize,
+		bytes_per_row: usize,
+		space: CGColorSpaceRef,
+		bitmap_info: u32,
+		provider: CGDataProviderRef,
+		decode: *const f64,
+		should_interpolate: bool,
+		intent: i32,
+	) -> CGImageRef;
+	fn CGImageRelease(image: CGImageRef);
+}
+
+// Linked for the Vision classes looked up by name below; nothing here calls into it directly.
+#[link(name = "Vision", kind = "framework")]
+unsafe extern "C" {}
+
+/// Vision has no documented input cap the way `Windows.Media.Ocr` does. This keeps a rendered
+/// page around the size of a 300 DPI letter scan, which is what the recognizer wants anyway and
+/// keeps one page's pixels near 40 MB rather than several times that.
+pub fn max_image_dimension() -> u32 {
+	4000
+}
+
+pub fn recognize_rgba(rgba: &[u8], width: u32, height: u32) -> Result<String, OcrError> {
+	let image = CgImage::new(rgba, width, height)?;
+	autoreleasepool(|| unsafe { recognize_image(image.0) })
+}
+
+/// A `CGImage` and the CoreGraphics objects behind it, released together.
+struct CgImage(CGImageRef);
+
+impl CgImage {
+	fn new(rgba: &[u8], width: u32, height: u32) -> Result<Self, OcrError> {
+		let length = isize::try_from(rgba.len()).map_err(|_| OcrError::Failed("bitmap too large".to_string()))?;
+		// CFDataCreate copies, so the image does not borrow from `rgba`.
+		let data = unsafe { CFDataCreate(ptr::null(), rgba.as_ptr(), length) };
+		if data.is_null() {
+			return Err(OcrError::Failed("allocating the bitmap failed".to_string()));
+		}
+		let provider = unsafe { CGDataProviderCreateWithCFData(data) };
+		let space = unsafe { CGColorSpaceCreateDeviceRGB() };
+		let image = if provider.is_null() || space.is_null() {
+			ptr::null_mut()
+		} else {
+			unsafe {
+				CGImageCreate(
+					width as usize,
+					height as usize,
+					8,
+					32,
+					width as usize * 4,
+					space,
+					K_CG_IMAGE_ALPHA_LAST,
+					provider,
+					ptr::null(),
+					false,
+					K_CG_RENDERING_INTENT_DEFAULT,
+				)
+			}
+		};
+		unsafe {
+			if !space.is_null() {
+				CGColorSpaceRelease(space);
+			}
+			if !provider.is_null() {
+				CGDataProviderRelease(provider);
+			}
+			CFRelease(data);
+		}
+		if image.is_null() {
+			return Err(OcrError::Failed("building the bitmap failed".to_string()));
+		}
+		Ok(Self(image))
+	}
+}
+
+impl Drop for CgImage {
+	fn drop(&mut self) {
+		unsafe { CGImageRelease(self.0) };
+	}
+}
+
+/// Runs one accurate text-recognition request over `image` and joins the recognized lines.
+unsafe fn recognize_image(image: CGImageRef) -> Result<String, OcrError> {
+	let request: *mut Object = msg_send![class!(VNRecognizeTextRequest), new];
+	if request.is_null() {
+		return Err(OcrError::Failed("Vision text recognition is unavailable".to_string()));
+	}
+	let _: () = msg_send![request, setRecognitionLevel: RECOGNITION_LEVEL_ACCURATE];
+	let _: () = msg_send![request, setUsesLanguageCorrection: true];
+	let options: *mut Object = msg_send![class!(NSDictionary), dictionary];
+	let handler: *mut Object = msg_send![class!(VNImageRequestHandler), alloc];
+	let handler: *mut Object = msg_send![handler, initWithCGImage: image options: options];
+	if handler.is_null() {
+		let _: () = msg_send![request, release];
+		return Err(OcrError::Failed("preparing the page for Vision failed".to_string()));
+	}
+	let requests: *mut Object = msg_send![class!(NSArray), arrayWithObject: request];
+	let mut error: *mut Object = ptr::null_mut();
+	let performed: bool = msg_send![handler, performRequests: requests error: &mut error];
+	let text = if performed { Ok(collect_text(request)) } else { Err(OcrError::Failed(error_message(error))) };
+	let _: () = msg_send![handler, release];
+	let _: () = msg_send![request, release];
+	text
+}
+
+/// Joins the top candidate of every recognized observation, one per line, in the order Vision
+/// reports them.
+unsafe fn collect_text(request: *mut Object) -> String {
+	let results: *mut Object = msg_send![request, results];
+	if results.is_null() {
+		return String::new();
+	}
+	let count: usize = msg_send![results, count];
+	let mut lines = Vec::with_capacity(count);
+	for index in 0..count {
+		let observation: *mut Object = msg_send![results, objectAtIndex: index];
+		let candidates: *mut Object = msg_send![observation, topCandidates: 1_usize];
+		if candidates.is_null() {
+			continue;
+		}
+		let candidate_count: usize = msg_send![candidates, count];
+		if candidate_count == 0 {
+			continue;
+		}
+		let candidate: *mut Object = msg_send![candidates, objectAtIndex: 0_usize];
+		let string: *mut Object = msg_send![candidate, string];
+		if let Some(line) = ns_string_to_rust(string) {
+			lines.push(line);
+		}
+	}
+	lines.join("\n")
+}
+
+unsafe fn error_message(error: *mut Object) -> String {
+	if error.is_null() {
+		return "recognition failed".to_string();
+	}
+	let description: *mut Object = msg_send![error, localizedDescription];
+	ns_string_to_rust(description).unwrap_or_else(|| "recognition failed".to_string())
+}
+
+unsafe fn ns_string_to_rust(string: *mut Object) -> Option<String> {
+	if string.is_null() {
+		return None;
+	}
+	let utf8: *const std::ffi::c_char = msg_send![string, UTF8String];
+	if utf8.is_null() {
+		return None;
+	}
+	Some(CStr::from_ptr(utf8).to_string_lossy().into_owned())
+}

--- a/crates/paperback/src/ui/ocr/unavailable.rs
+++ b/crates/paperback/src/ui/ocr/unavailable.rs
@@ -1,0 +1,15 @@
+//! The no-engine case: a build with neither Windows OCR nor Vision, which today means Linux.
+//!
+//! The parser tells those readers a page is image-only without offering OCR, and the menu item
+//! and the Enter binding are compiled out, so nothing should reach this module. It exists so the
+//! rest of the OCR code builds on every platform instead of being wrapped in `cfg` throughout.
+
+use super::OcrError;
+
+pub fn max_image_dimension() -> u32 {
+	0
+}
+
+pub fn recognize_rgba(_rgba: &[u8], _width: u32, _height: u32) -> Result<String, OcrError> {
+	Err(OcrError::Unavailable)
+}

--- a/crates/paperback/src/ui/ocr/windows.rs
+++ b/crates/paperback/src/ui/ocr/windows.rs
@@ -1,0 +1,112 @@
+//! The Windows OCR engine (`Windows.Media.Ocr`), reached through the `windows` crate.
+//!
+//! Recognition quality depends on the installed OCR language packs matching the document, and
+//! the API exposes no preprocessing or accuracy knobs, so there is nothing to tune here. The
+//! newer NPU-accelerated Windows AI text recognition would be faster and more accurate but
+//! needs Copilot+ class hardware and the Windows App SDK, so it stays out; swapping it in later
+//! means replacing this file and nothing else.
+
+use std::ptr::addr_of_mut;
+
+use windows::{
+	Graphics::Imaging::{BitmapBufferAccessMode, BitmapPixelFormat, SoftwareBitmap},
+	Media::Ocr::OcrEngine,
+	Win32::System::{
+		Com::{COINIT_MULTITHREADED, CoInitializeEx, CoUninitialize},
+		WinRT::IMemoryBufferByteAccess,
+	},
+	core::Interface,
+};
+
+use super::OcrError;
+
+/// What the engine reports as its largest accepted image side, or the documented 2600 px if it
+/// can't be read.
+pub fn max_image_dimension() -> u32 {
+	OcrEngine::MaxImageDimension().unwrap_or(2600)
+}
+
+/// Recognizes `rgba` on the calling thread, which must not already be COM-initialized: this
+/// sets up a multithreaded apartment and tears it down on the way out.
+pub fn recognize_rgba(rgba: &[u8], width: u32, height: u32) -> Result<String, OcrError> {
+	// A worker thread of ours, so the apartment is ours to set up. S_FALSE means it was already
+	// initialized compatibly, which is fine; only a hard error is worth reporting.
+	unsafe { CoInitializeEx(None, COINIT_MULTITHREADED) }
+		.ok()
+		.map_err(|err| OcrError::Failed(format!("COM init failed: {err}")))?;
+	let result = recognize_inner(rgba, width, height);
+	unsafe {
+		CoUninitialize();
+	}
+	result
+}
+
+fn recognize_inner(rgba: &[u8], width: u32, height: u32) -> Result<String, OcrError> {
+	let engine = create_engine()?;
+	let bitmap = build_bitmap(rgba, width, height)?;
+	let result = engine
+		.RecognizeAsync(&bitmap)
+		.and_then(|op| op.join())
+		.map_err(|err| OcrError::Failed(format!("recognition failed: {err}")))?;
+	let lines = result.Lines().map_err(|err| OcrError::Failed(format!("reading OCR lines failed: {err}")))?;
+	let mut text = String::new();
+	for line in lines {
+		let Ok(line_text) = line.Text() else {
+			continue;
+		};
+		text.push_str(&line_text.to_string_lossy());
+		text.push('\n');
+	}
+	Ok(text.trim_end().to_string())
+}
+
+/// Builds an engine for the user's profile languages, telling a missing language pack apart
+/// from a real failure: the API returns nothing at all when it has no recognizer to offer.
+fn create_engine() -> Result<OcrEngine, OcrError> {
+	match OcrEngine::TryCreateFromUserProfileLanguages() {
+		Ok(engine) => Ok(engine),
+		Err(err) => {
+			let has_any = OcrEngine::AvailableRecognizerLanguages().is_ok_and(|langs| langs.Size().unwrap_or(0) > 0);
+			if has_any {
+				Err(OcrError::Failed(format!("creating the OCR engine failed: {err}")))
+			} else {
+				Err(OcrError::NoLanguage)
+			}
+		}
+	}
+}
+
+/// Copies the rendered page into a `SoftwareBitmap` the engine can read.
+fn build_bitmap(rgba: &[u8], width: u32, height: u32) -> Result<SoftwareBitmap, OcrError> {
+	let expected = (width as usize) * (height as usize) * 4;
+	let bitmap = SoftwareBitmap::Create(
+		BitmapPixelFormat::Rgba8,
+		i32::try_from(width).map_err(|_| OcrError::Failed("bitmap width out of range".to_string()))?,
+		i32::try_from(height).map_err(|_| OcrError::Failed("bitmap height out of range".to_string()))?,
+	)
+	.map_err(|err| failed("creating the bitmap", &err))?;
+	let buffer = bitmap.LockBuffer(BitmapBufferAccessMode::Write).map_err(|err| failed("locking the bitmap", &err))?;
+	let reference = buffer.CreateReference().map_err(|err| failed("referencing the bitmap buffer", &err))?;
+	let access: IMemoryBufferByteAccess =
+		reference.cast().map_err(|err| failed("accessing the bitmap buffer", &err))?;
+	let mut data: *mut u8 = std::ptr::null_mut();
+	let mut capacity: u32 = 0;
+	unsafe { access.GetBuffer(addr_of_mut!(data), addr_of_mut!(capacity)) }
+		.map_err(|err| failed("reading the bitmap buffer", &err))?;
+	if data.is_null() || capacity as usize != expected {
+		return Err(OcrError::Failed(format!(
+			"bitmap buffer size mismatch (capacity {capacity}, expected {expected})"
+		)));
+	}
+	unsafe {
+		std::ptr::copy_nonoverlapping(rgba.as_ptr(), data, expected);
+	}
+	// The write lock and its buffer references drop as this returns, before the engine reads
+	// the bitmap.
+	Ok(bitmap)
+}
+
+/// Wraps a `WinRT` error with the step that produced it, for the log.
+fn failed(context: &str, err: &windows::core::Error) -> OcrError {
+	OcrError::Failed(format!("{context}: {err}"))
+}

--- a/crates/paperback/src/ui/reader_input.rs
+++ b/crates/paperback/src/ui/reader_input.rs
@@ -32,6 +32,19 @@ pub(super) fn build_text_ctrl(
 	text_ctrl.on_char(move |event| {
 		if let WindowEventData::Keyboard(kbd) = event {
 			if kbd.get_key_code() == Some(13) || kbd.get_key_code() == Some(32) {
+				// Enter on an image-only page runs OCR instead of the table/link activation
+				// below. Enter only; Space keeps its old behavior.
+				#[cfg(any(target_os = "windows", target_os = "macos"))]
+				if kbd.get_key_code() == Some(13) {
+					let on_placeholder = {
+						let dm = dm_for_enter.lock().unwrap();
+						dm.image_only_page_at_caret().is_some()
+					};
+					if on_placeholder {
+						dm_for_enter.lock().unwrap().start_ocr_for_current_page();
+						return;
+					}
+				}
 				let table_html = {
 					let dm = dm_for_enter.lock().unwrap();
 					dm.activate_current_table()

--- a/po/paperback.pot
+++ b/po/paperback.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: paperback 0.9.2\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-09-07 14:46+0000\n"
+"POT-Creation-Date: 2026-09-07 09:44-0600\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -611,6 +611,22 @@ msgstr[1] ""
 
 #. TRANSLATORS: Message/prompt shown in the file picker dialog to locate a missing book
 msgid "Locate Book"
+msgstr ""
+
+#. TRANSLATORS: Title of the Batch OCR dialog
+msgid "Batch OCR"
+msgstr ""
+
+#. TRANSLATORS: Label for the starting page field of the Batch OCR range
+msgid "&Start page:"
+msgstr ""
+
+#. TRANSLATORS: Label for the ending page field of the Batch OCR range
+msgid "&End page:"
+msgstr ""
+
+#. TRANSLATORS: Label for the button that starts the batch OCR
+msgid "OCR"
 msgstr ""
 
 #. TRANSLATORS: Title of the Jump to Bookmark dialog
@@ -1247,6 +1263,47 @@ msgid_plural "This document contains %d words."
 msgstr[0] ""
 msgstr[1] ""
 
+#. TRANSLATORS: Announced when Enter is pressed on an OCR placeholder while OCR is already running
+msgid "OCR in progress."
+msgstr ""
+
+#. TRANSLATORS: Announced when batch OCR is triggered with no document open
+#. TRANSLATORS: Announced when Batch OCR is chosen with no document open
+msgid "No document open."
+msgstr ""
+
+#. TRANSLATORS: Announced when batch OCR is started while another OCR job is running
+msgid "OCR already in progress."
+msgstr ""
+
+#. TRANSLATORS: Announced when the chosen batch OCR range contains no image-only pages
+msgid "No image-only pages in the given range."
+msgstr ""
+
+#. TRANSLATORS: Batch OCR progress announcement; the two %d placeholders are the pages done and the total pages
+msgid "OCR %d of %d."
+msgstr ""
+
+#. TRANSLATORS: Announced after OCR replaces an image-only page with the recognized text
+msgid "OCR complete."
+msgstr ""
+
+#. TRANSLATORS: Announced when OCR runs on a page but finds no recognizable text
+msgid "No text found."
+msgstr ""
+
+#. TRANSLATORS: Announced when batch OCR is stopped early; %d is the number of pages recognized before it stopped
+msgid "Batch OCR stopped. %d page recognized."
+msgid_plural "Batch OCR stopped. %d pages recognized."
+msgstr[0] ""
+msgstr[1] ""
+
+#. TRANSLATORS: Announced after batch OCR finishes; %d is the number of pages recognized
+msgid "Batch OCR complete. %d page recognized."
+msgid_plural "Batch OCR complete. %d pages recognized."
+msgstr[0] ""
+msgstr[1] ""
+
 #. TRANSLATORS: Error message shown when the requested document file does not exist; {} is the file path
 msgid "File not found: {}"
 msgstr ""
@@ -1396,6 +1453,10 @@ msgstr ""
 
 #. TRANSLATORS: Announced when opening the Table of Contents for a document that has none
 msgid "No table of contents."
+msgstr ""
+
+#. TRANSLATORS: Confirmation asked when Batch OCR is chosen while a batch is already running
+msgid "Batch OCR is running. Stop it?"
 msgstr ""
 
 #. TRANSLATORS: Title of the window that renders a document's content as HTML (e.g. for embedded web pages)
@@ -1852,6 +1913,10 @@ msgstr ""
 msgid "&Sleep Timer..."
 msgstr ""
 
+#. TRANSLATORS: Tools menu item that opens the Batch OCR dialog for image-only PDF pages
+msgid "&Batch OCR..."
+msgstr ""
+
 #. TRANSLATORS: Top-level "File" menu label in the menu bar
 msgid "&File"
 msgstr ""
@@ -2031,6 +2096,18 @@ msgid "Past end of container."
 msgstr ""
 
 msgid "Start of container."
+msgstr ""
+
+#. TRANSLATORS: Announced when OCR can't run because the system has no OCR language installed
+msgid "No OCR language is installed. Add one in your system language settings."
+msgstr ""
+
+#. TRANSLATORS: Announced when the OCR engine fails on a page
+msgid "OCR failed."
+msgstr ""
+
+#. TRANSLATORS: Announced when OCR is requested on a system that has no OCR engine
+msgid "OCR is not available on this system."
 msgstr ""
 
 #. TRANSLATORS: Title of the dialog showing the HTML rendering of a table activated in the document
@@ -2384,6 +2461,10 @@ msgid "Sleep Timer..."
 msgstr ""
 
 #. TRANSLATORS: Name of this keyboard-shortcut action, shown in the Customize Keyboard Shortcuts dialog (its list of assignable actions, and the "Set Shortcut for {}" / conflict-reassignment prompts).
+msgid "Batch OCR..."
+msgstr ""
+
+#. TRANSLATORS: Name of this keyboard-shortcut action, shown in the Customize Keyboard Shortcuts dialog (its list of assignable actions, and the "Set Shortcut for {}" / conflict-reassignment prompts).
 msgid "Customize Keyboard Shortcuts..."
 msgstr ""
 
@@ -2441,6 +2522,14 @@ msgstr ""
 
 #. TRANSLATORS: Shown in the Customize Keyboard Shortcuts list in place of a key combination when an action has no shortcut assigned
 msgid "None"
+msgstr ""
+
+#. TRANSLATORS: Line shown in place of a scanned PDF page with no text layer; Enter on it runs OCR
+msgid "[Image only. Press enter to OCR.]"
+msgstr ""
+
+#. TRANSLATORS: Line shown in place of a scanned PDF page with no text layer, where the system has no OCR engine
+msgid "[Image only. This page has no text to read.]"
 msgstr ""
 
 #. TRANSLATORS: Label inserted before a figure or image's description, e.g. "[Figure: a cat sleeping]"
@@ -2616,10 +2705,6 @@ msgstr ""
 
 #. TRANSLATORS: Error shown when a PDF fails to open for a reason other than a password; {} is the underlying error detail
 msgid "Failed to open PDF document: {}"
-msgstr ""
-
-#. TRANSLATORS: Notice inserted into the extracted text when a PDF has images but no text layer at all
-msgid "This PDF contains images only, with no extractable text. You may need to run it through OCR software to read its contents."
 msgstr ""
 
 msgid "Password-protected PPT files are not currently supported. Try saving the file as PPTX and opening that instead."
@@ -2818,7 +2903,7 @@ msgstr ""
 msgid "Switch to Text Mode"
 msgstr ""
 
-#. TRANSLATORS: Navigation bar title of the recent documents screen
+#. TRANSLATORS: Menu item to open the list of recently opened documents
 #: swift
 msgid "Recent Documents"
 msgstr ""
@@ -2883,7 +2968,7 @@ msgstr ""
 msgid "Locate"
 msgstr ""
 
-#. TRANSLATORS: Swipe action to remove a document from the recent documents list
+#. TRANSLATORS: Button to remove a document from the recent documents list
 #: swift
 msgid "Remove"
 msgstr ""
@@ -3440,7 +3525,7 @@ msgstr ""
 msgid "words"
 msgstr ""
 
-#. TRANSLATORS: TalkBack label for the button that dismisses the in-document search bar
+#. TRANSLATORS: Accessibility action on a text line to dismiss the in-document search
 #: kt
 msgid "Close Search"
 msgstr ""


### PR DESCRIPTION
# OCR for image-only PDF pages (per-page and batch)

For a scanned PDF (images only, no text layer), this adds OCR on Windows using the built-in `Windows.Media.Ocr` engine — both per-page and in bulk. I know it's only Windows, but hopefully this proof of concept still helps. This feature would be huge for many.

## What it does

**Per-page (Enter):**
- Each PDF page that **contains an image but no extractable text** now shows a placeholder line instead of the old single document-wide notice:
  `[Image only. Press enter to OCR.]`
- Pressing **Enter** while the caret is on that placeholder renders the page to a bitmap via pdfium, runs Windows OCR on a background thread (the UI doesn't freeze), and replaces the placeholder in the document with the recognized text, line by line.
- If OCR finds no text on the page, the placeholder stays and the app announces "No text found."

**Batch (Tools → Batch OCR…, default shortcut Ctrl+Shift+O):**
- A dialog lets you pick a **start** and **end** page, pre-filled with the whole document (1 → last page), and OCRs every image-only page in the range in one go.
- Runs on a background thread with **spoken progress** every 20 pages ("OCR 40 of 120.") and a final "Batch OCR complete. N pages recognized." — no progress-bar UI, matching the app's screen-reader-first design.
- Pages that already have text (or were already OCR'd) are skipped automatically; the shortcut is remappable in Customize Keyboard Shortcuts like any other action.

## What's new under the hood

This introduces the document buffer's **first mutation API** — until now parsed documents were effectively read-only:

- `DocumentBuffer::replace_range` (`paperback-core`) replaces a span in display units, rebuilds the per-char index tables, and shifts markers/`id_positions` that follow the edit.
- `DocumentSession::{replace_range, line_bounds_at, line_text_at}` — display-unit-correct line helpers (the existing `get_line_text` treats its argument as a char index, which misaligns after astral characters).
- A Windows OCR module in the desktop app that fills a WinRT `SoftwareBitmap` from the pdfium RGBA render and runs `OcrEngine` on a worker thread, marshalling results back with `wxdragon::call_after`.
- Batch OCR re-resolves each page's marker position as earlier pages grow, so offsets stay correct even when earlier replacements shift later pages.
- Results are applied in the context of the sliding text window: replaced spans on screen trigger a reload; edits before the current window shift it by the length delta.

## Windows OCR notes (read before judging quality)

- **We use the default engine with no quality tweaks.** `Windows.Media.Ocr` exposes no preprocessing or accuracy settings, and we deliberately make no attempt to tune it — I don't know anything about tuning that API.
- Pages are rendered to the engine at ~210 DPI (within its ~2600px maximum input dimension; larger inputs are silently downscaled).
- Recognition quality ultimately depends on the **installed OCR language packs matching the document's language** (the engine uses the user's profile languages; there's no language picker yet).
- The newer NPU-accelerated **Windows AI Text Recognition** API is reportedly faster and more accurate but requires Copilot+-class hardware (40+ TOPS) plus the Windows App SDK, so it's out of scope here; the engine call is isolated in one function, so swapping it later would be contained.

## Not included (out of scope for this pass)

- OCR results are **not persisted** — reopening the PDF shows the placeholders again. This is how I think it should stay since we don't want to get into saving new PDF files and stuff.
- No UI to choose the OCR language.
- Batch OCR has no cancel button (single-page OCR can't run mid-batch; the app announces "OCR in progress"). What's the best way to do this... replace Batch OCR in the Tools menu with Cancel Batch OCR?

## Testing

Tested on Windows 11 with NVDA against an image-only PDF: placeholder announced per image page; Enter runs OCR and the recognized text replaces the placeholder in the richedit; line and page navigation (`p`) read the OCR'd text; Tools → Batch OCR (Ctrl+Shift+O) OCRs a whole range with spoken progress and skips already-text pages. Windows-only feature.
