### PR TITLE
Stop asking macOS for a Windows-only media backend

### DIFF
--- a/crates/paperback/src/audio_player.rs
+++ b/crates/paperback/src/audio_player.rs
@@ -60,13 +60,9 @@ impl AudioPlayer {
 		// Hidden and unfocusable so it never surfaces to a screen reader, but deliberately
 		// *not* zero-sized: some Windows backends build an internal renderer window sized to
 		// the control, and a 0x0 one can leave `Load()` in flight with no `Loaded` event.
-		//
-		// WMP10 is requested explicitly rather than letting wxMediaCtrl fall back to its
-		// default "AM" backend, which never fires `MEDIA_LOADED` for audio-only files on
-		// modern Windows and so wedges every load after the first.
 		let media = MediaCtrl::builder(parent)
 			.with_style(MediaCtrlStyle::NoAutoResize)
-			.with_backend_name("wxWMP10MediaBackend")
+			.with_backend_name(media_backend_name())
 			.build();
 		media.hide();
 		media.set_can_focus(false);
@@ -275,6 +271,33 @@ impl AudioPlayer {
 	}
 }
 
+/// The `wxMediaBackend` subclass to build `wxMediaCtrl` on, or `""` to let wxWidgets choose.
+///
+/// Naming a backend that isn't registered on the current platform is silently fatal, so this
+/// has to stay platform-accurate: `wxMediaCtrl::Create` looks the name up in the RTTI table
+/// and, on a miss, leaves its backend pointer null and returns `false`. The constructor form
+/// wxdragon calls throws that `false` away, so we get back a perfectly live control whose
+/// every `Load`/`Play`/`Seek` returns `false` with no error anywhere: a DAISY book that opens
+/// fine and simply never makes a sound.
+///
+/// Windows registers three backends and `wxMediaCtrl`'s own auto-selection settles on the
+/// "AM" (DirectShow) one, which never fires `MEDIA_LOADED` for audio-only files on modern
+/// Windows and so wedges every load after the first, so WMP10 is named explicitly there.
+#[cfg(target_os = "windows")]
+const fn media_backend_name() -> &'static str {
+	"wxWMP10MediaBackend"
+}
+
+/// Every non-Windows platform compiles in exactly one backend (`wxAVMediaBackend` on macOS,
+/// `wxGStreamerMediaBackend` on GTK), so auto-selection picks the right one and keeps picking
+/// it if upstream ever renames the class. Both fire the `MEDIA_LOADED` and `MEDIA_FINISHED`
+/// events this player is driven by, and neither carries the WMP10 seek bias compensated for
+/// in `native_seek_target_ms`.
+#[cfg(not(target_os = "windows"))]
+const fn media_backend_name() -> &'static str {
+	""
+}
+
 fn apply_seek(media: MediaCtrl, state: &Rc<RefCell<PlayerState>>, source_index: usize, seek_ms: u64, playing: bool) {
 	state.borrow_mut().last_seek_target = Some((source_index, seek_ms));
 	let native_seek_ms = native_seek_target_ms(&media, seek_ms);
@@ -288,7 +311,7 @@ fn apply_seek(media: MediaCtrl, state: &Rc<RefCell<PlayerState>>, source_index: 
 }
 
 /// `wxWMP10MediaBackend::SetPosition` (the only Windows backend that reliably plays
-/// audio-only DAISY sources, see `AudioPlayer::new`) subtracts a full video frame's
+/// audio-only DAISY sources, see `media_backend_name`) subtracts a full video frame's
 /// worth of time (`1000 / playback_rate` ms) from every seek target before applying it.
 /// It's a workaround upstream added so video controls redraw the correct frame after a
 /// seek (`src/msw/mediactrl_wmp10.cpp`, `SetPosition`), fired unconditionally even for


### PR DESCRIPTION
DAISY audio playback is silently dead on macOS: the book opens, the timeline tracks, nothing ever plays.

`AudioPlayer::new` hardcoded `"wxWMP10MediaBackend"` when building its `wxMediaCtrl`. That class is only registered on Windows, and naming a backend that isn't registered fails quietly rather than loudly:

- `wxMediaCtrl::Create` looks the name up with `wxClassInfo::FindClass` and, on a miss, sets `m_imp = nullptr` and returns `false` (`src/common/mediactrlcmn.cpp:91`).
- wxdragon builds the control through the **constructor** form (`new wxMediaCtrl(...)`), which discards that `false`. The pointer is non-null, so wxdragon's `assert!` passes and `AudioPlayer::new` returns `Ok`.
- Every wrapper method is `if (m_imp) ... return false;`, so `Load`/`Play`/`Seek`/`Tell` all no-op.

The only trace was a `media control refused to load audio source` warning in the log.

## Fix

Backend name is now chosen per platform via `media_backend_name()`, matching the existing `native_seek_target_ms` cfg pattern in the same file.

- **Windows** keeps its explicit WMP10 pin. It registers three backends, and auto-selection settles on the AM (DirectShow) one that never fires `MEDIA_LOADED` for audio-only files.
- **Everywhere else** passes `""` and lets wxWidgets auto-select. macOS and GTK each compile in exactly one backend (`wxAVMediaBackend`, `wxGStreamerMediaBackend`), so auto-select is both correct today and robust to an upstream class rename.

Checked against the wxWidgets 3.3 sources that the build vendors, the rest of the player holds up on `wxAVMediaBackend`:

- `MEDIA_LOADED` fires (`observeValueForKeyPath` -> `FinishLoad()` -> `NotifyMovieLoaded()` on `AVPlayerItemStatusReadyToPlay`), so the seek-after-load path in `on_loaded` works.
- `MEDIA_FINISHED` fires (`playerItemDidReachEnd:` -> `QueueFinishEvent()`), so chapter advance works.
- `native_seek_target_ms`'s frame-bias compensation is correctly Windows-only: `wxAVMediaBackend::SetPosition` is a plain `seekToTime:` with `kCMTimeZero` tolerance.
- Hiding the control is safe; `AVPlayer` plays audio regardless of layer visibility.
- Paths with spaces are safe; `wxURI` percent-escapes on parse before `[NSURL URLWithString:]`.

## Testing

`cargo clippy --release --all-targets` and `cargo +nightly fmt --check` are clean locally on Windows, with no new warnings. The non-Windows arm was compiled locally by temporarily flipping the cfg predicates; CI's `test-macos` and `build-macos` jobs cover it for real.

Not yet verified by ear on a Mac with an actual DAISY book, which is the one thing this needs before it can be called done.

https://claude.ai/code/session_014gsyZq6qPmFeeaiCkC3pjp
