### PR TITLE
Repair the Polish translation and bring its help up to 0.9.0

### DIFF
--- a/doc/readme-pl.md
+++ b/doc/readme-pl.md
@@ -1,4 +1,4 @@
-# Paperback - wersja 0.8.5
+# Paperback - wersja 0.9.0
 
 ## Wprowadzenie
 
@@ -6,59 +6,77 @@ Paperback to lekki, szybki i dostępny czytnik e-booków i dokumentów dla wszys
 
 ## Wymagania systemowe
 
-Paperback działa obecnie w systemach Windows 10/11 i Linux. Obsługa systemu macOS jest planowana.
+Paperback działa obecnie w systemach Windows 10/11 oraz we wszystkich nowoczesnych wersjach macOS na procesorach ARM. Trwają intensywne prace nad natywnymi aplikacjami dla systemów iOS i Android. Publiczne wersje testowe są planowane niedługo po wydaniu wersji 0.9.0 na komputery. Nastąpi to przed wspólnym wydaniem 1.0, które obejmie wszystkie cztery platformy.
 
 ## Funkcje
 
 * Całkowicie samodzielna aplikacja, która nie wymaga instalowania dodatkowego oprogramowania na komputerze, aby zacząć czytać.
 * Bardzo szybkie działanie, nawet na starszym sprzęcie.
-* Prosty interfejs z kartami, który pozwala otworzyć obok siebie tyle dokumentów, ile potrzebujesz.
-* Zapisuje pozycję kursora w każdym otwieranym dokumencie.
+* Prosty interfejs z kartami, który pozwala otworzyć obok siebie tyle dokumentów, ile chcesz.
+* Zapisuje dokładną pozycję czytania w każdym otwieranym dokumencie.
 * Opcjonalnie zapamiętuje dokumenty otwarte przy zamknięciu programu i przywraca je przy następnym uruchomieniu.
-* Zaprojektowany przez użytkownika czytnika ekranu dla użytkowników czytników ekranu.
 * Zawiera funkcje nawigacji podobne do tych znanych z trybu przeglądania stron internetowych w wielu czytnikach ekranu, aby szybko i łatwo poruszać się po dokumentach.
 * Zawiera rozbudowany dialog Znajdź, między innymi z historią i obsługą wyrażeń regularnych.
 * Może działać w pełni przenośnie albo zostać zainstalowany z automatycznym skojarzeniem typów plików.
+* Obsługuje ogromną liczbę popularnych formatów plików.
+
+## Zgodność z czytnikami ekranu
+
+Paperback dobrze współpracuje ze wszystkimi głównymi czytnikami ekranu. Istnieje jednak jeden znany problem dotyczący użytkowników JAWS.
+
+### JAWS i linijki brajlowskie
+
+Jeśli używasz JAWS z linijką brajlowską, możesz zauważyć, że długie akapity są ucinane przy przesuwaniu w przód klawiszami nawigacji linijki. Dotyczy to również polecenia odczytu bieżącego akapitu. To błąd w obsłudze kontrolki tekstowej RICHEDIT50W po stronie JAWS, a nie w samym Paperbacku. Na rozwiązanie trzeba było długo czekać, przy znanej opieszałości firmy Vispero w odpowiadaniu na zgłoszenia dotyczące otwartego oprogramowania.
+
+Obejście, które po miesiącach oczekiwania wyszło w końcu na grupie dyskusyjnej JAWS, polega na edycji pliku `paperback.jcf` i ustawieniu opcji „Braille Presentation and Panning” na „Always use DOM if available”. Warto też włączyć „Pan Text by Paragraph”, bo inaczej linijka pozostanie na aktywnym akapicie, zamiast przesuwać się dalej. Przy obu ustawieniach przesuwanie linijki powinno działać poprawnie.
+
+Nazwy tych opcji podano po angielsku, bo tak brzmią w pliku konfiguracyjnym. W polskiej wersji JAWS ich etykiety w okienku ustawień mogą być przetłumaczone.
 
 ## Aktualnie obsługiwane typy plików
 
 Paperback obsługuje następujące formaty i rozszerzenia:
 
 * Pliki pomocy CHM (`.chm`)
+* Książki DAISY (`.opf`, `.zip`)
 * Książki EPUB (`.epub`)
 * E-booki FB2 (`.fb2`)
 * Dokumenty HTML (`.htm`, `.html`, `.xhtml`)
 * Dokumenty Markdown (`.md`, `.markdown`, `.mdx`, `.mdown`, `.mdwn`, `.mkd`, `.mkdn`, `.mkdown`, `.ronn`)
-* Dokumenty Microsoft Word (`.docx`, `.docm`)
+* Dokumenty Microsoft Word (`.docx`, `.docm`, `.doc`)
+* Książki MOBI/Kindle (`.mobi`, `.azw`, `.azw3`)
 * Prezentacje OpenDocument (`.odp`, `.fodp`)
 * Pliki tekstowe OpenDocument (`.odt`, `.fodt`)
 * Dokumenty PDF (`.pdf`)
-* Prezentacje PowerPoint (`.pptx`, `.pptm`)
+* Prezentacje PowerPoint (`.pptx`, `.pptm`, `.ppt`)
 * Dokumenty RTF (`.rtf`)
 * Pliki zwykłego tekstu i dzienników (`.txt`, `.log`)
-* Dokumenty XML (`.xml`)
 
 ## Skróty klawiszowe
 
-Paperback został zaprojektowany przede wszystkim do pracy z klawiaturą i czytnikiem ekranu. Poniżej znajdują się aktualne skróty.
+Paperback został zaprojektowany przede wszystkim do pracy z klawiaturą. Poniżej znajdują się aktualne skróty.
+
+Podane skróty dotyczą systemu Windows. Tam, gdzie macOS używa innych, odpowiednik podano w nawiasie. Wynika to głównie z tego, że skróty Ctrl+G, Ctrl+W oraz Alt+Strzałka w lewo i w prawo są w tym systemie zajęte przez inne konwencje systemowe lub aplikacyjne.
 
 ### Menu Plik
 
 * `Ctrl+O`: Otwórz dokument.
-* `Ctrl+F4`: Zamknij bieżący dokument.
-* `Ctrl+Shift+F4`: Zamknij wszystkie otwarte dokumenty.
+* `Ctrl+F4` (macOS: `Cmd+W`): Zamknij bieżący dokument.
+* `Ctrl+Shift+F4` (macOS: `Cmd+Shift+W`): Zamknij wszystkie otwarte dokumenty.
+* `Ctrl+Shift+T`: Otwórz ponownie ostatnio zamknięty dokument.
 * `Ctrl+R`: Pokaż dialog Wszystkie dokumenty (z menu Ostatnie dokumenty).
+* `Ctrl+Q`: Zakończ (tylko Windows; w systemie macOS znajduje się w menu aplikacji).
 
 ### Menu Przejdź
 
 * `Ctrl+F`: Pokaż dialog Znajdź.
-* `F3`: Znajdź następne.
-* `Shift+F3`: Znajdź poprzednie.
-* `Ctrl+G`: Przejdź do wiersza.
-* `Ctrl+Shift+G`: Przejdź do procentu.
+* `F3` (macOS: `Cmd+G`): Znajdź następne.
+* `Shift+F3` (macOS: `Cmd+Shift+G`): Znajdź poprzednie.
+* `Ctrl+G` (macOS: `Cmd+L`): Przejdź do wiersza.
+* `Ctrl+Shift+G` (macOS: `Cmd+Shift+L`): Przejdź do procentu.
 * `Ctrl+P`: Przejdź do strony (gdy jest obsługiwana przez bieżący dokument).
-* `Alt+Left`: Przejdź wstecz w historii nawigacji.
-* `Alt+Right`: Przejdź do przodu w historii nawigacji.
+* `=`: Odczytaj bieżącą pozycję procentową w dokumencie.
+* `Alt+Strzałka w lewo` (macOS: `Cmd+[`): Przejdź wstecz w historii nawigacji.
+* `Alt+Strzałka w prawo` (macOS: `Cmd+]`): Przejdź do przodu w historii nawigacji.
 * `[`: Poprzednia sekcja.
 * `]`: Następna sekcja.
 * `Shift+H`: Poprzedni nagłówek.
@@ -69,14 +87,20 @@ Paperback został zaprojektowany przede wszystkim do pracy z klawiaturą i czytn
 * `P`: Następna strona.
 * `Shift+B`: Poprzednia zakładka.
 * `B`: Następna zakładka.
+* `/`: Ustaw zakładkę tymczasową.
+* `\`: Przejdź do zakładki tymczasowej.
 * `Shift+N`: Poprzednia notatka.
 * `N`: Następna notatka.
 * `Ctrl+B`: Przejdź do wszystkich zakładek i notatek.
 * `Ctrl+Alt+B`: Przejdź tylko do zakładek.
 * `Ctrl+Alt+M`: Przejdź tylko do notatek.
-* `Ctrl+Shift+W`: Wyświetl tekst notatki w bieżącej pozycji.
+* `Ctrl+Shift+W` (macOS: `RawCtrl+Shift+W`, czyli fizyczny klawisz Control, a nie Cmd): Wyświetl tekst notatki w bieżącej pozycji.
 * `Shift+K`: Poprzedni odnośnik.
 * `K`: Następny odnośnik.
+* `Shift+G`: Poprzedni obraz.
+* `G`: Następny obraz.
+* `Shift+F`: Poprzedni rysunek.
+* `F`: Następny rysunek.
 * `Shift+T`: Poprzednia tabela.
 * `T`: Następna tabela.
 * `Shift+S`: Poprzedni separator.
@@ -85,21 +109,31 @@ Paperback został zaprojektowany przede wszystkim do pracy z klawiaturą i czytn
 * `L`: Następna lista.
 * `Shift+I`: Poprzedni element listy.
 * `I`: Następny element listy.
+* `Shift+,`: Przejdź na początek bieżącego kontenera (listy lub tabeli).
+* `,`: Przejdź poza koniec bieżącego kontenera (listy lub tabeli).
 
 ### Menu Narzędzia
 
-* `Ctrl+W`: Pokaż liczbę słów w bieżącym dokumencie.
+* `Ctrl+W` (macOS: `RawCtrl+W`, czyli fizyczny klawisz Control, a nie Cmd): Pokaż liczbę słów w bieżącym dokumencie.
 * `Ctrl+I`: Pokaż informacje o dokumencie.
 * `Ctrl+T`: Pokaż Spis treści.
 * `F7`: Pokaż Listę elementów.
 * `Ctrl+Shift+C`: Otwórz folder zawierający.
 * `Ctrl+Shift+V`: Otwórz bieżącą treść w Widoku WWW.
+* `Ctrl+U`: Wyświetl źródło dokumentu w nowej karcie.
 * `Ctrl+Shift+E`: Eksportuj dane dokumentu (`.paperback`).
 * `Ctrl+Shift+I`: Importuj dane dokumentu (`.paperback`).
 * `Ctrl+E`: Eksportuj bieżący dokument do zwykłego tekstu.
 * `Ctrl+Shift+B`: Przełącz zakładkę przy bieżącym zaznaczeniu lub kursorze.
-* `Ctrl+Shift+N`: Dodaj lub edytuj notatkę zakładki przy bieżącym zaznaczeniu lub kursorze.
-* `Ctrl+,`: Otwórz Opcje.
+* `Ctrl+Shift+N`: Dodaj lub edytuj notatkę do zakładki przy bieżącym zaznaczeniu lub kursorze.
+* `Ctrl+Alt+W`: Przełącz zawijanie wierszy.
+* `Ctrl+Spacja`: Odtwórz lub wstrzymaj narrację dźwiękową.
+* `'`: Przewiń narrację dźwiękową w przód.
+* `;`: Przewiń narrację dźwiękową w tył.
+* `Ctrl+'`: Zwiększ skok przewijania dźwięku.
+* `Ctrl+;`: Zmniejsz skok przewijania dźwięku.
+* `F11` (macOS: `RawCtrl+Ctrl+F`, czyli Control+Command+F): Przełącz tryb pełnoekranowy.
+* `Ctrl+,`: Otwórz Opcje (w systemie macOS: Preferencje, w menu aplikacji).
 * `Ctrl+Shift+S`: Przełącz Wyłącznik czasowy.
 
 ### Menu Pomoc
@@ -112,15 +146,15 @@ Paperback został zaprojektowany przede wszystkim do pracy z klawiaturą i czytn
 
 ### Dodatkowe klawisze w widoku dokumentu
 
-* `Delete` / `Numpad Delete` na kontrolce kart: zamknij kartę wybranego dokumentu.
-* `Enter` w tekście dokumentu: aktywuj odnośnik pod kursorem albo otwórz Widok tabeli, jeśli kursor znajduje się na znaczniku tabeli.
-* `Shift+F10` w tekście dokumentu: otwórz menu kontekstowe.
+* `Delete` / `Delete na klawiaturze numerycznej` na kontrolce kart: zamknij kartę wybranego dokumentu.
+* `Enter` albo `Spacja` w tekście dokumentu: aktywuj odnośnik pod kursorem albo otwórz Widok tabeli, jeśli kursor znajduje się na znaczniku tabeli.
+* `Shift+F10` albo klawisz Menu/Aplikacje w tekście dokumentu: otwórz menu kontekstowe.
 
 ## Obsługiwane języki
 
 Paperback jest tłumaczony na wiele języków, a kolejne są stale dodawane. Pełna lista znajduje się poniżej.
 
-Aby dowiedzieć się, jak pomóc w tłumaczeniu, przeczytaj [Przewodnik po tłumaczeniach](https://paperback.dev/translations/).
+Aby dowiedzieć się, jak pomóc w tłumaczeniu, przeczytaj [Przewodnik po tłumaczeniach](translating.md).
 
 * Bośniacki
 * Chiński uproszczony
@@ -128,6 +162,7 @@ Aby dowiedzieć się, jak pomóc w tłumaczeniu, przeczytaj [Przewodnik po tłum
 * Fiński
 * Francuski
 * Hiszpański
+* Holenderski
 * Japoński
 * Niemiecki
 * Polski
@@ -142,7 +177,7 @@ Aby dowiedzieć się, jak pomóc w tłumaczeniu, przeczytaj [Przewodnik po tłum
 * Aryan Choudhary: główny współtwórca.
 
 ### Darowizny
-Poniższe osoby przekazały darowizny na rozwój Paperbacka. Jeśli przekażesz darowiznę, Twoje imię i nazwisko nie zostanie tu dodane automatycznie. Dodaję tylko osoby, które chcą, aby ich wsparcie było publiczne.
+Poniższe osoby przekazały jakąkolwiek darowiznę na rozwój Paperbacka. Jeśli przekażesz darowiznę, Twoje imię i nazwisko nie zostanie tu dodane automatycznie. Dodaję tylko osoby, które chcą, aby ich wsparcie było publiczne.
 
 Uwaga: publiczne sponsorowanie w GitHub traktuję jako podstawę do automatycznego dodania do tej listy.
 
@@ -158,6 +193,7 @@ Uwaga: publiczne sponsorowanie w GitHub traktuję jako podstawę do automatyczne
 * Jonathan Rodriguez
 * Jonathan Schuster
 * Keao Wright
+* Michael Marshall
 * Pratik Patel
 * Roberto Perez
 * Sean Randall
@@ -165,6 +201,147 @@ Uwaga: publiczne sponsorowanie w GitHub traktuję jako podstawę do automatyczne
 * Tyler Rodick
 
 ## Lista zmian
+
+### Wersja 0.9.0
+
+#### Dodano
+
+##### Ogólne
+* Narzędzie wiersza poleceń o nazwie pb, które szybko przekształca dowolny format obsługiwany przez Paperbacka na HTML, Markdown albo zwykły tekst.
+* Opcję ponownego wczytywania dokumentów zmienionych na dysku przez inne programy.
+* Opcję Wyświetl źródło, która otwiera źródło dokumentu w nowej karcie. Jest przydatna na przykład przy edytowaniu plików Markdown.
+* Tekst dokumentu jest teraz dzielony na strony, dzięki czemu książki liczące dziesiątki milionów słów wczytują się w kilka sekund. Prosimy o zgłaszanie wszelkich nieprawidłowości związanych z tą zmianą.
+
+##### Obsługa platform
+* Obsługę systemu Windows na procesorach ARM64!
+* Natywną obsługę systemu macOS!
+* Przełącznik trybu pełnoekranowego.
+
+##### Dialog Wszystkie dokumenty
+* Przycisk Zlokalizuj, który pozwala znaleźć brakujące książki po zmianie ich ścieżki.
+* Filtr statusu i pasek statusu, dzięki którym można filtrować dokumenty według statusu oraz sprawdzić, ile dokumentów jest wyświetlanych i zaznaczonych.
+* Skrót `Ctrl+Shift+A`, który odznacza wszystkie dokumenty.
+
+##### Opcje i czytelność
+* Kartę czytelności z następującymi opcjami:
+    * zawijanie wierszy (przeniesione z karty ogólnej),
+    * wyświetlanie tabel w treści (nowość w tym wydaniu, opis poniżej),
+    * czcionka,
+    * kolor tła,
+    * odstęp między wierszami,
+    * odstęp między akapitami,
+    * odstęp między literami,
+    * wyrównanie tekstu.
+* Pozycję menu dla zawijania wierszy oraz przypisany do niej skrót klawiszowy.
+* Przełącznik sposobu wyświetlania tabel oraz ujednolicony wygląd tabel we wszystkich dokumentach.
+
+##### Nawigacja
+* Obsługę nawigacji po kontenerach.
+* Opcję automatycznego przenoszenia kursora na początek wiersza przy przechodzeniu między wierszami, podobnie jak w trybie przeglądania w czytnikach ekranu.
+* Skrót klawiszowy ze znakiem równości, który odczytuje bieżącą pozycję procentową w dokumencie.
+
+##### Zakładki
+* Zakładki tymczasowe: można mieć jedną na dokument i zostaje ona zapamiętana między uruchomieniami. Ukośnik ustawia zakładkę, a ukośnik odwrotny przenosi do niej.
+
+##### Liczba słów
+* Szacowany czas czytania w dialogu liczby słów oraz możliwość ustawienia własnej szybkości czytania, dzięki której ta informacja staje się naprawdę użyteczna.
+* Gdy przy otwieraniu dialogu liczby słów aktywne jest zaznaczenie, pokazywana jest też liczba zaznaczonych słów.
+
+##### Skróty klawiszowe
+* Możliwość dostosowania każdego skrótu klawiszowego w aplikacji za pomocą prostego dialogu.
+* Konfigurowalny skrót klawiszowy przywracający Paperbacka z zasobnika systemowego.
+
+##### Języki
+* Holenderski, fiński i polski.
+
+##### Eksport
+* Rozszerzono pozycję menu eksportu, aby umożliwić eksport do HTML i Markdown, obok zwykłego tekstu.
+
+##### Aktualizator
+* Przycisk anulowania w dialogu trwającej aktualizacji.
+* Aktualizator sprawdza teraz, czy w pobrany plik nikt nie ingerował.
+
+##### Widok WWW
+* Widok WWW otwiera się teraz na bieżącej pozycji czytania.
+
+##### Książki DAISY
+* Obsługę książek DAISY 2.0.
+* Obsługę odtwarzania dźwięku w formacie DAISY 2.02.
+
+##### Audiobooki
+* Możliwość odtwarzania audiobooków. Obsługiwane są audiobooki DAISY, również z tekstem, oraz archiwa ZIP z plikami dźwiękowymi.
+* Skróty klawiszowe i pozycje menu do odtwarzania i wstrzymywania narracji, przewijania w przód i w tył oraz zmiany skoku przewijania.
+* Opcje synchronizacji kursora czytania z odtwarzanym dźwiękiem, ustawienia skoku przewijania oraz wyboru, czy przewijanie poza koniec rozdziału przenosi do następnego.
+
+##### Dokumenty CHM
+* Obsługę list, elementów list, rysunków i obrazów.
+
+##### PowerPoint
+* Dokumenty PowerPoint obsługują teraz tabele.
+
+#### Naprawiono
+
+##### Ogólne
+* Dokumenty zapisane w starszych kodowaniach chińskich, japońskich i koreańskich, takich jak GBK, Big5 i Shift_JIS, wyświetlają się teraz poprawnie, a nie jako ciąg nieczytelnych znaków.
+* Polecenie „Otwórz ponownie ostatnio zamknięty”, które próbowało otwierać dołączony plik pomocy.
+* Wybrana karta nie otrzymywała poprawnie fokusa po ponownym uruchomieniu Paperbacka.
+* Obsługę plików na dyskach sieciowych Windows: polecenie pokazania pliku w folderze prawidłowo wskazuje teraz plik na dysku sieciowym, a ścieżki nie zawierają już dziwnych znaków.
+* Pliki .paperback nie są już wczytywane samoczynnie przy przywracaniu dokumentów. Zamiast tego po znalezieniu takiego pliku pojawia się pytanie o potwierdzenie.
+* Polecenie otwarcia folderu zawierającego wskazuje teraz dany plik w Eksploratorze.
+* Otwarcie pliku pomocy uwzględnia teraz wybrany język.
+* Interfejs Paperbacka skaluje się teraz poprawnie na ekranach o dużej gęstości pikseli.
+* Menu aktualizuje się teraz prawidłowo, a fokus przenosi się na kontrolkę tekstu przy otwieraniu pomocy w Paperbacku.
+* Zastosowano znacznie bezpieczniejszą metodę komunikacji między procesami w systemie Windows.
+* Tytuł aktywnego dokumentu jest teraz odczytywany przy przechodzeniu między kartami.
+* Zmniejszono zużycie pamięci przy dużych dokumentach przez zmniejszenie o połowę wewnętrznych tablic indeksu znaków.
+
+##### Dialog Wszystkie dokumenty
+* Klawisz Escape nie zamykał dialogów Informacje o dokumencie i Wszystkie dokumenty.
+* Pasek tytułu nie aktualizował się po zamknięciu dokumentu z dialogu Wszystkie dokumenty.
+* Plik readme.html nie będzie już dodawany do listy wszystkich dokumentów po otwarciu skrótem Shift+F1.
+* Usunięcie dokumentu z dialogu ostatnich dokumentów zamyka teraz również jego aktywną kartę.
+* Filtr wyszukiwania jest teraz zachowywany po usunięciu dokumentu.
+
+##### Nawigacja
+* Odczytywanie nieprawidłowego tekstu wiersza przy nawigacji po stronach w niektórych sytuacjach.
+* Ustawianie kursora w niewłaściwym miejscu przez polecenia Przejdź do wiersza, Przejdź do strony i Przejdź do procentu w dużych dokumentach.
+* Nieuwzględnianie wczytanego fragmentu dokumentu przez polecenia Znajdź i Znajdź następne w dużych dokumentach.
+
+##### Zakładki
+* Dźwięki zakładek i notatek odtwarzają się teraz wyłącznie przy przejściu przez słowo, które je zawiera.
+
+##### Czytelność
+* Przeskok na początek dokumentu przy włączaniu zawijania wierszy.
+
+##### Widok WWW
+* Okna Widoku WWW nie dało się rozciągnąć, a otwierało się w bardzo małym rozmiarze.
+* Obrazy wyświetlają się teraz poprawnie w osadzonym Widoku WWW.
+
+##### Aktualizator
+* Aktualizator pokazuje teraz poprawnie treść znaczników kodu w informacjach o wydaniu.
+
+##### Książki DAISY
+* Nieprawidłowe informacje na pasku statusu przy książkach DAISY.
+* Wczytywanie książek DAISY z błędnymi deklaracjami kodowania.
+
+##### Dokumenty RTF
+* Przetwarzanie dokumentów RTF ze znakami spoza alfabetu łacińskiego.
+* Grupy `\pict` w RTF, dzięki czemu dane osadzonych obrazów nie trafiają już do tekstu dokumentu.
+
+##### Książki Mobi/AZW3
+* Kotwice pozycji w pliku (filepos) w książkach Mobi, które rozrywały znaczniki HTML i wstawiały śmieci do tekstu książki.
+* Odnośniki w starszych książkach Mobi.
+* Znacznie ulepszono przetwarzanie plików AZW3.
+
+##### Dokumenty Word
+* Dokumenty Word z nazwami stylów zależnymi od języka, w których nagłówki nie wyświetlały się poprawnie.
+
+##### Dokumenty HTML/XHTML
+* Elementy HTML o nazwach dl, dt i dd, które nie powodowały podziału wiersza w dokumentach XHTML.
+
+##### Dokumenty PDF
+* Paperback wraca teraz do zwykłego wyodrębniania tekstu w przypadku błędnie otagowanych plików PDF.
+* Dokumenty PDF zawierające znaki sterujące w tytułach lub zakładkach nie powodują już awarii Paperbacka przy otwieraniu.
 
 ### Wersja 0.8.5
 * Dodano obsługę stron w książkach EPUB.
@@ -254,7 +431,7 @@ Uwaga: publiczne sponsorowanie w GitHub traktuję jako podstawę do automatyczne
 
 ### Wersja 0.6.1
 * Dodano obsługę plików PDF chronionych hasłem!
-* Dodano bardzo prostą funkcję przechodzenia do poprzedniej/następnej pozycji. Jeśli naciśniesz `Enter` na odnośniku wewnętrznym i kursor zostanie przeniesiony, ta pozycja zostanie zapamiętana i będzie można do niej wracać za pomocą `Alt+Left`/`Alt+Right`.
+* Dodano bardzo prostą funkcję przechodzenia do poprzedniej/następnej pozycji. Jeśli naciśniesz `Enter` na odnośniku wewnętrznym i kursor zostanie przeniesiony, ta pozycja zostanie zapamiętana i będzie można do niej wracać za pomocą `Alt+Strzałka w lewo`/`Alt+Strzałka w prawo`.
 * Dodano Listę elementów! Obecnie pokazuje tylko drzewo wszystkich nagłówków w dokumencie albo listę odnośników, ale w przyszłości planowane jest jej rozszerzenie.
 * Dodano opcję uruchamiania Paperbacka w zmaksymalizowanym oknie domyślnie.
 * Naprawiono nieprawidłowe działanie odnośników w niektórych dokumentach EPUB.
@@ -293,7 +470,7 @@ Uwaga: publiczne sponsorowanie w GitHub traktuję jako podstawę do automatyczne
 * Wprowadzono wiele wewnętrznych refaktoryzacji, dzięki którym aplikacja jest szybsza, a plik binarny mniejszy.
 * Treść Markdown jest teraz wstępnie przetwarzana do zgodności z CommonMark przed renderowaniem.
 * Nawigacja po listach i ich elementach jest teraz w pełni obsługiwana. Użyj `L` i `Shift+L`, aby przechodzić po listach, oraz `I` i `Shift+I`, aby przechodzić po elementach listy.
-* `Numpad Delete` działa teraz przy usuwaniu dokumentów z paska kart, tak samo jak zwykły `Delete`.
+* `Delete na klawiaturze numerycznej` działa teraz przy usuwaniu dokumentów z paska kart, tak samo jak zwykły `Delete`.
 * Paperback może teraz opcjonalnie minimalizować się do zasobnika systemowego. Ta opcja jest domyślnie wyłączona, ale po jej włączeniu minimalizacja z menu systemowego przenosi Paperback do zasobnika, skąd można go przywrócić kliknięciem utworzonej ikony.
 * Paperback jest teraz w pełni tłumaczalny! Lista obsługiwanych języków jest obecnie dość krótka, ale stale rośnie.
 * Paperback ma teraz oficjalną stronę: [paperback.dev](https://paperback.dev)!

--- a/po/pl.po
+++ b/po/pl.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: paperback 0.8.5\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-11 20:06+0000\n"
+"POT-Creation-Date: 2026-08-29 11:48-0600\n"
 "PO-Revision-Date: 2026-06-08 13:45+0200\n"
 "Last-Translator: Michał Dziwisz <michal@dziwisz.net>\n"
 "Language-Team: Polish\n"
@@ -36,14 +36,6 @@ msgstr "Wszystkie dokumenty"
 msgid "&search"
 msgstr "&Szukaj"
 
-#. TRANSLATORS: Label for the confirmation dialog "Yes" button
-msgid "&Yes"
-msgstr "&Tak"
-
-#. TRANSLATORS: Label for the confirmation dialog "No" button
-msgid "&No"
-msgstr "&Nie"
-
 #. TRANSLATORS: Column header for the document filename in the All Documents list
 msgid "File Name"
 msgstr "Nazwa pliku"
@@ -56,42 +48,14 @@ msgstr "Status"
 msgid "Path"
 msgstr "Ścieżka"
 
-#. TRANSLATORS: Button label to open the selected document
-msgid "&Open"
-msgstr "&Otwórz"
+#. TRANSLATORS: Label for the status filter dropdown in the All Documents dialog
+msgid "&Status:"
+msgstr "&Status:"
 
-#. TRANSLATORS: Button label to locate a missing file on disk
-#, fuzzy
-msgid "&Locate…"
-msgstr "&Znajdź…"
-
-#. TRANSLATORS: Button label to remove selected documents from the list
-msgid "&Remove"
-msgstr "&Usuń"
-
-#. TRANSLATORS: Button label to clear all documents from the list
-msgid "&Clear All"
-msgstr "&Wyczyść wszystko"
-
-#. TRANSLATORS: Label for a button that closes a dialog
-msgid "Close"
-msgstr "Zamknij"
-
-#, fuzzy
-msgid "Are you sure you want to remove the selected document? This will also remove its reading position and bookmarks."
-msgstr "Czy na pewno chcesz usunąć zaznaczony dokument? Spowoduje to również usunięcie pozycji czytania i zakładek."
-
-#, fuzzy
-msgid "Are you sure you want to remove the {} selected documents? This will also remove their reading positions and bookmarks."
-msgstr "Czy na pewno chcesz usunąć wybrane dokumenty z listy „{}”? Spowoduje to również usunięcie ich pozycji czytania i zakładek."
-
-#. TRANSLATORS: Title of the confirmation dialog
-msgid "Confirm"
-msgstr "Potwierdzenie"
-
-#. TRANSLATORS: Confirmation prompt when clearing all documents from the list.
-msgid "Are you sure you want to remove all documents from the list? This will also remove all reading positions and bookmarks."
-msgstr "Czy na pewno chcesz usunąć wszystkie dokumenty z listy? Spowoduje to też usunięcie wszystkich pozycji czytania i zakładek."
+#. TRANSLATORS: Option in the All Documents status filter to show documents of every status
+#. TRANSLATORS: Option in the filter dropdown to show all entries
+msgid "All"
+msgstr "Wszystko"
 
 #. TRANSLATORS: Status of a document that is currently open in a tab
 msgid "Open"
@@ -105,10 +69,72 @@ msgstr "Zamknięty"
 msgid "Missing"
 msgstr "Brakujący"
 
+#. TRANSLATORS: Button label to open the selected document
+msgid "&Open"
+msgstr "&Otwórz"
+
+#. TRANSLATORS: Button label to locate a missing file on disk
+msgid "&Locate…"
+msgstr "&Zlokalizuj…"
+
+#. TRANSLATORS: Button label to remove selected documents from the list
+msgid "&Remove"
+msgstr "&Usuń"
+
+#. TRANSLATORS: Button label to clear all documents from the list
+msgid "&Clear All"
+msgstr "&Wyczyść wszystko"
+
+#. TRANSLATORS: Label for a button that closes a dialog
+msgid "Close"
+msgstr "Zamknij"
+
+msgid "Are you sure you want to remove the selected document? This will also remove its reading position and bookmarks."
+msgstr "Czy na pewno chcesz usunąć zaznaczony dokument? Spowoduje to też usunięcie jego pozycji czytania i zakładek."
+
+msgid "Are you sure you want to remove the {} selected documents? This will also remove their reading positions and bookmarks."
+msgstr "Czy na pewno chcesz usunąć zaznaczone dokumenty ({})? Spowoduje to też usunięcie ich pozycji czytania i zakładek."
+
+#. TRANSLATORS: Title of the confirmation dialog
+msgid "Confirm"
+msgstr "Potwierdzenie"
+
+#. TRANSLATORS: Confirmation prompt when clearing all documents from the list.
+msgid "Are you sure you want to remove all documents from the list? This will also remove all reading positions and bookmarks."
+msgstr "Czy na pewno chcesz usunąć wszystkie dokumenty z listy? Spowoduje to też usunięcie wszystkich pozycji czytania i zakładek."
+
+#. TRANSLATORS: Status bar text in the All Documents dialog when the list is empty
+msgid "No documents."
+msgstr "Brak dokumentów."
+
+#. TRANSLATORS: Status bar text in the All Documents dialog showing the total number of documents in the list. The %d placeholder is replaced with the count. Plural form is chosen by that count.
+msgid "%d document."
+msgid_plural "%d documents."
+msgstr[0] "%d dokument."
+msgstr[1] "%d dokumenty."
+msgstr[2] "%d dokumentów."
+
+#. TRANSLATORS: Status bar text in the All Documents dialog when the single document in the list is selected
+msgid "1 of 1 document selected."
+msgstr "Zaznaczono 1 z 1 dokumentu."
+
+#. TRANSLATORS: Status bar text in the All Documents dialog when every document in the list is selected. The %d placeholder is replaced with the total count. Plural form is chosen by that count.
+msgid "All %d document selected."
+msgid_plural "All %d documents selected."
+msgstr[0] "Zaznaczono wszystkie dokumenty (%d)."
+msgstr[1] "Zaznaczono wszystkie dokumenty (%d)."
+msgstr[2] "Zaznaczono wszystkie dokumenty (%d)."
+
+#. TRANSLATORS: Status bar text in the All Documents dialog showing how many of the total documents are selected. The first %d is the selected count, the second %d is the total count. Plural form is chosen by the total count.
+msgid "%d of %d document selected."
+msgid_plural "%d of %d documents selected."
+msgstr[0] "Zaznaczono %d z %d dokumentu."
+msgstr[1] "Zaznaczono %d z %d dokumentów."
+msgstr[2] "Zaznaczono %d z %d dokumentów."
+
 #. TRANSLATORS: Message/prompt shown in the file picker dialog to locate a missing book
-#, fuzzy
 msgid "Locate Book"
-msgstr "Znajdź książkę"
+msgstr "Zlokalizuj książkę"
 
 #. TRANSLATORS: Title of the Jump to Bookmark dialog
 msgid "Jump to Bookmark"
@@ -117,10 +143,6 @@ msgstr "Przejdź do zakładki"
 #. TRANSLATORS: Label for the bookmark filter dropdown
 msgid "&Filter:"
 msgstr "&Filtr:"
-
-#. TRANSLATORS: Option in the filter dropdown to show all entries
-msgid "All"
-msgstr "Wszystko"
 
 #. TRANSLATORS: Option in the filter dropdown to show bookmarks only
 msgid "Bookmarks"
@@ -131,7 +153,6 @@ msgid "Notes"
 msgstr "Notatki"
 
 #. TRANSLATORS: Label for the bookmark/note list (used only as an accessibility label on macOS)
-#, fuzzy
 msgid "&Bookmarks:"
 msgstr "&Zakładki:"
 
@@ -139,7 +160,6 @@ msgstr "&Zakładki:"
 msgid "&Edit Note"
 msgstr "&Edytuj notatkę"
 
-#. TRANSLATORS: Standard "Delete" edit menu item label
 msgid "&Delete"
 msgstr "&Usuń"
 
@@ -165,11 +185,11 @@ msgstr "Błąd"
 
 #. TRANSLATORS: Title of the Bookmark Note editor dialog
 msgid "Bookmark Note"
-msgstr "Notatka zakładki"
+msgstr "Notatka do zakładki"
 
 #. TRANSLATORS: Label/prompt in the Note editor dialog
 msgid "Edit bookmark note:"
-msgstr "Edytuj notatkę zakładki:"
+msgstr "Edytuj notatkę do zakładki:"
 
 #. TRANSLATORS: Title of the Document Info dialog
 msgid "Document Info"
@@ -236,16 +256,14 @@ msgid "&Line number:"
 msgstr "Numer &wiersza:"
 
 #. TRANSLATORS: Label for the button that jumps to the entered position (a line, page, or percentage, depending on the dialog)
-#, fuzzy
 msgid "Go"
-msgstr "Start"
+msgstr "Przejdź"
 
 #. TRANSLATORS: Title of the Go to page dialog
 msgid "Go to page"
 msgstr "Przejdź do strony"
 
 #. TRANSLATORS: Label/prompt template for the page selection dialog. The %d placeholders represent current_page and max_pages respectively.
-#, c-format
 msgid "Go to page (%d/%d):"
 msgstr "Przejdź do strony (%d/%d):"
 
@@ -289,9 +307,9 @@ msgstr "HTML"
 msgid "Markdown"
 msgstr "Markdown"
 
-#. TRANSLATORS: Title of the Options dialog
-msgid "Options"
-msgstr "Opcje"
+#. TRANSLATORS: Title of the Settings dialog
+msgid "Settings"
+msgstr "Ustawienia"
 
 #. TRANSLATORS: Option to restore documents that were open when the app was last closed
 msgid "&Restore previously opened documents on startup"
@@ -302,9 +320,8 @@ msgid "&Word wrap"
 msgstr "&Zawijanie wierszy"
 
 #. TRANSLATORS: Option to render tables inline rather than showing a placeholder link
-#, fuzzy
 msgid "Render tables &inline"
-msgstr "Tabelki renderowane i wbudowane"
+msgstr "Wyświetlaj tabele w &treści"
 
 #. TRANSLATORS: Option to minimize the app window to the system tray instead of the taskbar
 msgid "&Minimize to system tray"
@@ -323,26 +340,84 @@ msgid "&Wrap navigation"
 msgstr "Zawijaj &nawigację"
 
 #. TRANSLATORS: Option to move the caret to the start of the line when navigating up or down
-#, fuzzy
 msgid "Move to &start of line"
-msgstr "Przejdź do początku wiersza"
+msgstr "Przechodź na &początek wiersza"
 
 #. TRANSLATORS: Option to play sound effects when bookmarks or notes are encountered
 msgid "Play &sounds on bookmarks and notes"
 msgstr "Odtwarzaj &dźwięki przy zakładkach i notatkach"
+
+#. TRANSLATORS: Option to move the reading caret to follow along with audio narration as it plays
+msgid "&Sync caret to audio playback"
+msgstr "&Przesuwaj kursor za odtwarzanym dźwiękiem"
+
+#. TRANSLATORS: Label for the audio seek amount dropdown, used when skipping audio narration backward/forward
+msgid "&Audio seek amount:"
+msgstr "&Skok przewijania dźwięku:"
+
+#. TRANSLATORS: Audio seek amount option, shown in the audio seek amount dropdown
+#. TRANSLATORS: Audio seek amount, announced after changing it via keyboard shortcut
+msgid "5 seconds"
+msgstr "5 sekund"
+
+#. TRANSLATORS: Audio seek amount option, shown in the audio seek amount dropdown
+#. TRANSLATORS: Audio seek amount, announced after changing it via keyboard shortcut
+msgid "10 seconds"
+msgstr "10 sekund"
+
+#. TRANSLATORS: Audio seek amount option, shown in the audio seek amount dropdown
+#. TRANSLATORS: Audio seek amount, announced after changing it via keyboard shortcut
+msgid "30 seconds"
+msgstr "30 sekund"
+
+#. TRANSLATORS: Audio seek amount option, shown in the audio seek amount dropdown
+#. TRANSLATORS: Audio seek amount, announced after changing it via keyboard shortcut
+msgid "1 minute"
+msgstr "1 minuta"
+
+#. TRANSLATORS: Audio seek amount option, shown in the audio seek amount dropdown
+#. TRANSLATORS: Audio seek amount, announced after changing it via keyboard shortcut
+msgid "2 minutes"
+msgstr "2 minuty"
+
+#. TRANSLATORS: Audio seek amount option, shown in the audio seek amount dropdown
+#. TRANSLATORS: Audio seek amount, announced after changing it via keyboard shortcut
+msgid "5 minutes"
+msgstr "5 minut"
+
+#. TRANSLATORS: Audio seek amount option, shown in the audio seek amount dropdown
+#. TRANSLATORS: Audio seek amount, announced after changing it via keyboard shortcut
+msgid "10 minutes"
+msgstr "10 minut"
+
+#. TRANSLATORS: Audio seek amount option, shown in the audio seek amount dropdown
+#. TRANSLATORS: Audio seek amount, announced after changing it via keyboard shortcut
+msgid "30 minutes"
+msgstr "30 minut"
+
+#. TRANSLATORS: Audio seek amount option, shown in the audio seek amount dropdown
+#. TRANSLATORS: Audio seek amount, announced after changing it via keyboard shortcut
+msgid "1 hour"
+msgstr "1 godzina"
+
+#. TRANSLATORS: Option controlling whether seeking audio narration past the end of a chapter's file continues into the next chapter, or stops at the end of the current one
+msgid "Seeking &past the end of a chapter continues into the next"
+msgstr "Przewijanie &poza koniec rozdziału przenosi do następnego"
 
 #. TRANSLATORS: Option to check for app updates automatically on startup
 msgid "Check for &updates on startup"
 msgstr "Sprawdzaj &aktualizacje przy uruchomieniu"
 
 #. TRANSLATORS: Option to automatically reload an open document when its file changes on disk
-#, fuzzy
 msgid "&Automatically reload changed documents"
-msgstr "&Automatyczne odświeżanie zmienionych dokumentów"
+msgstr "&Automatycznie przeładowuj zmienione dokumenty"
 
 #. TRANSLATORS: Button label to open the hotkey customization dialog
 msgid "Customize &Window Hotkey..."
 msgstr "Dostosuj &skrót okna..."
+
+msgid "Customize &Keyboard Shortcuts..."
+msgstr "Dostosuj &skróty klawiszowe..."
 
 #. TRANSLATORS: Label for the reading speed input field (Words Per Minute)
 msgid "&Reading speed (words per minute):"
@@ -350,7 +425,7 @@ msgstr "&Szybkość czytania (słowa na minutę):"
 
 #. TRANSLATORS: Label for the number of recently opened documents to keep in history
 msgid "Number of &recent documents to show:"
-msgstr "Liczba &ostatnich dokumentów do pokazania:"
+msgstr "Liczba wyświetlanych &ostatnich dokumentów:"
 
 #. TRANSLATORS: Label for the language selection dropdown
 msgid "&Language:"
@@ -473,12 +548,10 @@ msgid "Default"
 msgstr "Domyślne"
 
 #. TRANSLATORS: Font description prefix; {} is the font face name
-#, fuzzy
 msgid "Font: {}"
-msgstr "Źródło: {}"
+msgstr "Czcionka: {}"
 
 #. TRANSLATORS: Point size attribute; {} is the numeric size, "pt" is the unit abbreviation
-#, fuzzy
 msgid "{}pt"
 msgstr "{} pt"
 
@@ -523,7 +596,6 @@ msgid "&Key:"
 msgstr "&Klawisz:"
 
 #. TRANSLATORS: Button label to clear the current hotkey selection
-#, fuzzy
 msgid "Clear"
 msgstr "Wyczyść"
 
@@ -534,6 +606,59 @@ msgstr "Anuluj"
 #. TRANSLATORS: Representation of the Spacebar key
 msgid "Space"
 msgstr "Spacja"
+
+msgid "Customize Keyboard Shortcuts"
+msgstr "Dostosuj skróty klawiszowe"
+
+msgid "&Shortcuts:"
+msgstr "&Skróty:"
+
+msgid "&Set Shortcut..."
+msgstr "&Ustaw skrót..."
+
+msgid "&Clear Shortcut"
+msgstr "&Usuń skrót"
+
+msgid "&Reset to Default"
+msgstr "&Przywróć domyślny"
+
+msgid "Reset &All to Defaults"
+msgstr "Przywróć &wszystkie domyślne"
+
+#. TRANSLATORS: the three {} are, in order: the key chord, the action it's currently assigned to, and the action being (re)assigned to it
+msgid "'{}' is already assigned to '{}'. Reassign it to '{}'?"
+msgstr "Skrót „{}” jest już przypisany do „{}”. Przypisać go do „{}”?"
+
+#. TRANSLATORS: Title of the dialog warning that a shortcut is already taken
+msgid "Shortcut Conflict"
+msgstr "Konflikt skrótów"
+
+msgid "Reset all shortcuts to their default values?"
+msgstr "Przywrócić wszystkim skrótom wartości domyślne?"
+
+msgid "Reset Shortcuts"
+msgstr "Przywracanie skrótów"
+
+msgid "Set Shortcut for {}"
+msgstr "Ustaw skrót dla {}"
+
+msgid "Configure shortcut for {}:"
+msgstr "Skonfiguruj skrót dla {}:"
+
+msgid "Tip: click in the key field and press the key combination you want."
+msgstr "Wskazówka: przejdź do pola klawisza i naciśnij wybraną kombinację klawiszy."
+
+msgid "Detected: (none)"
+msgstr "Rozpoznano: (brak)"
+
+msgid "Detected: {}"
+msgstr "Rozpoznano: {}"
+
+msgid "No key detected"
+msgstr "Nie rozpoznano klawisza"
+
+msgid "&Clear"
+msgstr "&Wyczyść"
 
 #. TRANSLATORS: Title of the Sleep Timer dialog
 msgid "Sleep Timer"
@@ -559,42 +684,44 @@ msgstr "Brak wyboru"
 msgid "View Note"
 msgstr "Wyświetl notatkę"
 
-#. TRANSLATORS: Singular label for 1 hour duration
-msgid "1 hour"
-msgstr "1 godzina"
+#. TRANSLATORS: Duration segment for hours in the estimated reading time (e.g. "1 hour" / "5 hours"). The %d placeholder is replaced with the count.
+msgid "%d hour"
+msgid_plural "%d hours"
+msgstr[0] "%d godzina"
+msgstr[1] "%d godziny"
+msgstr[2] "%d godzin"
 
-#. TRANSLATORS: Plural label for hours duration (e.g. "2 hours")
-msgid "hours"
-msgstr "godz."
+#. TRANSLATORS: Duration segment for minutes in the estimated reading time (e.g. "1 minute" / "5 minutes"). The %d placeholder is replaced with the count.
+msgid "%d minute"
+msgid_plural "%d minutes"
+msgstr[0] "%d minuta"
+msgstr[1] "%d minuty"
+msgstr[2] "%d minut"
 
-#. TRANSLATORS: Singular label for 1 minute duration
-msgid "1 minute"
-msgstr "1 minuta"
-
-#. TRANSLATORS: Plural label for minutes duration (e.g. "2 minutes")
-msgid "minutes"
-msgstr "min"
-
-#. TRANSLATORS: Singular label for 1 second duration
-msgid "1 second"
-msgstr "1 sekunda"
-
-#. TRANSLATORS: Plural label for seconds duration (e.g. "2 seconds")
-msgid "seconds"
-msgstr "s"
+#. TRANSLATORS: Duration segment for seconds in the estimated reading time (e.g. "1 second" / "5 seconds"). The %d placeholder is replaced with the count.
+msgid "%d second"
+msgid_plural "%d seconds"
+msgstr[0] "%d sekunda"
+msgstr[1] "%d sekundy"
+msgstr[2] "%d sekund"
 
 #. TRANSLATORS: Prompt showing estimated reading time. The {} placeholder is replaced with a formatted duration like "1 hour, 5 minutes".
 msgid "Estimated reading time: {}"
 msgstr "Szacowany czas czytania: {}"
 
-#. TRANSLATORS: Message template for selection word count. The {} placeholder is replaced with the number of words.
-#, fuzzy
-msgid "The selection contains {} words."
-msgstr "Zbiór zawiera {} słów."
+#. TRANSLATORS: Message template for selection word count. The %d placeholder is replaced with the number of words.
+msgid "The selection contains %d word."
+msgid_plural "The selection contains %d words."
+msgstr[0] "Zaznaczenie zawiera %d słowo."
+msgstr[1] "Zaznaczenie zawiera %d słowa."
+msgstr[2] "Zaznaczenie zawiera %d słów."
 
-#. TRANSLATORS: Message template for document word count. The {} placeholder is replaced with the number of words.
-msgid "This document contains {} words."
-msgstr "Ten dokument zawiera {} słów."
+#. TRANSLATORS: Message template for document word count. The %d placeholder is replaced with the number of words.
+msgid "This document contains %d word."
+msgid_plural "This document contains %d words."
+msgstr[0] "Ten dokument zawiera %d słowo."
+msgstr[1] "Ten dokument zawiera %d słowa."
+msgstr[2] "Ten dokument zawiera %d słów."
 
 #. TRANSLATORS: Title of the Word Count dialog
 msgid "Word Count"
@@ -624,7 +751,18 @@ msgstr "Przejście do odnośnika wewnętrznego."
 msgid "Ready"
 msgstr "Gotowe"
 
-#. TRANSLATORS: Title of the dialog showing a table rendered as HTML when activated with Enter/Space
+#. TRANSLATORS: Announced after setting a temporary bookmark at the current position
+msgid "Temporary bookmark set."
+msgstr "Ustawiono zakładkę tymczasową."
+
+#. TRANSLATORS: Announced when jumping to a temporary bookmark but none has been set
+msgid "No temporary bookmark."
+msgstr "Brak zakładki tymczasowej."
+
+#. TRANSLATORS: Fallback announcement when jumping to a temporary bookmark on a blank line
+msgid "Temporary bookmark."
+msgstr "Zakładka tymczasowa."
+
 msgid "Table View"
 msgstr "Widok tabeli"
 
@@ -640,12 +778,10 @@ msgid "Failed to load document."
 msgstr "Nie udało się wczytać dokumentu."
 
 #. TRANSLATORS: "File" label prefix in the document-load error dialog; {} is the file path
-#, fuzzy
 msgid "File: {}"
 msgstr "Plik: {}"
 
 #. TRANSLATORS: "Details" label prefix in the document-load error dialog; {} is the underlying error message
-#, fuzzy
 msgid "Details: {}"
 msgstr "Szczegóły: {}"
 
@@ -710,6 +846,9 @@ msgstr "Znajdź"
 msgid "Find &what:"
 msgstr "Znajdź &tekst:"
 
+msgid "Options"
+msgstr "Opcje"
+
 #. TRANSLATORS: Checkbox to make the search case-sensitive
 msgid "&Match case"
 msgstr "Uwzględniaj &wielkość liter"
@@ -736,12 +875,11 @@ msgstr "Nie znaleziono."
 
 #. TRANSLATORS: Announced when a search reaches the end of the document and wraps back to the start
 msgid "No more results. Wrapping search."
-msgstr "Nie ma więcej wyników. Zawijanie wyszukiwania."
+msgstr "Nie ma więcej wyników. Wyszukiwanie zaczyna od początku."
 
 #. TRANSLATORS: Error shown when the active document has no known file path to reveal
-#, fuzzy
 msgid "Failed to reveal file in folder."
-msgstr "Nie udało się wyświetlić pliku w folderze."
+msgstr "Nie udało się pokazać pliku w folderze."
 
 #. TRANSLATORS: Error shown when the bundled help/readme file could not be located on disk
 msgid "readme.html not found. Please ensure the application was built properly."
@@ -759,52 +897,41 @@ msgstr "Nie udało się otworzyć strony wsparcia w przeglądarce."
 msgid "Unsupported format selected."
 msgstr "Wybrano nieobsługiwany format."
 
-#. TRANSLATORS: Main window title when no document is open
-msgid "Paperback"
-msgstr "Paperback"
-
-#. TRANSLATORS: Announced by screen readers after a document was automatically reloaded because its file changed on disk
-#, fuzzy
-msgid "Document reloaded."
-msgstr "Dokument został ponownie załadowany."
-
-#. TRANSLATORS: Message shown when the user tries to perform an action while a help/documentation Web View window is open
-#, fuzzy
-msgid "Paperback cannot perform any actions while Web View is open."
-msgstr "Aplikacja Paperback nie może wykonywać żadnych czynności, gdy okno Web View jest otwarte."
-
-#. TRANSLATORS: Window title when a document is open; {} is the document title
-msgid "{} - Paperback"
-msgstr "{} - Paperback"
-
-#. TRANSLATORS: Status bar character count; {} is the number of characters
-msgid "{} chars"
-msgstr "{} znaków"
-
-#. TRANSLATORS: Fallback file name stem used when the document's path has no file stem
-msgid "document"
-msgstr "dokument"
-
-#. TRANSLATORS: Error dialog shown when exporting a document to another format fails
-msgid "Failed to export document."
-msgstr "Nie udało się wyeksportować dokumentu."
-
-#. TRANSLATORS: Title of the file picker dialog shown when opening a document
-msgid "Open Document"
-msgstr "Otwórz dokument"
+#. TRANSLATORS: Announced when opening "All Documents" while the recent-documents list is empty
+msgid "No recent documents."
+msgstr "Brak ostatnich dokumentów."
 
 #. TRANSLATORS: Announced when "Go to Page" is used on a document that has no page numbers
 msgid "No pages."
 msgstr "Brak stron."
 
-#. TRANSLATORS: Announced when toggling word wrap; the message reflects the new state
-#, fuzzy
-msgid "Word wrap on."
-msgstr "Włączono zawijanie tekstu."
+#. TRANSLATORS: Announced when opening the Table of Contents for a document that has none
+msgid "No table of contents."
+msgstr "Brak spisu treści."
 
-#, fuzzy
-msgid "Word wrap off."
-msgstr "Wyłączanie zawijania tekstu."
+#. TRANSLATORS: Title of the window that renders a document's content as HTML (e.g. for embedded web pages)
+msgid "Web View"
+msgstr "Widok WWW"
+
+#. TRANSLATORS: Error shown when the document has no content that can be rendered in the Web View
+msgid "Could not determine content to display in Web View."
+msgstr "Nie udało się określić treści do wyświetlenia w Widoku WWW."
+
+#. TRANSLATORS: Fallback file name stem used when the document's path has no file stem
+msgid "document"
+msgstr "dokument"
+
+#. TRANSLATORS: Prefix before the file name in the tab title for a "View Source" tab, e.g. "Source: book.epub"
+msgid "Source:"
+msgstr "Źródło:"
+
+#. TRANSLATORS: Error shown when "View Source" is used on a document format that has no raw source to view
+msgid "Source view is not available for this document format."
+msgstr "Widok źródła nie jest dostępny dla tego formatu dokumentu."
+
+#. TRANSLATORS: Error shown when "View Source" fails to load the document's underlying source
+msgid "Could not load the document source."
+msgstr "Nie udało się wczytać źródła dokumentu."
 
 #. TRANSLATORS: File filter shown in the "Export to plain text" save dialog
 msgid "Plain text files (*.txt)|*.txt|All files (*.*)|*.*"
@@ -858,746 +985,570 @@ msgstr "Zakładki i notatki zostały zaimportowane."
 msgid "Import Successful"
 msgstr "Import zakończony"
 
-#. TRANSLATORS: Announced when opening the Table of Contents for a document that has none
-msgid "No table of contents."
-msgstr "Brak spisu treści."
-
-#. TRANSLATORS: Title of the window that renders a document's content as HTML (e.g. for embedded web pages)
-msgid "Web View"
-msgstr "Widok WWW"
-
-#. TRANSLATORS: Error shown when the document has no content that can be rendered in the Web View
-msgid "Could not determine content to display in Web View."
-msgstr "Nie udało się określić treści do pokazania w Widoku WWW."
-
-#. TRANSLATORS: Prefix before the file name in the tab title for a "View Source" tab, e.g. "Source: book.epub"
-#, fuzzy
-msgid "Source:"
-msgstr "Źródło:"
-
-#. TRANSLATORS: Error shown when "View Source" is used on a document format that has no raw source to view
-#, fuzzy
-msgid "Source view is not available for this document format."
-msgstr "W tym formacie dokumentu nie jest dostępny widok źródłowy."
-
-#. TRANSLATORS: Error shown when "View Source" fails to load the document's underlying source
-#, fuzzy
-msgid "Could not load the document source."
-msgstr "Nie udało się załadować źródła dokumentu."
-
 #. TRANSLATORS: Announced when the user cancels a running sleep timer
 msgid "Sleep timer cancelled."
 msgstr "Wyłącznik czasowy anulowany."
 
-#. TRANSLATORS: Announcement when the sleep timer is set for exactly 1 minute
-msgid "Sleep timer set for 1 minute."
-msgstr "Wyłącznik czasowy ustawiony na 1 minutę."
-
-#. TRANSLATORS: Announcement when the sleep timer is set; %d is the number of minutes (always 2 or more)
-#, c-format
-msgid "Sleep timer set for %d minutes."
-msgstr "Wyłącznik czasowy ustawiony na %d min."
-
-#. TRANSLATORS: Announced when opening "All Documents" while the recent-documents list is empty
-msgid "No recent documents."
-msgstr "Brak ostatnich dokumentów."
-
-#. TRANSLATORS: Menu item label to go to the previous section
-msgid "Previous Section\t["
-msgstr "Poprzednia sekcja\t["
-
-#. TRANSLATORS: Status bar help text for the "Previous Section" menu item
-msgid "Go to previous section"
-msgstr "Przejdź do poprzedniej sekcji"
-
-#. TRANSLATORS: Menu item label to go to the next section
-msgid "Next Section\t]"
-msgstr "Następna sekcja\t]"
-
-#. TRANSLATORS: Status bar help text for the "Next Section" menu item
-msgid "Go to next section"
-msgstr "Przejdź do następnej sekcji"
-
-#. TRANSLATORS: Menu item label to open the "go to page" dialog
-msgid "Go to &Page\tCtrl+P"
-msgstr "Przejdź do &strony\tCtrl+P"
-
-#. TRANSLATORS: Menu item label to go to the previous page
-msgid "Previous Pa&ge\tShift+P"
-msgstr "Poprzednia stro&na\tShift+P"
-
-#. TRANSLATORS: Menu item label to go to the next page
-msgid "Next Pag&e\tP"
-msgstr "Następna str&ona\tP"
-
-#. TRANSLATORS: Menu item label to go to the previous link
-msgid "Previous Lin&k\tShift+K"
-msgstr "Poprzedni odnośni&k\tShift+K"
-
-#. TRANSLATORS: Menu item label to go to the next link
-msgid "Next Lin&k\tK"
-msgstr "Następny odnośni&k\tK"
-
-#. TRANSLATORS: Menu item label to go to the previous image
-msgid "Previous Ima&ge\tShift+G"
-msgstr "Poprzedni &obraz\tShift+G"
-
-#. TRANSLATORS: Menu item label to go to the next image
-msgid "Next Ima&ge\tG"
-msgstr "Następny &obraz\tG"
-
-#. TRANSLATORS: Menu item label to go to the previous figure
-msgid "Previous Figu&re\tShift+F"
-msgstr "Poprzedni &rysunek\tShift+F"
-
-#. TRANSLATORS: Menu item label to go to the next figure
-msgid "Next Figu&re\tF"
-msgstr "Następny &rysunek\tF"
-
-#. TRANSLATORS: Menu item label to go to the previous table
-msgid "Previous &Table\tShift+T"
-msgstr "Poprzednia &tabela\tShift+T"
-
-#. TRANSLATORS: Menu item label to go to the next table
-msgid "Next &Table\tT"
-msgstr "Następna &tabela\tT"
-
-#. TRANSLATORS: Menu item label to go to the previous separator element
-msgid "Previous Se&parator\tShift+S"
-msgstr "Poprzedni se&parator\tShift+S"
-
-#. TRANSLATORS: Menu item label to go to the next separator element
-msgid "Next Se&parator\tS"
-msgstr "Następny se&parator\tS"
-
-#. TRANSLATORS: Menu item label to go to the previous list
-msgid "Previous L&ist\tShift+L"
-msgstr "Poprzednia &lista\tShift+L"
-
-#. TRANSLATORS: Menu item label to go to the next list
-msgid "Next L&ist\tL"
-msgstr "Następna &lista\tL"
-
-#. TRANSLATORS: Menu item label to go to the previous list item
-msgid "Previous List &Item\tShift+I"
-msgstr "Poprzedni element l&isty\tShift+I"
-
-#. TRANSLATORS: Menu item label to go to the next list item
-msgid "Next List I&tem\tI"
-msgstr "Następny element lis&ty\tI"
-
-#. TRANSLATORS: Menu item label to go to the start of the enclosing list/table
-#, fuzzy
-msgid "Container &Start\tShift+,"
-msgstr "Pojemnik i Start    Shift+,"
-
-#. TRANSLATORS: Status bar help text for the "Container Start" menu item
-#, fuzzy
-msgid "Go to the start of the current list or table"
-msgstr "Przejdź na początek bieżącej listy lub tabeli"
-
-#. TRANSLATORS: Menu item label to go past the end of the enclosing list/table
-#, fuzzy
-msgid "Past Container &End\t,"
-msgstr "Poprzedni kontener i koniec    ,"
-
-#. TRANSLATORS: Status bar help text for the "Past Container End" menu item
-#, fuzzy
-msgid "Go past the end of the current list or table"
-msgstr "Przejdź poza koniec bieżącej listy lub tabeli"
-
-#. TRANSLATORS: Menu item label to go to the next level-1 heading
-msgid "Next Heading Level 1\t1"
-msgstr "Następny nagłówek poziomu 1\t1"
-
-#. TRANSLATORS: Menu item label to go to the previous level-2 heading
-msgid "Previous Heading Level &2\tShift+2"
-msgstr "Poprzedni nagłówek poziomu &2\tShift+2"
-
-#. TRANSLATORS: Menu item label to go to the next level-2 heading
-msgid "Next Heading Level 2\t2"
-msgstr "Następny nagłówek poziomu 2\t2"
-
-#. TRANSLATORS: Menu item label to go to the previous level-3 heading
-msgid "Previous Heading Level &3\tShift+3"
-msgstr "Poprzedni nagłówek poziomu &3\tShift+3"
-
-#. TRANSLATORS: Menu item label to go to the next level-3 heading
-msgid "Next Heading Level 3\t3"
-msgstr "Następny nagłówek poziomu 3\t3"
-
-#. TRANSLATORS: Menu item label to go to the previous level-4 heading
-msgid "Previous Heading Level &4\tShift+4"
-msgstr "Poprzedni nagłówek poziomu &4\tShift+4"
-
-#. TRANSLATORS: Menu item label to go to the next level-4 heading
-msgid "Next Heading Level 4\t4"
-msgstr "Następny nagłówek poziomu 4\t4"
-
-#. TRANSLATORS: Menu item label to go to the previous level-5 heading
-msgid "Previous Heading Level &5\tShift+5"
-msgstr "Poprzedni nagłówek poziomu &5\tShift+5"
-
-#. TRANSLATORS: Menu item label to go to the next level-5 heading
-msgid "Next Heading Level 5\t5"
-msgstr "Następny nagłówek poziomu 5\t5"
-
-#. TRANSLATORS: Menu item label to go to the previous level-6 heading
-msgid "Previous Heading Level &6\tShift+6"
-msgstr "Poprzedni nagłówek poziomu &6\tShift+6"
-
-#. TRANSLATORS: Menu item label to go to the next level-6 heading
-msgid "Next Heading Level 6\t6"
-msgstr "Następny nagłówek poziomu 6\t6"
-
-#. TRANSLATORS: Menu item label to go to the previous heading of any level
-msgid "&Previous Heading\tShift+H"
-msgstr "&Poprzedni nagłówek\tShift+H"
-
-#. TRANSLATORS: Status bar help text for the "Previous Heading" menu item
-msgid "Go to previous heading"
-msgstr "Przejdź do poprzedniego nagłówka"
-
-#. TRANSLATORS: Menu item label to go to the next heading of any level
-msgid "&Next Heading\tH"
-msgstr "&Następny nagłówek\tH"
-
-#. TRANSLATORS: Status bar help text for the "Next Heading" menu item
-msgid "Go to next heading"
-msgstr "Przejdź do następnego nagłówka"
-
-#. TRANSLATORS: Menu item label to go to the previous level-1 heading
-msgid "Previous Heading Level &1\tShift+1"
-msgstr "Poprzedni nagłówek poziomu &1\tShift+1"
-
-#. TRANSLATORS: Menu item label to go to the previous bookmark
-msgid "&Previous Bookmark\tShift+B"
-msgstr "&Poprzednia zakładka\tShift+B"
-
-#. TRANSLATORS: Status bar help text for the "Previous Bookmark" menu item
-msgid "Go to previous bookmark"
-msgstr "Przejdź do poprzedniej zakładki"
-
-#. TRANSLATORS: Menu item label to go to the next bookmark
-msgid "&Next Bookmark\tB"
-msgstr "&Następna zakładka\tB"
-
-#. TRANSLATORS: Status bar help text for the "Next Bookmark" menu item
-msgid "Go to next bookmark"
-msgstr "Przejdź do następnej zakładki"
-
-#. TRANSLATORS: Menu item label to go to the previous note
-msgid "Previous &Note\tShift+N"
-msgstr "Poprzednia &notatka\tShift+N"
-
-#. TRANSLATORS: Status bar help text for the "Previous Note" menu item
-msgid "Go to previous note"
-msgstr "Przejdź do poprzedniej notatki"
-
-#. TRANSLATORS: Menu item label to go to the next note
-msgid "Next N&ote\tN"
-msgstr "Następna n&otatka\tN"
-
-#. TRANSLATORS: Status bar help text for the "Next Note" menu item
-msgid "Go to next note"
-msgstr "Przejdź do następnej notatki"
-
-#. TRANSLATORS: Menu item label to open the bookmark/note picker showing all entries
-msgid "Jump to &All...\tCtrl+B"
-msgstr "Przejdź do &wszystkich...\tCtrl+B"
-
-#. TRANSLATORS: Status bar help text for the "Jump to All" menu item
-msgid "Show all bookmarks and notes"
-msgstr "Pokaż wszystkie zakładki i notatki"
-
-#. TRANSLATORS: Menu item label to open the bookmark/note picker filtered to bookmarks only
-msgid "Jump to &Bookmarks Only...\tCtrl+Alt+B"
-msgstr "Przejdź tylko do &zakładek...\tCtrl+Alt+B"
-
-#. TRANSLATORS: Status bar help text for the "Jump to Bookmarks Only" menu item
-msgid "Show bookmarks only"
-msgstr "Pokaż tylko zakładki"
-
-#. TRANSLATORS: Menu item label to open the bookmark/note picker filtered to notes only
-msgid "Jump to Notes &Only...\tCtrl+Alt+M"
-msgstr "Przejdź tylko do n&otatek...\tCtrl+Alt+M"
-
-#. TRANSLATORS: Status bar help text for the "Jump to Notes Only" menu item
-msgid "Show notes only"
-msgstr "Pokaż tylko notatki"
-
-#. TRANSLATORS: Menu item label to view the note at the cursor position (macOS variant)
-msgid "&View Note Text\tRawCtrl+Shift+W"
-msgstr "&Wyświetl tekst notatki\tRawCtrl+Shift+W"
-
-#. TRANSLATORS: Menu item label to view the note at the cursor position
-msgid "&View Note Text\tCtrl+Shift+W"
-msgstr "&Wyświetl tekst notatki\tCtrl+Shift+W"
-
-#. TRANSLATORS: Status bar help text for the "View Note Text" menu item
-msgid "View the note at current position"
-msgstr "Wyświetl notatkę w bieżącej pozycji"
-
-#. TRANSLATORS: Top-level "File" menu bar label
-msgid "&File"
-msgstr "&Plik"
-
-#. TRANSLATORS: Top-level "Go" menu bar label
-msgid "&Go"
-msgstr "&Przejdź"
-
-#. TRANSLATORS: Top-level "Tools" menu bar label
-msgid "&Tools"
-msgstr "&Narzędzia"
-
-#. TRANSLATORS: Top-level "Help" menu bar label
-msgid "&Help"
-msgstr "Pomo&c"
-
-#. TRANSLATORS: Top-level "Edit" menu bar label (macOS only)
-#, fuzzy
-msgid "&Edit"
-msgstr "&Edytuj"
-
-#. TRANSLATORS: Menu item label to open a document
-msgid "&Open...\tCtrl+O"
-msgstr "&Otwórz...\tCtrl+O"
-
-#. TRANSLATORS: Status bar help text for the "Open" menu item
+msgid "Sleep timer set for %d minute."
+msgid_plural "Sleep timer set for %d minutes."
+msgstr[0] "Wyłącznik czasowy ustawiony na %d minutę."
+msgstr[1] "Wyłącznik czasowy ustawiony na %d minuty."
+msgstr[2] "Wyłącznik czasowy ustawiony na %d minut."
+
+#. TRANSLATORS: Main window title when no document is open
+msgid "Paperback"
+msgstr "Paperback"
+
+#. TRANSLATORS: Announced by screen readers after a document was automatically reloaded because its file changed on disk
+msgid "Document reloaded."
+msgstr "Dokument został przeładowany."
+
+#. TRANSLATORS: Message shown when the user tries to perform an action while a help/documentation Web View window is open
+msgid "Paperback cannot perform any actions while Web View is open."
+msgstr "Paperback nie może wykonywać żadnych czynności, gdy otwarty jest Widok WWW."
+
+#. TRANSLATORS: Window title when a document is open; {} is the document title
+msgid "{} - Paperback"
+msgstr "{} - Paperback"
+
+msgid "%d char"
+msgid_plural "%d chars"
+msgstr[0] "%d znak"
+msgstr[1] "%d znaki"
+msgstr[2] "%d znaków"
+
+#. TRANSLATORS: Error dialog shown when exporting a document to another format fails
+msgid "Failed to export document."
+msgstr "Nie udało się wyeksportować dokumentu."
+
+#. TRANSLATORS: Title of the file picker dialog shown when opening a document
+msgid "Open Document"
+msgstr "Otwórz dokument"
+
+#. TRANSLATORS: Announced when toggling word wrap; the message reflects the new state
+msgid "Word wrap on."
+msgstr "Zawijanie wierszy włączone."
+
+msgid "Word wrap off."
+msgstr "Zawijanie wierszy wyłączone."
+
+#. TRANSLATORS: Announced when toggling full screen mode; the message reflects the new state
+msgid "Full screen on."
+msgstr "Tryb pełnoekranowy włączony."
+
+msgid "Full screen off."
+msgstr "Tryb pełnoekranowy wyłączony."
+
+msgid "&Undo\tCtrl+Z"
+msgstr "&Cofnij\tCtrl+Z"
+
+msgid "&Redo\tCtrl+Shift+Z"
+msgstr "&Ponów\tCtrl+Shift+Z"
+
+msgid "Cu&t\tCtrl+X"
+msgstr "Wy&tnij\tCtrl+X"
+
+msgid "&Copy\tCtrl+C"
+msgstr "&Kopiuj\tCtrl+C"
+
+msgid "&Paste\tCtrl+V"
+msgstr "&Wklej\tCtrl+V"
+
+msgid "Select &All\tCtrl+A"
+msgstr "Zaznacz &wszystko\tCtrl+A"
+
+msgid "&Open..."
+msgstr "&Otwórz..."
+
 msgid "Open a document"
 msgstr "Otwórz dokument"
 
-#. TRANSLATORS: Menu item label to close the current document
-msgid "&Close\tCtrl+W"
-msgstr "&Zamknij\tCtrl+W"
+msgid "&Close"
+msgstr "&Zamknij"
 
-msgid "&Close\tCtrl+F4"
-msgstr "&Zamknij\tCtrl+F4"
-
-#. TRANSLATORS: Status bar help text for the "Close" menu item
 msgid "Close the current document"
 msgstr "Zamknij bieżący dokument"
 
-#. TRANSLATORS: Menu item label to close all open documents
-msgid "Close &All\tCtrl+Shift+W"
-msgstr "Zamknij &wszystkie\tCtrl+Shift+W"
+msgid "Close &All"
+msgstr "Zamknij &wszystkie"
 
-msgid "Close &All\tCtrl+Shift+F4"
-msgstr "Zamknij &wszystkie\tCtrl+Shift+F4"
-
-#. TRANSLATORS: Status bar help text for the "Close All" menu item
 msgid "Close all documents"
 msgstr "Zamknij wszystkie dokumenty"
 
-#. TRANSLATORS: Menu item label to reopen the most recently closed document
-msgid "Reopen &Last Closed\tCtrl+Shift+T"
-msgstr "Otwórz ponownie &ostatnio zamknięty\tCtrl+Shift+T"
+msgid "Reopen &Last Closed"
+msgstr "Otwórz ponownie &ostatnio zamknięty"
 
-#. TRANSLATORS: Status bar help text for the "Reopen Last Closed" menu item
 msgid "Reopen the last closed document"
 msgstr "Otwórz ponownie ostatnio zamknięty dokument"
 
-#. TRANSLATORS: Submenu label listing recently opened documents
 msgid "&Recent Documents"
 msgstr "&Ostatnie dokumenty"
 
-#. TRANSLATORS: Status bar help text for the "Recent Documents" submenu
 msgid "Open a recent document"
 msgstr "Otwórz ostatni dokument"
 
-#. TRANSLATORS: Menu item label to exit the application
-msgid "E&xit\tCtrl+Q"
-msgstr "Za&kończ\tCtrl+Q"
+#. TRANSLATORS: System tray menu item to quit the application
+msgid "E&xit"
+msgstr "Za&kończ"
 
-#. TRANSLATORS: Status bar help text for the "Exit" menu item
 msgid "Exit the application"
 msgstr "Zakończ aplikację"
 
-#. TRANSLATORS: Standard "Undo" edit menu item label
-#, fuzzy
-msgid "&Undo\tCtrl+Z"
-msgstr "&Cofnij    Ctrl+Z"
-
-#. TRANSLATORS: Standard "Redo" edit menu item label
-#, fuzzy
-msgid "&Redo\tCtrl+Shift+Z"
-msgstr "&Cofnij    Ctrl+Shift+Z"
-
-#. TRANSLATORS: Standard "Cut" edit menu item label
-#, fuzzy
-msgid "Cu&t\tCtrl+X"
-msgstr "Cu&t    Ctrl+X"
-
-#. TRANSLATORS: Standard "Copy" edit menu item label
-#, fuzzy
-msgid "&Copy\tCtrl+C"
-msgstr "&Kopiuj    Ctrl+C"
-
-#. TRANSLATORS: Standard "Paste" edit menu item label
-#, fuzzy
-msgid "&Paste\tCtrl+V"
-msgstr "&Wklej    Ctrl+V"
-
-#. TRANSLATORS: Standard "Select All" edit menu item label
-#, fuzzy
-msgid "Select &All\tCtrl+A"
-msgstr "Zaznacz wszystko    Ctrl+A"
-
-#. TRANSLATORS: Menu item label to open the find dialog
-msgid "&Find...\tCtrl+F"
-msgstr "&Znajdź...\tCtrl+F"
-
-#. TRANSLATORS: Status bar help text for the "Find" menu item
-msgid "Find text in the document"
-msgstr "Znajdź tekst w dokumencie"
-
-#. TRANSLATORS: Menu item label to find the next match
-#, fuzzy
-msgid "Find &Next\tCtrl+G"
-msgstr "Znajdź i następny    Ctrl+G"
-
-msgid "Find &Next\tF3"
-msgstr "Znajdź &następne\tF3"
-
-#. TRANSLATORS: Status bar help text for the "Find Next" menu item
-msgid "Find next occurrence"
-msgstr "Znajdź następne wystąpienie"
-
-#. TRANSLATORS: Menu item label to find the previous match
-#, fuzzy
-msgid "Find &Previous\tCtrl+Shift+G"
-msgstr "Znajdź i poprzedni    Ctrl+Shift+G"
-
-msgid "Find &Previous\tShift+F3"
-msgstr "Znajdź &poprzednie\tShift+F3"
-
-#. TRANSLATORS: Status bar help text for the "Find Previous" menu item
-msgid "Find previous occurrence"
-msgstr "Znajdź poprzednie wystąpienie"
-
-#. TRANSLATORS: Menu item label to open the "go to line" dialog
-#, fuzzy
-msgid "Go to &line...\tCtrl+L"
-msgstr "Przejdź do wiersza...    Ctrl+L"
-
-msgid "Go to &line...\tCtrl+G"
-msgstr "Przejdź do &wiersza...\tCtrl+G"
-
-#. TRANSLATORS: Status bar help text for the "Go to line" menu item
-msgid "Go to a specific line"
-msgstr "Przejdź do określonego wiersza"
-
-#. TRANSLATORS: Menu item label to open the "go to percent" dialog (macOS variant)
-#, fuzzy
-msgid "Go to &percent...\tCtrl+Shift+L"
-msgstr "Przejdź do &percent...    Ctrl+Shift+L"
-
-#. TRANSLATORS: Menu item label to open the "go to percent" dialog
-msgid "Go to &percent...\tCtrl+Shift+G"
-msgstr "Przejdź do &procentu...\tCtrl+Shift+G"
-
-#. TRANSLATORS: Status bar help text for the "Go to percent" menu item
-msgid "Go to a percentage of the document"
-msgstr "Przejdź do procentowej pozycji dokumentu"
-
-#. TRANSLATORS: Menu item label to go back in navigation history
-#, fuzzy
-msgid "Go &Back\tCtrl+["
-msgstr "Przejdź do przodu i do tyłu    Ctrl+["
-
-msgid "Go &Back\tAlt+Left"
-msgstr "W&stecz\tAlt+Left"
-
-#. TRANSLATORS: Status bar help text for the "Go Back" menu item
-msgid "Go back in history"
-msgstr "Przejdź wstecz w historii"
-
-#. TRANSLATORS: Menu item label to go forward in navigation history
-#, fuzzy
-msgid "Go &Forward\tCtrl+]"
-msgstr "Przejdź do &Dalej    Ctrl+]"
-
-msgid "Go &Forward\tAlt+Right"
-msgstr "D&o przodu\tAlt+Right"
-
-#. TRANSLATORS: Status bar help text for the "Go Forward" menu item
-msgid "Go forward in history"
-msgstr "Przejdź do przodu w historii"
-
-#. TRANSLATORS: Submenu label containing section navigation commands
-msgid "&Sections"
-msgstr "&Sekcje"
-
-#. TRANSLATORS: Status bar help text for the "Sections" submenu
-msgid "Navigate by sections"
-msgstr "Nawiguj po sekcjach"
-
-#. TRANSLATORS: Submenu label containing heading navigation commands
-msgid "&Headings"
-msgstr "&Nagłówki"
-
-#. TRANSLATORS: Status bar help text for the "Headings" submenu
-msgid "Navigate by headings"
-msgstr "Nawiguj po nagłówkach"
-
-#. TRANSLATORS: Submenu label containing page navigation commands
-msgid "&Pages"
-msgstr "S&trony"
-
-#. TRANSLATORS: Status bar help text for the "Pages" submenu
-msgid "Navigate by pages"
-msgstr "Nawiguj po stronach"
-
-#. TRANSLATORS: Submenu label containing bookmark/note navigation commands
-msgid "&Bookmarks"
-msgstr "&Zakładki"
-
-#. TRANSLATORS: Status bar help text for the "Bookmarks" submenu
-msgid "Navigate by bookmarks"
-msgstr "Nawiguj po zakładkach"
-
-#. TRANSLATORS: Submenu label containing link navigation commands
-msgid "&Links"
-msgstr "&Odnośniki"
-
-#. TRANSLATORS: Status bar help text for the "Links" submenu
-msgid "Navigate by links"
-msgstr "Nawiguj po odnośnikach"
-
-#. TRANSLATORS: Submenu label containing image navigation commands
-msgid "&Images"
-msgstr "&Obrazy"
-
-#. TRANSLATORS: Status bar help text for the "Images" submenu
-msgid "Navigate by images"
-msgstr "Nawiguj po obrazach"
-
-#. TRANSLATORS: Submenu label containing figure navigation commands
-msgid "&Figures"
-msgstr "&Rysunki"
-
-#. TRANSLATORS: Status bar help text for the "Figures" submenu
-msgid "Navigate by figures"
-msgstr "Nawiguj po rysunkach"
-
-#. TRANSLATORS: Submenu label containing table navigation commands
-msgid "&Tables"
-msgstr "&Tabele"
-
-#. TRANSLATORS: Status bar help text for the "Tables" submenu
-msgid "Navigate by tables"
-msgstr "Nawiguj po tabelach"
-
-#. TRANSLATORS: Submenu label containing separator-element navigation commands
-msgid "&Separators"
-msgstr "Se&paratory"
-
-#. TRANSLATORS: Status bar help text for the "Separators" submenu
-msgid "Navigate by separators"
-msgstr "Nawiguj po separatorach"
-
-#. TRANSLATORS: Submenu label containing list navigation commands
-msgid "&Lists"
-msgstr "&Listy"
-
-#. TRANSLATORS: Status bar help text for the "Lists" submenu
-msgid "Navigate by lists"
-msgstr "Nawiguj po listach"
-
-#. TRANSLATORS: Submenu label containing container (list/table) navigation commands
-#, fuzzy
-msgid "&Containers"
-msgstr "&Pojemniki"
-
-#. TRANSLATORS: Status bar help text for the "Containers" submenu
-#, fuzzy
-msgid "Navigate by containers"
-msgstr "Nawigacja według kontenerów"
-
-#. TRANSLATORS: Menu item label to import bookmark/position data for the document
-msgid "&Import Document Data...\tCtrl+Shift+I"
-msgstr "&Importuj dane dokumentu...\tCtrl+Shift+I"
-
-#. TRANSLATORS: Status bar help text for the "Import Document Data" menu item
-msgid "Import bookmarks and position"
-msgstr "Importuj zakładki i pozycję"
-
-#. TRANSLATORS: Menu item label to export bookmark/position data for the document
-msgid "&Export Document Data...\tCtrl+Shift+E"
-msgstr "&Eksportuj dane dokumentu...\tCtrl+Shift+E"
-
-#. TRANSLATORS: Status bar help text for the "Export Document Data" menu item
-msgid "Export bookmarks and position"
-msgstr "Eksportuj zakładki i pozycję"
-
-#. TRANSLATORS: Menu item label to export the document as plain text
-msgid "Export to &Plain Text...\tCtrl+E"
-msgstr "Eksportuj do &zwykłego tekstu...\tCtrl+E"
-
-#. TRANSLATORS: Status bar help text for the "Export to Plain Text" menu item
-msgid "Export document as plain text"
-msgstr "Eksportuj dokument jako zwykły tekst"
-
-#. TRANSLATORS: Menu item label to export the document as HTML
-msgid "Export to &HTML..."
-msgstr "Eksportuj do &HTML..."
-
-#. TRANSLATORS: Status bar help text for the "Export to HTML" menu item
-msgid "Export document as HTML"
-msgstr "Eksportuj dokument jako HTML"
-
-#. TRANSLATORS: Menu item label to export the document as Markdown
-msgid "Export to &Markdown..."
-msgstr "Eksportuj do &Markdown..."
-
-#. TRANSLATORS: Status bar help text for the "Export to Markdown" menu item
-msgid "Export document as Markdown"
-msgstr "Eksportuj dokument jako Markdown"
-
-#. TRANSLATORS: Menu item label to show the word count dialog
-msgid "&Word Count\tRawCtrl+W"
-msgstr "&Liczba słów\tRawCtrl+W"
-
-msgid "&Word Count\tCtrl+W"
-msgstr "&Liczba słów\tCtrl+W"
-
-#. TRANSLATORS: Status bar help text for the "Word Count" menu item
-msgid "Show word count"
-msgstr "Pokaż liczbę słów"
-
-#. TRANSLATORS: Menu item label to show the document info dialog
-msgid "Document &Info\tCtrl+I"
-msgstr "&Informacje o dokumencie\tCtrl+I"
-
-#. TRANSLATORS: Status bar help text for the "Document Info" menu item
-msgid "Show document information"
-msgstr "Pokaż informacje o dokumencie"
-
-#. TRANSLATORS: Menu item label to show the table of contents dialog
-msgid "&Table of Contents\tCtrl+T"
-msgstr "&Spis treści\tCtrl+T"
-
-#. TRANSLATORS: Status bar help text for the "Table of Contents" menu item
-msgid "Show table of contents"
-msgstr "Pokaż spis treści"
-
-#. TRANSLATORS: Menu item label to show the elements list dialog
-msgid "&Elements List...\tF7"
-msgstr "Lista &elementów...\tF7"
-
-#. TRANSLATORS: Status bar help text for the "Elements List" menu item
-msgid "Show elements list"
-msgstr "Pokaż listę elementów"
-
-#. TRANSLATORS: Menu item label to reveal the document file in the system file manager
-#, fuzzy
-msgid "Reveal &File in Folder\tCtrl+Shift+C"
-msgstr "Pokaż i zapisz w folderze    Ctrl+Shift+C"
-
-#. TRANSLATORS: Status bar help text for the "Reveal File in Folder" menu item
-#, fuzzy
-msgid "Reveal document in the file manager"
-msgstr "Wyświetl dokument w menedżerze plików"
-
-#. TRANSLATORS: Menu item label to open the document in the web view
-msgid "Open in &Web View\tCtrl+Shift+V"
-msgstr "Otwórz w &Widoku WWW\tCtrl+Shift+V"
-
-#. TRANSLATORS: Status bar help text for the "Open in Web View" menu item
-msgid "Open document in web view"
-msgstr "Otwórz dokument w Widoku WWW"
-
-#. TRANSLATORS: Menu item label to open the document's raw source in a new tab
-#, fuzzy
-msgid "View &Source\tCtrl+U"
-msgstr "Wyświetl źródło    Ctrl+U"
-
-#. TRANSLATORS: Status bar help text for the "View Source" menu item
-#, fuzzy
-msgid "Open the document source in a new tab"
-msgstr "Otwórz źródło dokumentu w nowej karcie"
-
-#. TRANSLATORS: Submenu label containing import/export commands
-msgid "I&mport/Export"
-msgstr "I&mport/eksport"
-
-#. TRANSLATORS: Status bar help text for the "Import/Export" submenu
-msgid "Import and export options"
-msgstr "Opcje importu i eksportu"
-
-#. TRANSLATORS: Menu item label to toggle a bookmark at the current position
-msgid "Toggle &Bookmark\tCtrl+Shift+B"
-msgstr "Przełącz &zakładkę\tCtrl+Shift+B"
-
-#. TRANSLATORS: Menu item label to add a bookmark with an attached note
-msgid "Bookmark with &Note\tCtrl+Shift+N"
-msgstr "Zakładka z &notatką\tCtrl+Shift+N"
-
-#. TRANSLATORS: Checkable menu item label to toggle word wrap
-#, fuzzy
-msgid "Word w&rap\tCtrl+Alt+W"
-msgstr "Zawijanie tekstu    Ctrl+Alt+W"
-
-#. TRANSLATORS: Status bar help text for the "Word wrap" menu item
-#, fuzzy
-msgid "Toggle word wrap"
-msgstr "Włącz/wyłącz zawijanie tekstu"
-
-#. TRANSLATORS: Menu item label to open the application options/preferences dialog
-msgid "&Options\tCtrl+,"
-msgstr "&Opcje\tCtrl+,"
-
-#. TRANSLATORS: Menu item label to open the sleep timer dialog
-msgid "&Sleep Timer...\tCtrl+Shift+S"
-msgstr "&Wyłącznik czasowy...\tCtrl+Shift+S"
-
-#. TRANSLATORS: Menu item label to open the About dialog
-msgid "&About Paperback\tCtrl+F1"
-msgstr "&O programie Paperback\tCtrl+F1"
-
-#. TRANSLATORS: Status bar help text for the "About" menu item
-msgid "About this application"
-msgstr "Informacje o tej aplikacji"
-
-#. TRANSLATORS: Menu item label to open the help documentation in a web browser
-msgid "View Help in &Browser\tF1"
-msgstr "Wyświetl pomoc w &przeglądarce\tF1"
-
-#. TRANSLATORS: Status bar help text for the "View Help in Browser" menu item
-msgid "View help in default browser"
-msgstr "Wyświetl pomoc w domyślnej przeglądarce"
-
-#. TRANSLATORS: Menu item label to open the help documentation inside Paperback itself
-msgid "View Help in &Paperback\tShift+F1"
-msgstr "Wyświetl pomoc w &Paperbacku\tShift+F1"
-
-#. TRANSLATORS: Status bar help text for the "View Help in Paperback" menu item
-msgid "View help in Paperback"
-msgstr "Wyświetl pomoc w Paperbacku"
-
-#. TRANSLATORS: Menu item label to check for application updates
-msgid "Check for &Updates\tCtrl+Shift+U"
-msgstr "Sprawdź &aktualizacje\tCtrl+Shift+U"
-
-#. TRANSLATORS: Status bar help text for the "Check for Updates" menu item
-msgid "Check for updates"
-msgstr "Sprawdź aktualizacje"
-
-#. TRANSLATORS: Menu item label to open the donation page
-msgid "&Donate\tCtrl+D"
-msgstr "&Wesprzyj\tCtrl+D"
-
-#. TRANSLATORS: Status bar help text for the "Donate" menu item
-msgid "Support Paperback development"
-msgstr "Wesprzyj rozwój Paperbacka"
-
-#. TRANSLATORS: Placeholder menu item shown in the Recent Documents submenu when there are none
 msgid "(No recent documents)"
 msgstr "(Brak ostatnich dokumentów)"
 
-#. TRANSLATORS: Menu item label to open the full recent-documents list dialog
-msgid "Show All...\tCtrl+R"
-msgstr "Pokaż wszystko...\tCtrl+R"
+msgid "Show All..."
+msgstr "Pokaż wszystkie..."
+
+msgid "Previous Section"
+msgstr "Poprzednia sekcja"
+
+msgid "Go to previous section"
+msgstr "Przejdź do poprzedniej sekcji"
+
+msgid "Next Section"
+msgstr "Następna sekcja"
+
+msgid "Go to next section"
+msgstr "Przejdź do następnej sekcji"
+
+msgid "Go to &Page"
+msgstr "Przejdź do &strony"
+
+msgid "Previous Pa&ge"
+msgstr "Poprzednia stro&na"
+
+msgid "Next Pag&e"
+msgstr "Następna str&ona"
+
+msgid "Previous Lin&k"
+msgstr "Poprzedni odnośni&k"
+
+msgid "Next Lin&k"
+msgstr "Następny odnośni&k"
+
+msgid "Previous Ima&ge"
+msgstr "Poprzedni &obraz"
+
+msgid "Next Ima&ge"
+msgstr "Następny &obraz"
+
+msgid "Previous Figu&re"
+msgstr "Poprzedni &rysunek"
+
+msgid "Next Figu&re"
+msgstr "Następny &rysunek"
+
+msgid "Previous &Table"
+msgstr "Poprzednia &tabela"
+
+msgid "Next &Table"
+msgstr "Następna &tabela"
+
+msgid "Previous Se&parator"
+msgstr "Poprzedni se&parator"
+
+msgid "Next Se&parator"
+msgstr "Następny se&parator"
+
+msgid "Previous L&ist"
+msgstr "Poprzednia &lista"
+
+msgid "Next L&ist"
+msgstr "Następna &lista"
+
+msgid "Previous List &Item"
+msgstr "Poprzedni element l&isty"
+
+msgid "Next List I&tem"
+msgstr "Następny element lis&ty"
+
+msgid "Container &Start"
+msgstr "&Początek kontenera"
+
+msgid "Go to the start of the current list or table"
+msgstr "Przejdź na początek bieżącej listy lub tabeli"
+
+msgid "Past Container &End"
+msgstr "Za &koniec kontenera"
+
+msgid "Go past the end of the current list or table"
+msgstr "Przejdź poza koniec bieżącej listy lub tabeli"
+
+msgid "&Previous Heading"
+msgstr "&Poprzedni nagłówek"
+
+msgid "Go to previous heading"
+msgstr "Przejdź do poprzedniego nagłówka"
+
+msgid "&Next Heading"
+msgstr "&Następny nagłówek"
+
+msgid "Go to next heading"
+msgstr "Przejdź do następnego nagłówka"
+
+msgid "Previous Heading Level &1"
+msgstr "Poprzedni nagłówek poziomu &1"
+
+msgid "Next Heading Level 1"
+msgstr "Następny nagłówek poziomu 1"
+
+msgid "Previous Heading Level &2"
+msgstr "Poprzedni nagłówek poziomu &2"
+
+msgid "Next Heading Level 2"
+msgstr "Następny nagłówek poziomu 2"
+
+msgid "Previous Heading Level &3"
+msgstr "Poprzedni nagłówek poziomu &3"
+
+msgid "Next Heading Level 3"
+msgstr "Następny nagłówek poziomu 3"
+
+msgid "Previous Heading Level &4"
+msgstr "Poprzedni nagłówek poziomu &4"
+
+msgid "Next Heading Level 4"
+msgstr "Następny nagłówek poziomu 4"
+
+msgid "Previous Heading Level &5"
+msgstr "Poprzedni nagłówek poziomu &5"
+
+msgid "Next Heading Level 5"
+msgstr "Następny nagłówek poziomu 5"
+
+msgid "Previous Heading Level &6"
+msgstr "Poprzedni nagłówek poziomu &6"
+
+msgid "Next Heading Level 6"
+msgstr "Następny nagłówek poziomu 6"
+
+msgid "&Previous Bookmark"
+msgstr "&Poprzednia zakładka"
+
+msgid "Go to previous bookmark"
+msgstr "Przejdź do poprzedniej zakładki"
+
+msgid "&Next Bookmark"
+msgstr "&Następna zakładka"
+
+msgid "Go to next bookmark"
+msgstr "Przejdź do następnej zakładki"
+
+msgid "Previous &Note"
+msgstr "Poprzednia &notatka"
+
+msgid "Go to previous note"
+msgstr "Przejdź do poprzedniej notatki"
+
+msgid "Next N&ote"
+msgstr "Następna n&otatka"
+
+msgid "Go to next note"
+msgstr "Przejdź do następnej notatki"
+
+msgid "Jump to &All..."
+msgstr "Przejdź do &wszystkich..."
+
+msgid "Show all bookmarks and notes"
+msgstr "Pokaż wszystkie zakładki i notatki"
+
+msgid "Jump to &Bookmarks Only..."
+msgstr "Przejdź tylko do &zakładek..."
+
+msgid "Show bookmarks only"
+msgstr "Pokaż tylko zakładki"
+
+msgid "Jump to Notes &Only..."
+msgstr "Przejdź tylko do n&otatek..."
+
+msgid "Show notes only"
+msgstr "Pokaż tylko notatki"
+
+msgid "&View Note Text"
+msgstr "&Wyświetl treść notatki"
+
+msgid "View the note at current position"
+msgstr "Wyświetl notatkę w bieżącej pozycji"
+
+msgid "&Find..."
+msgstr "&Znajdź..."
+
+msgid "Find text in the document"
+msgstr "Znajdź tekst w dokumencie"
+
+msgid "Find next occurrence"
+msgstr "Znajdź następne wystąpienie"
+
+msgid "Find previous occurrence"
+msgstr "Znajdź poprzednie wystąpienie"
+
+msgid "Go to &line..."
+msgstr "Przejdź do &wiersza..."
+
+msgid "Go to a specific line"
+msgstr "Przejdź do określonego wiersza"
+
+msgid "Go to &percent..."
+msgstr "Przejdź do &procentu..."
+
+msgid "Go to a percentage of the document"
+msgstr "Przejdź do procentowej pozycji dokumentu"
+
+msgid "Go &Back"
+msgstr "Przejdź &wstecz"
+
+msgid "Go back in history"
+msgstr "Przejdź wstecz w historii"
+
+msgid "Go &Forward"
+msgstr "Przejdź do &przodu"
+
+msgid "Go forward in history"
+msgstr "Przejdź do przodu w historii"
+
+msgid "&Sections"
+msgstr "&Sekcje"
+
+msgid "Navigate by sections"
+msgstr "Nawiguj po sekcjach"
+
+msgid "&Headings"
+msgstr "&Nagłówki"
+
+msgid "Navigate by headings"
+msgstr "Nawiguj po nagłówkach"
+
+msgid "&Pages"
+msgstr "S&trony"
+
+msgid "Navigate by pages"
+msgstr "Nawiguj po stronach"
+
+msgid "&Bookmarks"
+msgstr "&Zakładki"
+
+msgid "Navigate by bookmarks"
+msgstr "Nawiguj po zakładkach"
+
+msgid "&Links"
+msgstr "&Odnośniki"
+
+msgid "Navigate by links"
+msgstr "Nawiguj po odnośnikach"
+
+msgid "&Images"
+msgstr "&Obrazy"
+
+msgid "Navigate by images"
+msgstr "Nawiguj po obrazach"
+
+msgid "&Figures"
+msgstr "&Rysunki"
+
+msgid "Navigate by figures"
+msgstr "Nawiguj po rysunkach"
+
+msgid "&Tables"
+msgstr "&Tabele"
+
+msgid "Navigate by tables"
+msgstr "Nawiguj po tabelach"
+
+msgid "&Separators"
+msgstr "Se&paratory"
+
+msgid "Navigate by separators"
+msgstr "Nawiguj po separatorach"
+
+msgid "&Lists"
+msgstr "&Listy"
+
+msgid "Navigate by lists"
+msgstr "Nawiguj po listach"
+
+msgid "&Containers"
+msgstr "&Kontenery"
+
+msgid "Navigate by containers"
+msgstr "Nawiguj po kontenerach"
+
+msgid "&About Paperback"
+msgstr "&O programie Paperback"
+
+msgid "About this application"
+msgstr "Informacje o tej aplikacji"
+
+msgid "View Help in &Browser"
+msgstr "Wyświetl pomoc w &przeglądarce"
+
+msgid "View help in default browser"
+msgstr "Wyświetl pomoc w domyślnej przeglądarce"
+
+msgid "View Help in &Paperback"
+msgstr "Wyświetl pomoc w &Paperbacku"
+
+msgid "View help in Paperback"
+msgstr "Wyświetl pomoc w Paperbacku"
+
+msgid "Check for &Updates"
+msgstr "Sprawdź &aktualizacje"
+
+msgid "Check for updates"
+msgstr "Sprawdź aktualizacje"
+
+msgid "&Donate"
+msgstr "&Wesprzyj"
+
+msgid "Support Paperback development"
+msgstr "Wesprzyj rozwój Paperbacka"
+
+msgid "&Import Document Data..."
+msgstr "&Importuj dane dokumentu..."
+
+msgid "Import bookmarks and position"
+msgstr "Importuj zakładki i pozycję"
+
+msgid "&Export Document Data..."
+msgstr "&Eksportuj dane dokumentu..."
+
+msgid "Export bookmarks and position"
+msgstr "Eksportuj zakładki i pozycję"
+
+msgid "Export to &Plain Text..."
+msgstr "Eksportuj do &zwykłego tekstu..."
+
+msgid "Export document as plain text"
+msgstr "Eksportuj dokument jako zwykły tekst"
+
+msgid "Export to &HTML..."
+msgstr "Eksportuj do &HTML..."
+
+msgid "Export document as HTML"
+msgstr "Eksportuj dokument jako HTML"
+
+msgid "Export to &Markdown..."
+msgstr "Eksportuj do &Markdown..."
+
+msgid "Export document as Markdown"
+msgstr "Eksportuj dokument jako Markdown"
+
+msgid "&Word Count"
+msgstr "&Liczba słów"
+
+msgid "Show word count"
+msgstr "Pokaż liczbę słów"
+
+msgid "Document &Info"
+msgstr "&Informacje o dokumencie"
+
+msgid "Show document information"
+msgstr "Pokaż informacje o dokumencie"
+
+msgid "&Table of Contents"
+msgstr "&Spis treści"
+
+msgid "Show table of contents"
+msgstr "Pokaż spis treści"
+
+msgid "&Elements List..."
+msgstr "Lista &elementów..."
+
+msgid "Show elements list"
+msgstr "Pokaż listę elementów"
+
+msgid "Reveal &File in Folder"
+msgstr "Pokaż &plik w folderze"
+
+msgid "Reveal document in the file manager"
+msgstr "Pokaż dokument w menedżerze plików"
+
+msgid "Open in &Web View"
+msgstr "Otwórz w &Widoku WWW"
+
+msgid "Open document in web view"
+msgstr "Otwórz dokument w Widoku WWW"
+
+msgid "View &Source"
+msgstr "Wyświetl ź&ródło"
+
+msgid "Open the document source in a new tab"
+msgstr "Otwórz źródło dokumentu w nowej karcie"
+
+msgid "I&mport/Export"
+msgstr "I&mport/eksport"
+
+msgid "Import and export options"
+msgstr "Opcje importu i eksportu"
+
+msgid "Toggle &Bookmark"
+msgstr "Przełącz &zakładkę"
+
+msgid "Bookmark with &Note"
+msgstr "Zakładka z &notatką"
+
+msgid "Word w&rap"
+msgstr "Zawijanie wie&rszy"
+
+msgid "Toggle word wrap"
+msgstr "Włącz lub wyłącz zawijanie wierszy"
+
+msgid "&Play/Pause Audio"
+msgstr "&Odtwórz lub wstrzymaj dźwięk"
+
+msgid "Play or pause this document's audio narration"
+msgstr "Odtwórz lub wstrzymaj narrację dźwiękową tego dokumentu"
+
+msgid "Seek Audio &Forward"
+msgstr "Przewiń dźwięk w &przód"
+
+msgid "Skip the audio narration forward"
+msgstr "Przewiń narrację dźwiękową w przód"
+
+msgid "Seek Audio &Backward"
+msgstr "Przewiń dźwięk w &tył"
+
+msgid "Skip the audio narration backward"
+msgstr "Przewiń narrację dźwiękową w tył"
+
+msgid "&Increase Audio Seek Amount"
+msgstr "&Zwiększ skok przewijania dźwięku"
+
+msgid "Increase how far seeking the audio narration moves"
+msgstr "Zwiększ skok przewijania narracji dźwiękowej"
+
+msgid "&Decrease Audio Seek Amount"
+msgstr "Z&mniejsz skok przewijania dźwięku"
+
+msgid "Decrease how far seeking the audio narration moves"
+msgstr "Zmniejsz skok przewijania narracji dźwiękowej"
+
+msgid "&Full Screen"
+msgstr "Tryb &pełnoekranowy"
+
+msgid "Toggle full screen"
+msgstr "Włącz lub wyłącz tryb pełnoekranowy"
+
+msgid "&Settings"
+msgstr "&Ustawienia"
+
+msgid "&Sleep Timer..."
+msgstr "&Wyłącznik czasowy..."
+
+msgid "&File"
+msgstr "&Plik"
+
+msgid "&Go"
+msgstr "&Przejdź"
+
+msgid "&Tools"
+msgstr "&Narzędzia"
+
+msgid "&Help"
+msgstr "Pomo&c"
+
+msgid "&Edit"
+msgstr "&Edycja"
 
 #. TRANSLATORS: Announced when the document has no sections to navigate
 msgid "No sections."
@@ -1612,17 +1563,14 @@ msgid "No previous section"
 msgstr "Brak poprzedniej sekcji"
 
 #. TRANSLATORS: Announced when the document has no headings at the given level; %d is the heading level number
-#, c-format
 msgid "No headings at level %d."
 msgstr "Brak nagłówków poziomu %d."
 
 #. TRANSLATORS: Announced when there is no next heading at the given level; %d is the heading level number
-#, c-format
 msgid "No next heading at level %d."
 msgstr "Brak następnego nagłówka poziomu %d."
 
 #. TRANSLATORS: Announced when there is no previous heading at the given level; %d is the heading level number
-#, c-format
 msgid "No previous heading at level %d."
 msgstr "Brak poprzedniego nagłówka poziomu %d."
 
@@ -1738,12 +1686,14 @@ msgid "Wrapping to end. "
 msgstr "Zawijanie do końca. "
 
 #. TRANSLATORS: Announcement when landing on a heading; %s is the heading text, %d is the heading level number
-#, c-format
 msgid "%s Heading level %d"
 msgstr "%s Nagłówek poziomu %d"
 
+#. TRANSLATORS: Announcement when landing on a page with no extractable text; %d is the page number
+msgid "Page %d"
+msgstr "Strona %d"
+
 #. TRANSLATORS: Announcement when landing on a page; %d is the page number, %s is the page text
-#, c-format
 msgid "Page %d: %s"
 msgstr "Strona %d: %s"
 
@@ -1766,26 +1716,21 @@ msgid "No previous position."
 msgstr "Brak poprzedniej pozycji."
 
 #. TRANSLATORS: Announced when the document has no containers (lists/tables) to navigate
-#, fuzzy
 msgid "No containers."
-msgstr "Żadnych pojemników."
+msgstr "Brak kontenerów."
 
 #. TRANSLATORS: Announced when the caret is not currently inside a container (list/table)
-#, fuzzy
 msgid "Not in a container."
-msgstr "Nie w pojemniku."
+msgstr "Poza kontenerem."
 
 #. TRANSLATORS: Announced when jumping to the start/end of the container (list/table) the caret is inside, and the target line is blank
-#, fuzzy
 msgid "Past end of container."
-msgstr "Poza końcem kontenera."
+msgstr "Za końcem kontenera."
 
-#, fuzzy
 msgid "Start of container."
 msgstr "Początek kontenera."
 
 #. TRANSLATORS: Announcement when landing on a bookmark; %s is the bookmark/line text, %d is the bookmark's 1-based index
-#, c-format
 msgid "%s - Bookmark %d"
 msgstr "%s - Zakładka %d"
 
@@ -1822,6 +1767,23 @@ msgstr "Zakładka usunięta."
 msgid "Bookmark added."
 msgstr "Zakładka dodana."
 
+#. TRANSLATORS: Announced when trying to play/pause audio on a document that has none
+#. TRANSLATORS: Announced when trying to seek audio on a document that has none
+msgid "This document has no audio."
+msgstr "Ten dokument nie zawiera dźwięku."
+
+#. TRANSLATORS: Announced when trying to seek audio before playback has established a position
+msgid "Audio hasn't started playing yet."
+msgstr "Odtwarzanie dźwięku jeszcze się nie rozpoczęło."
+
+#. TRANSLATORS: Announced when the audio seek amount is already at its largest preset; {} is the current amount, e.g. "1 hour"
+msgid "{} (maximum)"
+msgstr "{} (maksimum)"
+
+#. TRANSLATORS: Announced when the audio seek amount is already at its smallest preset; {} is the current amount, e.g. "5 seconds"
+msgid "{} (minimum)"
+msgstr "{} (minimum)"
+
 msgid "Enter bookmark note:"
 msgstr "Wpisz notatkę zakładki:"
 
@@ -1853,332 +1815,548 @@ msgstr "&Przywróć"
 msgid "Restore Paperback"
 msgstr "Przywróć Paperback"
 
-#. TRANSLATORS: System tray menu item to quit the application
-msgid "E&xit"
-msgstr "Za&kończ"
-
 #. TRANSLATORS: Status bar help text for the tray menu's "Exit" item
 msgid "Exit Paperback"
 msgstr "Zakończ Paperback"
 
+msgid "Open..."
+msgstr "Otwórz..."
+
+msgid "Close All"
+msgstr "Zamknij wszystkie"
+
+msgid "Reopen Last Closed"
+msgstr "Otwórz ponownie ostatnio zamknięty"
+
+msgid "Show All Recent Documents..."
+msgstr "Pokaż wszystkie ostatnie dokumenty..."
+
+msgid "Exit"
+msgstr "Zakończ"
+
+msgid "Find..."
+msgstr "Znajdź..."
+
+msgid "Find Next"
+msgstr "Znajdź następne"
+
+msgid "Find Previous"
+msgstr "Znajdź poprzednie"
+
+msgid "Go to Line..."
+msgstr "Przejdź do wiersza..."
+
+msgid "Go to Percent..."
+msgstr "Przejdź do procentu..."
+
+msgid "Go to Page..."
+msgstr "Przejdź do strony..."
+
+msgid "Go Back"
+msgstr "Przejdź wstecz"
+
+msgid "Go Forward"
+msgstr "Przejdź do przodu"
+
+msgid "Announce Percentage"
+msgstr "Odczytaj procent"
+
+msgid "Set Temporary Bookmark"
+msgstr "Ustaw zakładkę tymczasową"
+
+msgid "Jump to Temporary Bookmark"
+msgstr "Przejdź do zakładki tymczasowej"
+
+msgid "Previous Heading"
+msgstr "Poprzedni nagłówek"
+
+msgid "Next Heading"
+msgstr "Następny nagłówek"
+
+msgid "Previous Heading Level 1"
+msgstr "Poprzedni nagłówek poziomu 1"
+
+msgid "Previous Heading Level 2"
+msgstr "Poprzedni nagłówek poziomu 2"
+
+msgid "Previous Heading Level 3"
+msgstr "Poprzedni nagłówek poziomu 3"
+
+msgid "Previous Heading Level 4"
+msgstr "Poprzedni nagłówek poziomu 4"
+
+msgid "Previous Heading Level 5"
+msgstr "Poprzedni nagłówek poziomu 5"
+
+msgid "Previous Heading Level 6"
+msgstr "Poprzedni nagłówek poziomu 6"
+
+msgid "Previous Page"
+msgstr "Poprzednia strona"
+
+msgid "Next Page"
+msgstr "Następna strona"
+
+msgid "Previous Bookmark"
+msgstr "Poprzednia zakładka"
+
+msgid "Next Bookmark"
+msgstr "Następna zakładka"
+
+msgid "Previous Note"
+msgstr "Poprzednia notatka"
+
+msgid "Next Note"
+msgstr "Następna notatka"
+
+msgid "Jump to All Bookmarks..."
+msgstr "Przejdź do wszystkich zakładek..."
+
+msgid "Jump to Bookmarks Only..."
+msgstr "Przejdź tylko do zakładek..."
+
+msgid "Jump to Notes Only..."
+msgstr "Przejdź tylko do notatek..."
+
+msgid "View Note Text"
+msgstr "Wyświetl treść notatki"
+
+msgid "Previous Link"
+msgstr "Poprzedni odnośnik"
+
+msgid "Next Link"
+msgstr "Następny odnośnik"
+
+msgid "Previous Image"
+msgstr "Poprzedni obraz"
+
+msgid "Next Image"
+msgstr "Następny obraz"
+
+msgid "Previous Figure"
+msgstr "Poprzedni rysunek"
+
+msgid "Next Figure"
+msgstr "Następny rysunek"
+
+msgid "Previous Table"
+msgstr "Poprzednia tabela"
+
+msgid "Next Table"
+msgstr "Następna tabela"
+
+msgid "Previous Separator"
+msgstr "Poprzedni separator"
+
+msgid "Next Separator"
+msgstr "Następny separator"
+
+msgid "Previous List"
+msgstr "Poprzednia lista"
+
+msgid "Next List"
+msgstr "Następna lista"
+
+msgid "Previous List Item"
+msgstr "Poprzedni element listy"
+
+msgid "Next List Item"
+msgstr "Następny element listy"
+
+msgid "Container Start"
+msgstr "Początek kontenera"
+
+msgid "Past Container End"
+msgstr "Za koniec kontenera"
+
+msgid "Elements List..."
+msgstr "Lista elementów..."
+
+msgid "Reveal File in Folder"
+msgstr "Pokaż plik w folderze"
+
+msgid "Open in Web View"
+msgstr "Otwórz w Widoku WWW"
+
+msgid "View Source"
+msgstr "Wyświetl źródło"
+
+msgid "Toggle Bookmark"
+msgstr "Przełącz zakładkę"
+
+msgid "Bookmark with Note"
+msgstr "Zakładka z notatką"
+
+msgid "Toggle Word Wrap"
+msgstr "Włącz lub wyłącz zawijanie wierszy"
+
+msgid "Play/Pause Audio"
+msgstr "Odtwórz lub wstrzymaj dźwięk"
+
+msgid "Seek Audio Forward"
+msgstr "Przewiń dźwięk w przód"
+
+msgid "Seek Audio Backward"
+msgstr "Przewiń dźwięk w tył"
+
+msgid "Increase Audio Seek Amount"
+msgstr "Zwiększ skok przewijania dźwięku"
+
+msgid "Decrease Audio Seek Amount"
+msgstr "Zmniejsz skok przewijania dźwięku"
+
+msgid "Full Screen"
+msgstr "Tryb pełnoekranowy"
+
+msgid "Settings..."
+msgstr "Ustawienia..."
+
+msgid "Sleep Timer..."
+msgstr "Wyłącznik czasowy..."
+
+msgid "Customize Keyboard Shortcuts..."
+msgstr "Dostosuj skróty klawiszowe..."
+
+msgid "Import Document Data..."
+msgstr "Importuj dane dokumentu..."
+
+msgid "Export Document Data..."
+msgstr "Eksportuj dane dokumentu..."
+
+msgid "Export to Plain Text..."
+msgstr "Eksportuj do zwykłego tekstu..."
+
+msgid "Export to HTML..."
+msgstr "Eksportuj do HTML..."
+
+msgid "Export to Markdown..."
+msgstr "Eksportuj do Markdown..."
+
+msgid "About Paperback"
+msgstr "O programie Paperback"
+
+msgid "View Help in Browser"
+msgstr "Wyświetl pomoc w przeglądarce"
+
+msgid "View Help in Paperback"
+msgstr "Wyświetl pomoc w Paperbacku"
+
+msgid "Check for Updates"
+msgstr "Sprawdź aktualizacje"
+
+msgid "Donate"
+msgstr "Wesprzyj"
+
+msgid "File"
+msgstr "Plik"
+
+msgid "Tools"
+msgstr "Narzędzia"
+
+msgid "Help"
+msgstr "Pomoc"
+
+msgid "None"
+msgstr "Brak"
+
+#. TRANSLATORS: Label inserted before a figure or image's description, e.g. "[Figure: a cat sleeping]"
+msgid "Figure"
+msgstr "Rysunek"
+
+msgid "Image"
+msgstr "Obraz"
+
+#. TRANSLATORS: Error shown when a DAISY .opf file is invalid or its DTBook XML can't be located
+msgid "Invalid DAISY .opf file or could not find DTBook XML in manifest"
+msgstr "Nieprawidłowy plik .opf formatu DAISY albo nie znaleziono pliku XML DTBook w manifeście"
+
+#. TRANSLATORS: Error shown when a DAISY 2.02 ncc.html file names no readable content pages
+msgid "Invalid DAISY 2.02 ncc.html file or could not find its content pages"
+msgstr "Nieprawidłowy plik ncc.html formatu DAISY 2.02 albo nie znaleziono jego stron z treścią"
+
 #. TRANSLATORS: Error shown when a DAISY book's DTBook XML fails to convert to plain text
-#, fuzzy
 msgid "Failed to convert DTBook XML to text"
 msgstr "Nie udało się przekonwertować pliku XML DTBook na tekst"
 
 #. TRANSLATORS: Error shown when a ZIP file is not a recognizable DAISY 3 or DAISY 2.02 book
-#, fuzzy
 msgid "ZIP archive does not appear to be a valid DAISY 3 or DAISY 2.02 book"
-msgstr "Archiwum ZIP nie wydaje się być prawidłową książką w formacie DAISY 3 lub DAISY 2.02"
+msgstr "Archiwum ZIP nie wygląda na prawidłową książkę w formacie DAISY 3 ani DAISY 2.02"
 
-#. TRANSLATORS: Error shown when a DAISY .opf file is invalid or its DTBook XML can't be located
-#, fuzzy
-msgid "Invalid DAISY .opf file or could not find DTBook XML in manifest"
-msgstr "Plik .opf formatu DAISY jest nieprawidłowy lub nie znaleziono pliku XML DTBook w manifeście"
+#. TRANSLATORS: Error shown when an EPUB's container.xml is missing its rootfile reference
+msgid "rootfile not found in container.xml"
+msgstr "nie znaleziono elementu rootfile w pliku container.xml"
+
+#. TRANSLATORS: Error shown when an EPUB spine item's content type cannot be converted
+msgid "unsupported content"
+msgstr "nieobsługiwana treść"
 
 #. TRANSLATORS: Error shown when an EPUB's OPF document has no <package> element
-#, fuzzy
 msgid "OPF package element missing"
-msgstr "Brakuje elementu pakietu OPF"
+msgstr "brak elementu package w pliku OPF"
 
 #. TRANSLATORS: Reason given when an EPUB has no spine items that could be read
-#, fuzzy
 msgid "no readable spine items"
-msgstr "brak pozycji z czytelnym tytułem na grzbiecie"
+msgstr "brak czytelnych pozycji w grzbiecie publikacji"
 
 #. TRANSLATORS: Reason given when EPUB spine items failed to convert; {} is a comma-separated list of underlying errors
-#, fuzzy
 msgid "failed to convert spine items: {}"
-msgstr "Nie udało się przekonwertować elementów kręgosłupa: {}"
+msgstr "nie udało się przekonwertować pozycji grzbietu publikacji: {}"
 
 #. TRANSLATORS: Error shown when an EPUB has no readable content; {} is the specific reason (see the two messages above)
-#, fuzzy
 msgid "EPUB has no readable content ({})"
 msgstr "Plik EPUB nie zawiera treści, którą można odczytać ({})"
 
-#. TRANSLATORS: Error shown when an EPUB's container.xml is missing its rootfile reference
-#, fuzzy
-msgid "rootfile not found in container.xml"
-msgstr "Nie znaleziono pliku rootfile w pliku container.xml"
-
-#. TRANSLATORS: Error shown when an EPUB spine item's content type cannot be converted
-#, fuzzy
-msgid "unsupported content"
-msgstr "treść nieobsługiwana"
-
 #. TRANSLATORS: Error shown when an FB2 (FictionBook) file's XML fails to convert to plain text
-#, fuzzy
 msgid "Failed to convert FB2 XML to text"
-msgstr "Nie udało się przekonwertować pliku FB2 XML na tekst"
+msgstr "Nie udało się przekonwertować pliku XML FB2 na tekst"
 
 #. TRANSLATORS: Error shown when an HTML file has no content; {} is the file path
-#, fuzzy
 msgid "HTML file is empty: {}"
 msgstr "Plik HTML jest pusty: {}"
 
 #. TRANSLATORS: Error shown when an HTML file fails to convert to plain text; {} is the file path
-#, fuzzy
 msgid "Failed to convert HTML to text: {}"
 msgstr "Nie udało się przekonwertować kodu HTML na tekst: {}"
 
-#. TRANSLATORS: Label inserted before a figure or image's description, e.g. "[Figure: a cat sleeping]"
-#, fuzzy
-msgid "Figure"
-msgstr "Rysunek"
-
-#, fuzzy
-msgid "Image"
-msgstr "Obraz"
-
 #. TRANSLATORS: Error shown when a Markdown file fails to convert to plain text; {} is the file path
-#, fuzzy
 msgid "Failed to convert Markdown to text: {}"
-msgstr "Nie udało się przekonwertować Markdownu na tekst: {}"
-
-#. TRANSLATORS: Error shown when a MOBI file is too small to contain a valid header
-#, fuzzy
-msgid "File too short"
-msgstr "Plik jest za krótki"
-
-#. TRANSLATORS: Error shown when a MOBI file's record offset table is truncated/corrupt
-#, fuzzy
-msgid "Invalid record offsets"
-msgstr "Nieprawidłowe przesunięcia rekordów"
-
-#. TRANSLATORS: Error shown when a MOBI file has no records
-#, fuzzy
-msgid "No records found"
-msgstr "Nie znaleziono żadnych wpisów"
-
-#. TRANSLATORS: Error shown when a MOBI file's first record has an invalid offset range
-#, fuzzy
-msgid "Invalid Record 0 offsets"
-msgstr "Nieprawidłowy rekord 0 przesunięć"
-
-#. TRANSLATORS: Error shown when a MOBI file's first record is too small to be valid
-#, fuzzy
-msgid "Invalid Record 0"
-msgstr "Nieprawidłowy rekord 0"
-
-#. TRANSLATORS: Error shown when a MOBI file is missing its MOBI header
-#, fuzzy
-msgid "No MOBI header"
-msgstr "Brak nagłówka MOBI"
-
-#. TRANSLATORS: Error shown when a MOBI file's header signature doesn't match the expected "MOBI" identifier
-#, fuzzy
-msgid "Invalid MOBI identifier"
-msgstr "Nieprawidłowy identyfikator MOBI"
-
-#. TRANSLATORS: Error shown when a MOBI file's content record range is invalid
-#, fuzzy
-msgid "Invalid content record range"
-msgstr "Nieprawidłowy zakres rekordów treści"
-
-#. TRANSLATORS: Error shown when a MOBI file's Huffman/CDIC compression records are invalid
-#, fuzzy
-msgid "Invalid HUFF/CDIC records"
-msgstr "Nieprawidłowe rekordy HUFF/CDIC"
-
-#. TRANSLATORS: Error shown when a MOBI file's header is missing Huffman compression parameters
-#, fuzzy
-msgid "Missing HUFF parameters in header"
-msgstr "Brakujące parametry HUFF w nagłówku"
-
-#. TRANSLATORS: Error shown when a MOBI file uses an unrecognized compression mode; {} is the numeric mode value
-#, fuzzy
-msgid "Unsupported compression mode ({})"
-msgstr "Nieobsługiwany tryb kompresji ({})"
+msgstr "Nie udało się przekonwertować pliku Markdown na tekst: {}"
 
 #. TRANSLATORS: Error shown when a MOBI file's Huffman compression record is too small to be valid
-#, fuzzy
 msgid "Invalid HUFF record"
 msgstr "Nieprawidłowy rekord HUFF"
 
 #. TRANSLATORS: Error shown when a MOBI file's Huffman compression record has the wrong signature
-#, fuzzy
 msgid "Invalid HUFF header"
 msgstr "Nieprawidłowy nagłówek HUFF"
 
 #. TRANSLATORS: Error shown when a MOBI file's Huffman cache table offset is out of bounds
-#, fuzzy
 msgid "Invalid HUFF cache offset"
-msgstr "Nieprawidłowy offset pamięci podręcznej HUFF"
+msgstr "Nieprawidłowe przesunięcie pamięci podręcznej HUFF"
 
 #. TRANSLATORS: Error shown when a MOBI file's Huffman code length is invalid
-#, fuzzy
 msgid "Code len out of bounds"
-msgstr "Długość kodu wykracza poza dopuszczalny zakres"
+msgstr "Długość kodu poza dopuszczalnym zakresem"
 
 #. TRANSLATORS: Error shown when a MOBI file's Huffman table has an invalid terminal-code entry
-#, fuzzy
 msgid "Bad term"
-msgstr "Niewłaściwy termin"
+msgstr "Nieprawidłowy kod końcowy"
 
 #. TRANSLATORS: Error shown when a MOBI file's Huffman base table offset is out of bounds
-#, fuzzy
 msgid "Invalid HUFF base offset"
 msgstr "Nieprawidłowe przesunięcie bazowe HUFF"
 
 #. TRANSLATORS: Error shown when a MOBI file's compressed dictionary record has the wrong signature
-#, fuzzy
 msgid "Invalid CDIC header"
 msgstr "Nieprawidłowy nagłówek CDIC"
 
 #. TRANSLATORS: Error shown when a MOBI file's compressed dictionary offset table is out of bounds
-#, fuzzy
 msgid "Invalid CDIC offsets"
 msgstr "Nieprawidłowe przesunięcia CDIC"
 
 #. TRANSLATORS: Error shown when a MOBI file's compressed dictionary phrase offset is out of bounds
-#, fuzzy
 msgid "Invalid CDIC phrase offset"
-msgstr "Nieprawidłowy offset frazy CDIC"
+msgstr "Nieprawidłowe przesunięcie frazy CDIC"
 
 #. TRANSLATORS: Error shown when a MOBI file's compressed dictionary phrase length is out of bounds
-#, fuzzy
 msgid "Invalid CDIC phrase length"
 msgstr "Nieprawidłowa długość frazy CDIC"
 
 #. TRANSLATORS: Error shown when a MOBI file's Huffman code length is out of range; {} is the invalid length value
-#, fuzzy
 msgid "Invalid code_len {}"
-msgstr "Nieprawidłowa długość kodu (code_len){}"
+msgstr "Nieprawidłowa długość kodu (code_len) {}"
 
 #. TRANSLATORS: Error shown when a MOBI file's Huffman decoder recurses too deeply (likely corrupt data)
-#, fuzzy
 msgid "Decode stack overflow"
-msgstr "Rozszyfrowanie błędu przepełnienia stosu"
+msgstr "Przepełnienie stosu podczas dekodowania"
+
+#. TRANSLATORS: Error shown when a MOBI file is too small to contain a valid header
+msgid "File too short"
+msgstr "Plik jest za krótki"
+
+#. TRANSLATORS: Error shown when a MOBI file's record offset table is truncated/corrupt
+msgid "Invalid record offsets"
+msgstr "Nieprawidłowe przesunięcia rekordów"
+
+#. TRANSLATORS: Error shown when a MOBI file has no records
+msgid "No records found"
+msgstr "Nie znaleziono żadnych rekordów"
+
+#. TRANSLATORS: Error shown when a MOBI file's first record has an invalid offset range
+msgid "Invalid Record 0 offsets"
+msgstr "Nieprawidłowe przesunięcia rekordu 0"
+
+#. TRANSLATORS: Error shown when a MOBI file's first record is too small to be valid
+msgid "Invalid Record 0"
+msgstr "Nieprawidłowy rekord 0"
+
+#. TRANSLATORS: Error shown when a MOBI file is missing its MOBI header
+msgid "No MOBI header"
+msgstr "Brak nagłówka MOBI"
+
+#. TRANSLATORS: Error shown when a MOBI file's header signature doesn't match the expected "MOBI" identifier
+msgid "Invalid MOBI identifier"
+msgstr "Nieprawidłowy identyfikator MOBI"
+
+#. TRANSLATORS: Error shown when a MOBI file's content record range is invalid
+msgid "Invalid content record range"
+msgstr "Nieprawidłowy zakres rekordów treści"
+
+#. TRANSLATORS: Error shown when a MOBI file's Huffman/CDIC compression records are invalid
+msgid "Invalid HUFF/CDIC records"
+msgstr "Nieprawidłowe rekordy HUFF/CDIC"
+
+#. TRANSLATORS: Error shown when a MOBI file's header is missing Huffman compression parameters
+msgid "Missing HUFF parameters in header"
+msgstr "Brak parametrów HUFF w nagłówku"
+
+#. TRANSLATORS: Error shown when a MOBI file uses an unrecognized compression mode; {} is the numeric mode value
+msgid "Unsupported compression mode ({})"
+msgstr "Nieobsługiwany tryb kompresji ({})"
 
 #. TRANSLATORS: Error shown when an ODP presentation file has no pages/slides
-#, fuzzy
 msgid "ODP file does not contain any pages"
 msgstr "Plik ODP nie zawiera żadnych stron"
 
 #. TRANSLATORS: Error shown when a flat-XML ODP presentation file has no pages/slides
-#, fuzzy
 msgid "FODP file does not contain any pages"
 msgstr "Plik FODP nie zawiera żadnych stron"
 
-#. TRANSLATORS: Notice inserted into the extracted text when a PDF has images but no text layer at all
-#, fuzzy
-msgid "This PDF contains images only, with no extractable text. You may need to run it through OCR software to read its contents."
-msgstr "Ten plik PDF zawiera wyłącznie obrazy i nie zawiera tekstu, który można by wyodrębnić. Aby zapoznać się z jego treścią, może być konieczne przetworzenie go za pomocą oprogramowania do rozpoznawania tekstu (OCR)."
-
 #. TRANSLATORS: Error detail shown when a PDF's password is missing or wrong (the internal sentinel prefix before it is not translated)
-#, fuzzy
 msgid "Password required or incorrect"
-msgstr "Wymagane hasło lub hasło jest nieprawidłowe"
+msgstr "Wymagane hasło albo hasło jest nieprawidłowe"
 
 #. TRANSLATORS: Error shown when a PDF fails to open for a reason other than a password; {} is the underlying error detail
-#, fuzzy
 msgid "Failed to open PDF document: {}"
 msgstr "Nie udało się otworzyć dokumentu PDF: {}"
 
-#. TRANSLATORS: Error shown when a PPTX presentation file has no slides
-#, fuzzy
-msgid "PPTX file contains no slides"
-msgstr "Plik PPTX nie zawiera żadnych slajdów"
+#. TRANSLATORS: Notice inserted into the extracted text when a PDF has images but no text layer at all
+msgid "This PDF contains images only, with no extractable text. You may need to run it through OCR software to read its contents."
+msgstr "Ten plik PDF zawiera wyłącznie obrazy i nie ma w nim tekstu, który można wyodrębnić. Aby poznać jego treść, być może trzeba będzie przetworzyć go programem rozpoznającym tekst (OCR)."
 
-#, fuzzy
 msgid "Password-protected PPT files are not currently supported. Try saving the file as PPTX and opening that instead."
-msgstr "Pliki PPT chronione hasłem nie są obecnie obsługiwane. Spróbuj zapisać plik w formacie PPTX i otworzyć go w tej wersji."
+msgstr "Pliki PPT chronione hasłem nie są obecnie obsługiwane. Spróbuj zapisać plik w formacie PPTX i otworzyć tę wersję."
 
 #. TRANSLATORS: Error shown when a legacy PPT presentation file has no slides
-#, fuzzy
 msgid "PPT file contains no slides"
 msgstr "Plik PPT nie zawiera żadnych slajdów"
 
 #. TRANSLATORS: Error shown when a legacy PPT file's OLE container has no PowerPoint Document stream
-#, fuzzy
 msgid "PowerPoint Document stream not found"
-msgstr "Nie znaleziono strumienia dokumentów programu PowerPoint"
+msgstr "Nie znaleziono strumienia dokumentu programu PowerPoint"
+
+#. TRANSLATORS: Error shown when a PPTX presentation file has no slides
+msgid "PPTX file contains no slides"
+msgstr "Plik PPTX nie zawiera żadnych slajdów"
 
 #. TRANSLATORS: Error shown when an RTF document's tokens fail to parse; {} is the underlying lexer error
-#, fuzzy
 msgid "Failed to parse RTF document: {}"
 msgstr "Nie udało się przetworzyć dokumentu RTF: {}"
 
-#. TRANSLATORS: Error shown when both DOC parsing strategies fail; the two {} are the underlying error details
-#, fuzzy
-msgid "Legacy DOC parse failed: {}. OOXML fallback failed: {}"
-msgstr "Nie udało się przetworzyć pliku DOC w formacie starszym: {}. Nie udało się zastosować formatu zastępczego OOXML: {}"
+#. TRANSLATORS: Error detail shown when an encrypted Office (OOXML) file needs a password (the internal sentinel prefix before it is not translated)
+msgid "File is encrypted and requires a password"
+msgstr "Plik jest zaszyfrowany i wymaga hasła"
 
-#. TRANSLATORS: Error shown when a ZIP file contains no readable Word document content
-#, fuzzy
-msgid "No readable content found in the ZIP archive"
-msgstr "W archiwum ZIP nie znaleziono żadnej treści, którą można by odczytać"
+#. TRANSLATORS: Error shown when decrypting an encrypted Office (OOXML) file fails; {} is the underlying error
+msgid "Decryption failed (wrong password?): {}"
+msgstr "Nie udało się odszyfrować (błędne hasło?): {}"
 
 #. TRANSLATORS: Error shown when a legacy DOC file is missing required header fields
-#, fuzzy
 msgid "DOC file is missing required FIB fields"
 msgstr "W pliku DOC brakuje wymaganych pól FIB"
 
 #. TRANSLATORS: Error shown when a legacy DOC file's header signature is invalid
-#, fuzzy
 msgid "Not a valid DOC file (invalid FIB magic)"
-msgstr "Nieprawidłowy plik DOC (nieprawidłowy identyfikator FIB)"
+msgstr "To nie jest prawidłowy plik DOC (nieprawidłowy identyfikator FIB)"
 
 #. TRANSLATORS: Error detail shown when an encrypted legacy DOC file needs a password (the internal sentinel prefix before it is not translated)
-#, fuzzy
 msgid "DOC file is encrypted and requires a password"
-msgstr "Plik DOC jest zaszyfrowany i wymaga podania hasła"
+msgstr "Plik DOC jest zaszyfrowany i wymaga hasła"
 
 #. TRANSLATORS: Error detail shown when decrypting a legacy DOC file fails (the internal sentinel prefix before it is not translated); {} is the underlying error
-#, fuzzy
 msgid "DOC decryption failed (wrong password?): {}"
 msgstr "Nie udało się odszyfrować pliku DOC (błędne hasło?): {}"
 
 #. TRANSLATORS: Error shown when a DOC file's fallback content doesn't look like plain text
-#, fuzzy
 msgid "File content does not look like plain text"
 msgstr "Zawartość pliku nie wygląda na zwykły tekst"
 
 #. TRANSLATORS: Error shown when a DOC file's fallback content has no readable text
-#, fuzzy
 msgid "No readable text content found"
-msgstr "Nie znaleziono żadnej treści tekstowej nadającej się do odczytania"
+msgstr "Nie znaleziono treści tekstowej, którą można odczytać"
 
-#. TRANSLATORS: Error detail shown when an encrypted Office (OOXML) file needs a password (the internal sentinel prefix before it is not translated)
-#, fuzzy
-msgid "File is encrypted and requires a password"
-msgstr "Plik jest zaszyfrowany i wymaga podania hasła"
+#. TRANSLATORS: Error shown when a ZIP file contains no readable Word document content
+msgid "No readable content found in the ZIP archive"
+msgstr "W archiwum ZIP nie znaleziono treści, którą można odczytać"
 
-#. TRANSLATORS: Error shown when decrypting an encrypted Office (OOXML) file fails; {} is the underlying error
-#, fuzzy
-msgid "Decryption failed (wrong password?): {}"
-msgstr "Nie udało się odszyfrować (błędne hasło?): {}"
+#. TRANSLATORS: Error shown when both DOC parsing strategies fail; the two {} are the underlying error details
+msgid "Legacy DOC parse failed: {}. OOXML fallback failed: {}"
+msgstr "Nie udało się przetworzyć pliku w starym formacie DOC: {}. Zapasowe otwieranie przez OOXML również się nie powiodło: {}"
 
 #. TRANSLATORS: Error shown when a file has no extension to determine its format; {} is the file path
-#, fuzzy
 msgid "No file extension found for: {}"
 msgstr "Nie znaleziono rozszerzenia pliku dla: {}"
 
 #. TRANSLATORS: Error shown when no parser supports a file's extension; {} is the extension (without the leading dot)
-#, fuzzy
 msgid "No parser found for extension: .{}"
-msgstr "Nie znaleziono programu analizującego pliki z rozszerzeniem: .{}"
+msgstr "Nie znaleziono parsera dla rozszerzenia: .{}"
 
 #. TRANSLATORS: Error shown when every parser for a file's extension failed; {} is the extension (without the leading dot)
-#, fuzzy
 msgid "All parsers failed for extension: .{}"
-msgstr "Wszystkie analizatory nie powiodły się dla rozszerzenia: . {}"
+msgstr "Wszystkie parsery zawiodły dla rozszerzenia: .{}"
 
 #. TRANSLATORS: Error detail shown when a password-protected ZIP-based document needs a password (the internal sentinel prefix before it is not translated)
-#, fuzzy
 msgid "Password required"
 msgstr "Wymagane hasło"
 
 #. TRANSLATORS: Error detail shown when the password for a ZIP-based document is wrong (the internal sentinel prefix before it is not translated)
-#, fuzzy
 msgid "Password incorrect"
 msgstr "Nieprawidłowe hasło"
+
+msgid "Unknown update file format."
+msgstr "Nieznany format pliku aktualizacji."
+
+msgid "Failed to open disk image"
+msgstr "Nie udało się otworzyć obrazu dysku"
+
+msgid "The update has been downloaded and its disk image opened. Quit %s and drag the new version into Applications to finish installing."
+msgstr "Aktualizacja została pobrana, a jej obraz dysku otwarty. Zamknij %s i przeciągnij nową wersję do folderu Aplikacje, aby zakończyć instalację."
+
+msgid "Update Ready"
+msgstr "Aktualizacja gotowa"
+
+msgid "Failed to get current exe path"
+msgstr "Nie udało się pobrać bieżącej ścieżki pliku exe"
+
+msgid "Failed to launch installer script"
+msgstr "Nie udało się uruchomić skryptu instalatora"
+
+msgid "Failed to launch update script"
+msgstr "Nie udało się uruchomić skryptu aktualizacji"
+
+msgid "Update failed"
+msgstr "Aktualizacja nie powiodła się"
+
+msgid ""
+"Update downloaded to: %s\n"
+"Please install it manually."
+msgstr ""
+"Aktualizacja została pobrana do: %s\n"
+"Zainstaluj ją ręcznie."
 
 msgid "Update to %s"
 msgstr "Zaktualizuj do %s"
 
 msgid "A new version of %s is available. Here's what's new:"
 msgstr "Dostępna jest nowa wersja %s. Oto zmiany:"
+
+#. TRANSLATORS: Label for the confirmation dialog "Yes" button
+msgid "&Yes"
+msgstr "&Tak"
+
+#. TRANSLATORS: Label for the confirmation dialog "No" button
+msgid "&No"
+msgstr "&Nie"
 
 msgid "No release notes provided."
 msgstr "Nie podano informacji o wydaniu."
@@ -2199,675 +2377,872 @@ msgid "Info"
 msgstr "Informacja"
 
 msgid "Security verification failed. The update might have been tampered with: %s"
-msgstr "Weryfikacja bezpieczeństwa nie powiodła się. Aktualizacja mogła zostać zmodyfikowana: %s"
+msgstr "Weryfikacja bezpieczeństwa nie powiodła się. W aktualizację mógł ktoś ingerować: %s"
 
 msgid "Security Error"
 msgstr "Błąd bezpieczeństwa"
 
-msgid "Update failed"
-msgstr "Aktualizacja nie powiodła się"
-
-msgid ""
-"Update downloaded to: %s\n"
-"Please install it manually."
-msgstr ""
-"Aktualizacja została pobrana do: %s\n"
-"Zainstaluj ją ręcznie."
-
-msgid "Update Ready"
-msgstr "Aktualizacja gotowa"
-
-msgid "Failed to get current exe path"
-msgstr "Nie udało się pobrać bieżącej ścieżki pliku exe"
-
-msgid "Failed to launch installer script"
-msgstr "Nie udało się uruchomić skryptu instalatora"
-
-msgid "Failed to launch update script"
-msgstr "Nie udało się uruchomić skryptu aktualizacji"
-
-msgid "Unknown update file format."
-msgstr "Nieznany format pliku aktualizacji."
-
-#, fuzzy
-msgid "Go To…"
-msgstr "Przejdź do…"
-
-#, fuzzy
-msgid "Recent Documents"
-msgstr "Najnowsze dokumenty"
-
-#, fuzzy
-msgid "Switch to TTS Mode"
-msgstr "Przełącz na tryb TTS"
-
-#, fuzzy
-msgid "Switch to Text Mode"
-msgstr "Przejdź do trybu tekstowego"
-
-#, fuzzy
-msgid "Sleep Timer (active)"
-msgstr "Wyłącznik czasowy (aktywny)"
-
-#, fuzzy
-msgid "Settings"
-msgstr "Ustawienia"
-
-#, fuzzy
-msgid "More options"
-msgstr "Więcej opcji"
-
-#, fuzzy
-msgid "No document open"
-msgstr "Nie ma otwartych dokumentów"
-
-#, fuzzy
-msgid "Recent"
-msgstr "Najnowsze"
-
-#, fuzzy
-msgid "Screen dimmed by sleep timer. Tap to wake."
-msgstr "Ekran przyciemnił się z powodu wyłącznika czasowego. Dotknij, aby go wybudzić."
-
-#, fuzzy
-msgid "Open Error"
-msgstr "Błąd otwarty"
-
-#, fuzzy
-msgid "Open document"
-msgstr "Otwórz dokument"
-
-#, fuzzy
-msgid "Title"
-msgstr "Tytuł"
-
-#, fuzzy
-msgid "Author"
-msgstr "Autor"
-
-#, fuzzy
-msgid "File"
-msgstr "Plik"
-
-#, fuzzy
-msgid "Words"
-msgstr "Słowa"
-
-#, fuzzy
-msgid "Lines"
-msgstr "Linie"
-
-#, fuzzy
-msgid "Characters"
-msgstr "Postacie"
-
-#, fuzzy
-msgid "Characters (excluding spaces)"
-msgstr "Znaki (bez spacji)"
-
-#, fuzzy
-msgid "Type"
-msgstr "Typ"
-
-#, fuzzy
-msgid "Done"
-msgstr "Gotowe"
-
-#, fuzzy
-msgid "No Elements"
-msgstr "Brak elementów"
-
-#, fuzzy
-msgid "Headings, images, and other elements will appear here."
-msgstr "W tym miejscu pojawią się nagłówki, obrazy i inne elementy."
-
-#, fuzzy
-msgid "Search…"
-msgstr "Wyszukaj…"
-
-#, fuzzy
-msgid "Match Case"
-msgstr "Dopasuj sprawę"
-
-#, fuzzy
-msgid "Whole Word"
-msgstr "Całe słowo"
-
-#, fuzzy
-msgid "Regular Expression"
-msgstr "Wyrażenie regularne"
-
-#, fuzzy
-msgid "Previous result"
-msgstr "Poprzedni wynik"
-
-#, fuzzy
-msgid "Next result"
-msgstr "Kolejny wynik"
-
-#, fuzzy
-msgid "Search"
-msgstr "Wyszukiwanie"
-
-#, fuzzy
-msgid "Mode"
-msgstr "Tryb"
-
-#, fuzzy
-msgid "Page"
-msgstr "Strona"
-
-#, fuzzy
-msgid "Percent"
-msgstr "Procent"
-
-#, fuzzy
-msgid "Line number"
-msgstr "Numer wiersza"
-
-#, fuzzy
-msgid "Page number"
-msgstr "Numer strony"
-
-#, fuzzy
-msgid "Percentage"
-msgstr "Procent"
-
-#, fuzzy
-msgid "Go To"
-msgstr "Przejdź do"
-
-#, fuzzy
-msgid "Password"
-msgstr "Hasło"
-
-#, fuzzy
-msgid "Enter password for {}"
-msgstr "Wprowadź hasło do serwisu {}"
-
-#, fuzzy
-msgid "Password Required"
-msgstr "Wymagane hasło"
-
-#, fuzzy
-msgid "No Recent Documents"
-msgstr "Brak ostatnich dokumentów"
-
-#, fuzzy
-msgid "Documents you open will appear here."
-msgstr "W tym miejscu pojawią się otwierane dokumenty."
-
-#, fuzzy
-msgid "Remove"
-msgstr "Usuń"
-
-#, fuzzy
-msgid "Rule"
-msgstr "Zasada"
-
-#, fuzzy
-msgid "Scope"
-msgstr "Zakres"
-
-#, fuzzy
-msgid "Word"
-msgstr "Word"
-
-#, fuzzy
-msgid "Paragraph"
-msgstr "Akapit"
-
-#, fuzzy
-msgid "Pattern & Replacement"
-msgstr "Wzór i wymiana"
-
-#, fuzzy
-msgid "Pattern"
-msgstr "Wzór"
-
-#, fuzzy
-msgid "Replacement"
-msgstr "Wymiana"
-
-#, fuzzy
-msgid "Whole word only"
-msgstr "Tylko całe słowa"
-
-#, fuzzy
-msgid "Regular expression (\\1 = first capture group)"
-msgstr "Wyrażenie regularne (\\1 = pierwsza grupa przechwytująca)"
-
-#, fuzzy
-msgid "Enabled"
-msgstr "Włączone"
-
-#, fuzzy
-msgid "Apply to"
-msgstr "Zgłoś się do"
-
-#, fuzzy
-msgid "Voices"
-msgstr "Głosy"
-
-#, fuzzy
-msgid "New Rule"
-msgstr "Nowa zasada"
-
-#, fuzzy
-msgid "Edit Rule"
-msgstr "Edytuj regułę"
-
-#, fuzzy
-msgid "Save"
-msgstr "Zapisz"
-
-#, fuzzy
-msgid "All voices"
-msgstr "Wszystkie głosy"
-
-#, fuzzy
-msgid "Apply To"
-msgstr "Zgłoś się do"
-
-#, fuzzy
-msgid "Text to Speech"
-msgstr "Synteza mowy"
-
-#, fuzzy
-msgid "Voice"
-msgstr "Głos"
-
-#, fuzzy
-msgid "Rate"
-msgstr "Ocena"
-
-#, fuzzy
-msgid "Speech Rate"
-msgstr "Tempo mowy"
-
-#, fuzzy
-msgid "Pitch"
-msgstr "Pitch"
-
-#, fuzzy
-msgid "Speech Dictionary"
-msgstr "Słownik mowy"
-
-#, fuzzy
-msgid "Play Sample"
-msgstr "Odtwórz fragment"
-
-#, fuzzy
-msgid "Behavior"
-msgstr "Zachowanie"
-
-#, fuzzy
-msgid "Restore last open documents"
-msgstr "Przywróć ostatnio otwarte dokumenty"
-
-#, fuzzy
-msgid "Swipe up moves forward"
-msgstr "Przesunięcie palcem w górę powoduje przejście do następnej strony"
-
-#, fuzzy
-msgid "Active"
-msgstr "Aktywne"
-
-#, fuzzy
-msgid "Time remaining"
-msgstr "Pozostały czas"
-
-#, fuzzy
-msgid "Cancel Timer"
-msgstr "Anuluj licznik czasu"
-
-#, fuzzy
-msgid "Set timer"
-msgstr "Ustaw minutnik"
-
-#, fuzzy
-msgid "Edit"
-msgstr "Edytuj"
-
-#, fuzzy
-msgid "Add Rule"
-msgstr "Dodaj regułę"
-
-#, fuzzy
-msgid "No Rules"
-msgstr "Bez zasad"
-
-#, fuzzy
-msgid "Contents"
-msgstr "Spis treści"
-
-#, fuzzy
-msgid "No Table of Contents"
-msgstr "Brak spisu treści"
-
-#, fuzzy
-msgid "This document has no table of contents."
-msgstr "Ten dokument nie zawiera spisu treści."
-
-#, fuzzy
-msgid "Tabs"
-msgstr "Zakładki"
-
-#, fuzzy
-msgid "Navigation unit"
-msgstr "Moduł nawigacyjny"
-
-#, fuzzy
-msgid "Previous {}"
-msgstr "Poprzedni artykuł: {}"
-
-#, fuzzy
-msgid "Pause"
-msgstr "Pauza"
-
-#, fuzzy
-msgid "Play"
-msgstr "Zagraj"
-
-#, fuzzy
-msgid "End of document"
-msgstr "Koniec dokumentu"
-
-#, fuzzy
-msgid "Beginning of document"
-msgstr "Początek dokumentu"
-
-#, fuzzy
-msgid "Next {}"
-msgstr "Następny artykuł: {}"
-
-#, fuzzy
-msgid "Press play to start listening."
-msgstr "Naciśnij przycisk odtwarzania, aby rozpocząć odsłuch."
-
-#, fuzzy
-msgid "Locate"
-msgstr "Znajdź"
-
-#, fuzzy
-msgid "File Missing"
-msgstr "Brak pliku"
-
-#, fuzzy
-msgid "Currently Open"
-msgstr "Obecnie dostępne"
-
-#, fuzzy
-msgid "Document Information"
-msgstr "Informacje o dokumencie"
-
-#, fuzzy
-msgid "Expanded"
-msgstr "Rozszerzone"
-
-#, fuzzy
-msgid "Collapsed"
-msgstr "Zwiń"
-
-#, fuzzy
-msgid "Collapse"
-msgstr "Zwiń"
-
-#, fuzzy
-msgid "Expand"
-msgstr "Rozwiń"
-
-#, fuzzy
-msgid "Untitled Link"
-msgstr "Link bez tytułu"
-
-#, fuzzy
-msgid "No supported books or folders found here."
-msgstr "Nie znaleziono tutaj żadnych obsługiwanych plików ani folderów."
-
-#, fuzzy
-msgid "Folder"
-msgstr "Folder"
-
-#, fuzzy
-msgid "Internal Storage"
-msgstr "Pamięć wewnętrzna"
-
-#, fuzzy
-msgid "Search Term"
-msgstr "Wyszukiwane hasło"
-
-#, fuzzy
-msgid "Search History"
-msgstr "Historia wyszukiwania"
-
-#, fuzzy
-msgid "Find Next"
-msgstr "Znajdź następny"
-
-#, fuzzy
-msgid "Password:"
-msgstr "Hasło:"
-
-#, fuzzy
-msgid "All Files Access Required"
-msgstr "Wymagany dostęp do wszystkich plików"
-
-#, fuzzy
-msgid "Paperback requires the 'All Files Access' permission to enable the custom in-app file browser."
-msgstr "Aplikacja Paperback wymaga uprawnienia „Dostęp do wszystkich plików”, aby umożliwić działanie niestandardowej przeglądarki plików w aplikacji."
-
-#, fuzzy
-msgid "Why we need this:"
-msgstr "Dlaczego jest to nam potrzebne:"
-
-#, fuzzy
-msgid "• To provide a fast, fully screen-reader accessible file manager inside the app."
-msgstr "• Zapewnienie w ramach aplikacji szybkiego menedżera plików, w pełni dostępnego dla czytników ekranu."
-
-#, fuzzy
-msgid "• To load large files instantly without needing to copy them into the app's cache."
-msgstr "• Aby błyskawicznie wczytywać duże pliki bez konieczności kopiowania ich do pamięci podręcznej aplikacji."
-
-#, fuzzy
-msgid "• To display the exact local file paths of your documents."
-msgstr "• Aby wyświetlić dokładne lokalne ścieżki dostępu do dokumentów."
-
-#, fuzzy
-msgid "If you deny this permission, you can still use the Android System File Picker to open your books by turning off the custom file browser setting."
-msgstr "Jeśli nie udzielisz tego uprawnienia, nadal będziesz mógł korzystać z systemowego selektora plików systemu Android do otwierania swoich książek, wyłączając opcję niestandardowej przeglądarki plików."
-
-#, fuzzy
-msgid "Grant"
-msgstr "Dotacja"
-
-#, fuzzy
-msgid "Not Now"
-msgstr "Nie teraz"
-
-#, fuzzy
-msgid "Restore last open book"
-msgstr "Przywróć ostatnio otwartą książkę"
-
-#, fuzzy
-msgid "Use in-app file browser (requires All Files permission)"
-msgstr "Skorzystaj z przeglądarki plików w aplikacji (wymagane uprawnienie „Wszystkie pliki”)"
-
-#, fuzzy
-msgid "Text-to-Speech"
-msgstr "Synteza mowy"
-
-#, fuzzy
-msgid "System Default"
-msgstr "Ustawienia domyślne systemu"
-
-#, fuzzy
-msgid "Custom Timer"
-msgstr "Timer niestandardowy"
-
-#, fuzzy
-msgid "Minutes"
-msgstr "Protokół"
-
-#, fuzzy
-msgid "Back"
-msgstr "Powrót"
-
-#, fuzzy
-msgid "Start"
-msgstr "Start"
-
-#, fuzzy
-msgid "Change to:"
-msgstr "Zmień na:"
-
-#, fuzzy
-msgid "Custom time..."
-msgstr "Czas na coś specjalnego..."
-
-#, fuzzy
-msgid "Find Previous"
-msgstr "Znajdź poprzedni"
-
-#, fuzzy
-msgid "Close Search"
-msgstr "Zamknij wyszukiwanie"
-
-#, fuzzy
-msgid "Settings imported"
-msgstr "Ustawienia zaimportowano"
-
-#, fuzzy
-msgid "Failed to import settings"
-msgstr "Nie udało się zaimportować ustawień"
-
-#, fuzzy
+#: swift
+msgid "Export Document Data"
+msgstr "Eksport danych dokumentu"
+
+#: swift
+msgid "Import Document Data"
+msgstr "Import danych dokumentu"
+
+#: swift
 msgid "Settings exported"
-msgstr "Eksportowane ustawienia"
+msgstr "Ustawienia wyeksportowane"
 
-#, fuzzy
+#: swift
 msgid "Failed to export settings"
 msgstr "Nie udało się wyeksportować ustawień"
 
-#, fuzzy
-msgid "No document open. Please open a book."
-msgstr "Nie masz otwartego żadnego dokumentu. Otwórz książkę."
+#: swift
+msgid "Settings imported"
+msgstr "Ustawienia zaimportowane"
 
-#, fuzzy
-msgid "No Documents"
-msgstr "Brak dokumentów"
+#: swift
+msgid "Failed to import settings"
+msgstr "Nie udało się zaimportować ustawień"
 
-#, fuzzy
-msgid "Show All"
-msgstr "Pokaż wszystko"
-
-#, fuzzy
-msgid "Sleep timer: {}"
-msgstr "Timer wyłączania: {}"
-
-#, fuzzy
-msgid "Cancel sleep timer"
-msgstr "Anuluj wyłącznik czasowy"
-
-#, fuzzy
-msgid "Import"
-msgstr "Importuj"
-
-#, fuzzy
-msgid "Import Document Data"
-msgstr "Importuj dane z dokumentu"
-
-#, fuzzy
-msgid "Export Document Data"
-msgstr "Eksportuj dane dokumentu"
-
-#, fuzzy
-msgid "Open Book"
-msgstr "Otwarta książka"
-
-#, fuzzy
-msgid "Elements List"
-msgstr "Lista elementów"
-
-#, fuzzy
-msgid "Show Document"
-msgstr "Pokaż dokument"
-
-#, fuzzy
-msgid "Show Text"
-msgstr "Pokaż tekst"
-
-#, fuzzy
-msgid "Pause Read Aloud"
-msgstr "Wstrzymaj odczytywanie na głos"
-
-#, fuzzy
-msgid "Read Aloud"
-msgstr "Czytaj na głos"
-
-#, fuzzy
-msgid "Help"
-msgstr "Pomoc"
-
-#, fuzzy
-msgid "More Options"
-msgstr "Więcej opcji"
-
-#, fuzzy
-msgid "Heading"
-msgstr "Nagłówek"
-
-#, fuzzy
-msgid "Link"
-msgstr "Link"
-
-#, fuzzy
-msgid "Section"
-msgstr "Sekcja"
-
-#, fuzzy
-msgid "List"
-msgstr "Lista"
-
-#, fuzzy
-msgid "List Item"
-msgstr "Pozycja listy"
-
-#, fuzzy
-msgid "Table"
-msgstr "Tabela"
-
-#, fuzzy
-msgid "Separator"
-msgstr "Separator"
-
-#, fuzzy
+#: swift
 msgid "Document Data"
 msgstr "Dane dokumentu"
 
-#, fuzzy
+#: swift
+msgid "More options"
+msgstr "Więcej opcji"
+
+#: swift
+msgid "Switch to TTS Mode"
+msgstr "Przełącz na tryb mowy"
+
+#: swift
+msgid "Switch to Text Mode"
+msgstr "Przełącz na tryb tekstowy"
+
+#: swift
+msgid "Go To…"
+msgstr "Przejdź do…"
+
+#: swift
+msgid "Recent Documents"
+msgstr "Ostatnie dokumenty"
+
+#: swift
+msgid "Sleep Timer (active)"
+msgstr "Wyłącznik czasowy (aktywny)"
+
+#: swift
+msgid "Type"
+msgstr "Typ"
+
+#: swift
+msgid "No Elements"
+msgstr "Brak elementów"
+
+#: swift
+msgid "Headings, images, and other elements will appear here."
+msgstr "Tu pojawią się nagłówki, obrazy i inne elementy."
+
+#: swift
+msgid "No document open"
+msgstr "Nie otwarto żadnego dokumentu"
+
+#: swift
+msgid "Show All"
+msgstr "Pokaż wszystkie"
+
+#: swift
+msgid "Search…"
+msgstr "Szukaj…"
+
+#: swift
+msgid "Match Case"
+msgstr "Uwzględniaj wielkość liter"
+
+#: swift
+msgid "Whole Word"
+msgstr "Całe słowa"
+
+#: swift
+msgid "Regular Expression"
+msgstr "Wyrażenie regularne"
+
+#: swift
+msgid "Open Error"
+msgstr "Błąd otwierania"
+
+#: swift
+msgid "Open Book"
+msgstr "Otwórz książkę"
+
+#: swift
+msgid "Locate"
+msgstr "Zlokalizuj"
+
+#: swift
+msgid "Remove"
+msgstr "Usuń"
+
+#: swift
+msgid "File Missing"
+msgstr "Brak pliku"
+
+#: swift
+msgid "Currently Open"
+msgstr "Obecnie otwarte"
+
+#: swift
+msgid "No Recent Documents"
+msgstr "Brak ostatnich dokumentów"
+
+#: swift
+msgid "Documents you open will appear here."
+msgstr "Tu pojawią się otwierane dokumenty."
+
+#: swift
+msgid "Text to Speech"
+msgstr "Synteza mowy"
+
+#: swift
+msgid "Voice"
+msgstr "Głos"
+
+#: swift
+msgid "Rate"
+msgstr "Tempo"
+
+#: swift
+msgid "Speech Rate"
+msgstr "Tempo mowy"
+
+#: swift
+msgid "Pitch"
+msgstr "Wysokość głosu"
+
+#: swift
+msgid "Speech Dictionary"
+msgstr "Słownik mowy"
+
+#: swift
+msgid "Play Sample"
+msgstr "Odtwórz próbkę"
+
+#: swift
+msgid "Text Size"
+msgstr "Rozmiar tekstu"
+
+#: swift
+msgid "Line Spacing"
+msgstr "Odstęp między wierszami"
+
+#: swift
+msgid "Paragraph Spacing"
+msgstr "Odstęp między akapitami"
+
+#: swift
+msgid "Alignment"
+msgstr "Wyrównanie"
+
+#: swift
+msgid "Behavior"
+msgstr "Zachowanie"
+
+#: swift
+msgid "Restore last open documents"
+msgstr "Przywracaj ostatnio otwarte dokumenty"
+
+#: swift
+msgid "Swipe up moves forward"
+msgstr "Przesunięcie w górę przenosi do przodu"
+
+#: swift
+msgid "Title"
+msgstr "Tytuł"
+
+#: swift
+msgid "Author"
+msgstr "Autor"
+
+#: swift
+msgid "Words"
+msgstr "Słowa"
+
+#: swift
+msgid "Lines"
+msgstr "Wiersze"
+
+#: swift
+msgid "Characters"
+msgstr "Znaki"
+
+#: swift
+msgid "Characters (excluding spaces)"
+msgstr "Znaki (bez spacji)"
+
+#: swift
+msgid "Mode"
+msgstr "Tryb"
+
+#: swift
+msgid "Page"
+msgstr "Strona"
+
+#: swift
+msgid "Percent"
+msgstr "Procent"
+
+#: swift
+msgid "Line number"
+msgstr "Numer wiersza"
+
+#: swift
+msgid "Page number"
+msgstr "Numer strony"
+
+#: swift
+msgid "Percentage"
+msgstr "Procent"
+
+#: swift
+msgid "Go To"
+msgstr "Przejdź do"
+
+#: swift
+msgid "Password"
+msgstr "Hasło"
+
+#: swift
+msgid "Enter password for {}"
+msgstr "Wprowadź hasło do {}"
+
+#: swift
+msgid "Password Required"
+msgstr "Wymagane hasło"
+
+#: swift
+msgid "Rule"
+msgstr "Reguła"
+
+#: swift
+msgid "Scope"
+msgstr "Zakres"
+
+#: swift
+msgid "Word"
+msgstr "Słowo"
+
+#: swift
+msgid "Paragraph"
+msgstr "Akapit"
+
+#: swift
+msgid "Pattern & Replacement"
+msgstr "Wzorzec & zamiennik"
+
+#: swift
+msgid "Pattern"
+msgstr "Wzorzec"
+
+#: swift
+msgid "Replacement"
+msgstr "Zamiennik"
+
+#: swift
+msgid "Whole word only"
+msgstr "Tylko całe słowa"
+
+#: swift
+msgid "Regular expression (\\1 = first capture group)"
+msgstr "Wyrażenie regularne (\\1 = pierwsza grupa przechwytująca)"
+
+#: swift
+msgid "Enabled"
+msgstr "Włączona"
+
+#: swift
+msgid "Apply to"
+msgstr "Zastosuj do"
+
+#: swift
+msgid "Voices"
+msgstr "Głosy"
+
+#: swift
+msgid "New Rule"
+msgstr "Nowa reguła"
+
+#: swift
+msgid "Edit Rule"
+msgstr "Edytuj regułę"
+
+#: swift
+msgid "Save"
+msgstr "Zapisz"
+
+#: swift
+msgid "All voices"
+msgstr "Wszystkie głosy"
+
+#: swift
+msgid "Apply To"
+msgstr "Zastosuj do"
+
+#: swift
 msgid "Sleep timer running, {} remaining"
-msgstr "Czasomierz uśpienia działa, pozostało {}"
+msgstr "Wyłącznik czasowy działa, pozostało {}"
 
-#, fuzzy
+#: swift
 msgid "Custom"
-msgstr "Niestandardowe"
+msgstr "Własny"
 
-#, fuzzy
+#: swift
 msgid "Custom: {} minutes"
-msgstr "Na zamówienie: {} minut"
+msgstr "Własny: {} minut"
 
-#, fuzzy
+#: swift
 msgid "Duration"
 msgstr "Czas trwania"
 
-#, fuzzy
+#: swift
+msgid "Minutes"
+msgstr "Minuty"
+
+#: swift
+msgid "Done"
+msgstr "Gotowe"
+
+#: swift
 msgid "Stop Timer"
-msgstr "Zatrzymaj licznik czasu"
+msgstr "Zatrzymaj wyłącznik"
+
+#: swift
+msgid "Start Timer"
+msgstr "Uruchom wyłącznik"
+
+#: swift
+msgid "Edit"
+msgstr "Edytuj"
+
+#: swift
+msgid "Add Rule"
+msgstr "Dodaj regułę"
+
+#: swift
+msgid "No Rules"
+msgstr "Brak reguł"
+
+#: swift
+msgid "Tabs"
+msgstr "Karty"
+
+#: swift
+msgid "Contents"
+msgstr "Spis treści"
+
+#: swift
+msgid "No Table of Contents"
+msgstr "Brak spisu treści"
+
+#: swift
+msgid "This document has no table of contents."
+msgstr "Ten dokument nie zawiera spisu treści."
+
+#: swift
+msgid "Navigation unit"
+msgstr "Jednostka nawigacji"
+
+#: swift
+msgid "Previous {}"
+msgstr "Poprzedni element: {}"
+
+#: swift
+msgid "Pause"
+msgstr "Wstrzymaj"
+
+#: swift
+msgid "Play"
+msgstr "Odtwórz"
+
+#: swift
+msgid "End of document"
+msgstr "Koniec dokumentu"
+
+#: swift
+msgid "Beginning of document"
+msgstr "Początek dokumentu"
+
+#: swift
+msgid "Next {}"
+msgstr "Następny element: {}"
+
+#: swift
+msgid "Press play to start listening."
+msgstr "Naciśnij przycisk odtwarzania, aby rozpocząć słuchanie."
+
+#: kt
+msgid "Document Information"
+msgstr "Informacje o dokumencie"
+
+#: kt
+msgid "Untitled Link"
+msgstr "Odnośnik bez tytułu"
+
+#: kt
+msgid "Export Document"
+msgstr "Eksport dokumentu"
+
+#: kt
+msgid "Select a format to export the current document:"
+msgstr "Wybierz format eksportu bieżącego dokumentu:"
+
+#: kt
+msgid "Plain Text (.txt)"
+msgstr "Zwykły tekst (.txt)"
+
+#: kt
+msgid "HTML (.html)"
+msgstr "HTML (.html)"
+
+#: kt
+msgid "Markdown (.md)"
+msgstr "Markdown (.md)"
+
+#: kt
+msgid "No supported books or folders found here."
+msgstr "Nie znaleziono tu obsługiwanych książek ani folderów."
+
+#: kt
+msgid "Folder"
+msgstr "Folder"
+
+#: kt
+msgid "Internal Storage"
+msgstr "Pamięć wewnętrzna"
+
+#: kt
+msgid "Search Term"
+msgstr "Szukany tekst"
+
+#: kt
+msgid "Search History"
+msgstr "Historia wyszukiwania"
+
+#: kt
+msgid "Password:"
+msgstr "Hasło:"
+
+#: kt
+msgid "All Files Access Required"
+msgstr "Wymagany dostęp do wszystkich plików"
+
+#: kt
+msgid "Paperback requires the 'All Files Access' permission to enable the custom in-app file browser."
+msgstr "Paperback potrzebuje uprawnienia „Dostęp do wszystkich plików”, aby udostępnić własną przeglądarkę plików w aplikacji."
+
+#: kt
+msgid "Why we need this:"
+msgstr "Dlaczego jest potrzebne:"
+
+#: kt
+msgid "To provide a fast, fully screen-reader accessible file manager inside the app."
+msgstr "Aby zapewnić w aplikacji szybki menedżer plików, w pełni dostępny dla czytników ekranu."
+
+#: kt
+msgid "To load large files instantly without needing to copy them into the app's cache."
+msgstr "Aby wczytywać duże pliki natychmiast, bez kopiowania ich do pamięci podręcznej aplikacji."
+
+#: kt
+msgid "To display the exact local file paths of your documents."
+msgstr "Aby pokazywać dokładne lokalne ścieżki Twoich dokumentów."
+
+#: kt
+msgid "If you deny this permission, you can still use the Android System File Picker to open your "
+msgstr "Jeśli odmówisz tego uprawnienia, nadal możesz otwierać swoje "
+
+#: kt
+msgid "Grant"
+msgstr "Przyznaj"
+
+#: kt
+msgid "Not Now"
+msgstr "Nie teraz"
+
+#: kt
+msgid "Custom Timer"
+msgstr "Własny wyłącznik czasowy"
+
+#: kt
+msgid "Back"
+msgstr "Wstecz"
+
+#: kt
+msgid "Start"
+msgstr "Uruchom"
+
+#: kt
+msgid "Active: {} remaining"
+msgstr "Aktywny: pozostało {}"
+
+#: kt
+msgid "remaining"
+msgstr "pozostało"
+
+#: kt
+msgid "Cancel Timer"
+msgstr "Anuluj wyłącznik czasowy"
+
+#: kt
+msgid "Change to:"
+msgstr "Zmień na:"
+
+#: kt
+msgid "{} minutes"
+msgstr "{} minut"
+
+#: kt
+msgid "Custom time..."
+msgstr "Własny czas..."
+
+#: kt
+msgid "Expanded"
+msgstr "Rozwinięte"
+
+#: kt
+msgid "Collapsed"
+msgstr "Zwinięte"
+
+#: kt
+msgid "Collapse"
+msgstr "Zwiń"
+
+#: kt
+msgid "Expand"
+msgstr "Rozwiń"
+
+#: kt
+msgid "This document contains {} words."
+msgstr "Ten dokument zawiera {} słów."
+
+#: kt
+msgid "words"
+msgstr "słowa"
+
+#: kt
+msgid "Close Search"
+msgstr "Zamknij wyszukiwanie"
+
+#: kt
+msgid "Document exported"
+msgstr "Dokument wyeksportowany"
+
+#: kt
+msgid "Failed to export document"
+msgstr "Nie udało się wyeksportować dokumentu"
+
+#: kt
+msgid "No document open. Please open a book."
+msgstr "Nie otwarto żadnego dokumentu. Otwórz książkę."
+
+#: kt
+msgid "No Documents"
+msgstr "Brak dokumentów"
+
+#: kt
+msgid "Sleep timer: {}"
+msgstr "Wyłącznik czasowy: {}"
+
+#: kt
+msgid "Cancel sleep timer"
+msgstr "Anuluj wyłącznik czasowy"
+
+#: kt
+msgid "Import"
+msgstr "Importuj"
+
+#: kt
+msgid "More Options"
+msgstr "Więcej opcji"
+
+#: kt
+msgid "Pause Read Aloud"
+msgstr "Wstrzymaj czytanie na głos"
+
+#: kt
+msgid "Read Aloud"
+msgstr "Czytaj na głos"
+
+#: kt
+msgid "Export As"
+msgstr "Eksportuj jako"
+
+#: kt
+msgid "Elements List"
+msgstr "Lista elementów"
+
+#: kt
+msgid "No more matches."
+msgstr "Nie ma więcej dopasowań."
+
+#: kt
+msgid "Heading"
+msgstr "Nagłówek"
+
+#: kt
+msgid "Link"
+msgstr "Odnośnik"
+
+#: kt
+msgid "Section"
+msgstr "Sekcja"
+
+#: kt
+msgid "List"
+msgstr "Lista"
+
+#: kt
+msgid "List Item"
+msgstr "Element listy"
+
+#: kt
+msgid "Table"
+msgstr "Tabela"
+
+#: kt
+msgid "Separator"
+msgstr "Separator"
+
+#: kt
+msgid "{} seconds"
+msgstr "{} sekund"
+
+#: kt
+msgid "✓ Granted"
+msgstr "✓ Przyznane"
+
+#: kt
+msgid "Before You Start"
+msgstr "Zanim zaczniesz"
+
+#: kt
+msgid "Paperback works best with a couple of permissions. Here's what we ask for and why:"
+msgstr "Paperback działa najlepiej z kilkoma uprawnieniami. Oto o co prosimy i dlaczego:"
+
+#: kt
+msgid "Notifications"
+msgstr "Powiadomienia"
+
+#: kt
+msgid "Lets Paperback show playback controls in the notification shade while text-to-speech is "
+msgstr "Pozwala Paperbackowi pokazywać sterowanie odtwarzaniem w obszarze powiadomień, gdy synteza mowy "
+
+#: kt
+msgid "Enable Notifications"
+msgstr "Włącz powiadomienia"
+
+#: kt
+msgid "All Files Access"
+msgstr "Dostęp do wszystkich plików"
+
+#: kt
+msgid "Powers the optional in-app file browser, so you can open documents from anywhere on your "
+msgstr "Umożliwia działanie opcjonalnej przeglądarki plików w aplikacji, dzięki czemu otworzysz dokumenty z dowolnego miejsca "
+
+#: kt
+msgid "Enable File Access"
+msgstr "Włącz dostęp do plików"
+
+#: kt
+msgid "Continue"
+msgstr "Kontynuuj"
+
+#: kt
+msgid "Restore last open book"
+msgstr "Przywracaj ostatnio otwartą książkę"
+
+#: kt
+msgid "Use in-app file browser (requires All Files permission)"
+msgstr "Używaj przeglądarki plików w aplikacji (wymaga uprawnienia „Dostęp do wszystkich plików”)"
+
+#: kt
+msgid "Text-to-Speech"
+msgstr "Synteza mowy"
+
+#: kt
+msgid "System Default"
+msgstr "Domyślne systemowe"
+
+#: kt
+msgid "Back {}"
+msgstr "Wstecz {}"
+
+#: kt
+msgid "Forward {}"
+msgstr "Do przodu {}"
+
+#: kt
+msgid "Enter {}"
+msgstr "Wprowadź {}"
+
+#: kt
+msgid "Error loading document: {}"
+msgstr "Błąd wczytywania dokumentu: {}"
+
+#: kt
+msgid "1.5×"
+msgstr "1,5×"
+
+#: kt
+msgid "Speech Engine"
+msgstr "Silnik mowy"
+
+#~ msgid "hours"
+#~ msgstr "godz."
+
+#~ msgid "Sleep timer set for 1 minute."
+#~ msgstr "Wyłącznik czasowy ustawiony na 1 minutę."
+
+#~ msgid "Go to &Page\tCtrl+P"
+#~ msgstr "Przejdź do &strony\tCtrl+P"
+
+#~ msgid "&View Note Text\tRawCtrl+Shift+W"
+#~ msgstr "&Wyświetl tekst notatki\tRawCtrl+Shift+W"
+
+#~ msgid "&View Note Text\tCtrl+Shift+W"
+#~ msgstr "&Wyświetl tekst notatki\tCtrl+Shift+W"
+
+#~ msgid "&Open...\tCtrl+O"
+#~ msgstr "&Otwórz...\tCtrl+O"
+
+#~ msgid "&Close\tCtrl+W"
+#~ msgstr "&Zamknij\tCtrl+W"
+
+#~ msgid "&Close\tCtrl+F4"
+#~ msgstr "&Zamknij\tCtrl+F4"
+
+#~ msgid "Close &All\tCtrl+Shift+W"
+#~ msgstr "Zamknij &wszystkie\tCtrl+Shift+W"
+
+#~ msgid "Close &All\tCtrl+Shift+F4"
+#~ msgstr "Zamknij &wszystkie\tCtrl+Shift+F4"
+
+#~ msgid "E&xit\tCtrl+Q"
+#~ msgstr "Za&kończ\tCtrl+Q"
+
+#~ msgid "&Find...\tCtrl+F"
+#~ msgstr "&Znajdź...\tCtrl+F"
 
 #, fuzzy
-msgid "Start Timer"
-msgstr "Uruchom licznik czasu"
+#~ msgid "Find &Next\tCtrl+G"
+#~ msgstr "Znajdź i następny    Ctrl+G"
+
+#~ msgid "Find &Next\tF3"
+#~ msgstr "Znajdź &następne\tF3"
+
+#, fuzzy
+#~ msgid "Find &Previous\tCtrl+Shift+G"
+#~ msgstr "Znajdź i poprzedni    Ctrl+Shift+G"
+
+#~ msgid "Find &Previous\tShift+F3"
+#~ msgstr "Znajdź &poprzednie\tShift+F3"
+
+#, fuzzy
+#~ msgid "Go to &line...\tCtrl+L"
+#~ msgstr "Przejdź do wiersza...    Ctrl+L"
+
+#~ msgid "Go to &line...\tCtrl+G"
+#~ msgstr "Przejdź do &wiersza...\tCtrl+G"
+
+#, fuzzy
+#~ msgid "Go to &percent...\tCtrl+Shift+L"
+#~ msgstr "Przejdź do &percent...    Ctrl+Shift+L"
+
+#~ msgid "Go to &percent...\tCtrl+Shift+G"
+#~ msgstr "Przejdź do &procentu...\tCtrl+Shift+G"
+
+#~ msgid "Go &Back\tAlt+Left"
+#~ msgstr "W&stecz\tAlt+Left"
+
+#~ msgid "Go &Forward\tAlt+Right"
+#~ msgstr "D&o przodu\tAlt+Right"
+
+#~ msgid "&Import Document Data...\tCtrl+Shift+I"
+#~ msgstr "&Importuj dane dokumentu...\tCtrl+Shift+I"
+
+#~ msgid "&Export Document Data...\tCtrl+Shift+E"
+#~ msgstr "&Eksportuj dane dokumentu...\tCtrl+Shift+E"
+
+#~ msgid "&Word Count\tRawCtrl+W"
+#~ msgstr "&Liczba słów\tRawCtrl+W"
+
+#~ msgid "&Word Count\tCtrl+W"
+#~ msgstr "&Liczba słów\tCtrl+W"
+
+#~ msgid "Document &Info\tCtrl+I"
+#~ msgstr "&Informacje o dokumencie\tCtrl+I"
+
+#~ msgid "&Table of Contents\tCtrl+T"
+#~ msgstr "&Spis treści\tCtrl+T"
+
+#~ msgid "Bookmark with &Note\tCtrl+Shift+N"
+#~ msgstr "Zakładka z &notatką\tCtrl+Shift+N"
+
+#, fuzzy
+#~ msgid "Word w&rap\tCtrl+Alt+W"
+#~ msgstr "Zawijanie tekstu    Ctrl+Alt+W"
+
+#~ msgid "&Options\tCtrl+,"
+#~ msgstr "&Opcje\tCtrl+,"
+
+#~ msgid "&Sleep Timer...\tCtrl+Shift+S"
+#~ msgstr "&Wyłącznik czasowy...\tCtrl+Shift+S"
+
+#~ msgid "View Help in &Paperback\tShift+F1"
+#~ msgstr "Wyświetl pomoc w &Paperbacku\tShift+F1"
+
+#~ msgid "Check for &Updates\tCtrl+Shift+U"
+#~ msgstr "Sprawdź &aktualizacje\tCtrl+Shift+U"
+
+#~ msgid "Show All...\tCtrl+R"
+#~ msgstr "Pokaż wszystko...\tCtrl+R"
+
+#, fuzzy
+#~ msgid "Recent"
+#~ msgstr "Najnowsze"
+
+#, fuzzy
+#~ msgid "Screen dimmed by sleep timer. Tap to wake."
+#~ msgstr "Ekran przyciemnił się z powodu wyłącznika czasowego. Dotknij, aby go wybudzić."
+
+#, fuzzy
+#~ msgid "Open document"
+#~ msgstr "Otwórz dokument"
+
+#, fuzzy
+#~ msgid "Next result"
+#~ msgstr "Kolejny wynik"
+
+#, fuzzy
+#~ msgid "Search"
+#~ msgstr "Wyszukiwanie"
+
+#, fuzzy
+#~ msgid "Active"
+#~ msgstr "Aktywne"
+
+#, fuzzy
+#~ msgid "Set timer"
+#~ msgstr "Ustaw minutnik"
+
+#, fuzzy
+#~ msgid "Show Document"
+#~ msgstr "Pokaż dokument"
+
+#, fuzzy
+#~ msgid "Show Text"
+#~ msgstr "Pokaż tekst"
 
 #~ msgid "Are you sure you want to remove this document from the list? This will also remove its reading position."
 #~ msgstr "Czy na pewno chcesz usunąć ten dokument z listy? Spowoduje to też usunięcie jego pozycji czytania."


### PR DESCRIPTION
The auto-translate runs had filled the gaps in this locale with machine output that `msgfmt` accepts but a user does not. Since `pl` is on the human-maintained list the bot will not touch it again, so this is a one-time cleanup of the damage already committed rather than something that will keep recurring.

The catalog goes from 335 translated / 449 fuzzy / 52 untranslated to **836 translated, nothing fuzzy or empty**. Every entry was reviewed by hand against the current pot. Worth noting that fuzzy entries are not harmless here: `patois-build` compiles with `msgfmt --use-fuzzy`, so all of these were reaching users.

### What the machine had broken

- **13 menu accelerators lost**, because the ampersand was translated as the Polish word *i* (and): "Find &Next" became "Znajdź i następny" (*Find and next*), "Go &Back" became "Przejdź do przodu i do tyłu" (*Go forward and back*), "Reveal &File in Folder" became "Pokaż i zapisz w folderze" (*Show and save in folder*).
- **6 entries lost the tab** separating a label from its shortcut, replaced with spaces, so a screen reader announces `Zaznacz wszystko    Ctrl+A` as the item's name rather than as a shortcut.
- **Plural forms broken**: ngettext entries dropped `%d` entirely (`%d document.` became just "dokument") or used the wrong placeholder syntax, and all three Polish plural forms were identical, which defeats the point of having three.
- **Semantic errors**: Undo and Redo shared one translation, `Cu&t` was left in English, `Font: {}` became "Źródło: {}" (*Source: {}*), `Go` became "Start".

### Also in this PR

Terminology unified across the catalog (Web View was rendered two different ways, `parser` two ways, and the word "word" two ways), and two wording fixes: the signature failure message said the update might have been *modified*, losing the security sense of "tampered with", and the image-only PDF notice turned "may need" into a categorical "must".

**The help was still the 0.8.5 document** — 30 headings against the English 64 — and it would never have corrected itself, since listing `pl` in `human-maintained-locales.txt` opts it out for `doc/readme-<lang>.md` too. The most serious omission was the **Screen Reader Compatibility** section, including the JAWS and Braille Displays subsection with the `paperback.jcf` workaround: in an app written for screen reader users that is the section that matters most, and a reader using the Polish help had no way to learn about it. Also added: the 0.9.0 changelog, the new system requirements, four newly supported file types, the macOS shortcut equivalents, the container navigation and temporary bookmark keys, Dutch in the language list, and one donor name. The 0.8.5-and-older changelog was already complete and is untouched.

Key names in the help are now Polish while modifiers are left alone, matching what the German translation does (`Leertaste`, `Alt+Pfeil nach links`, `Entf auf dem Ziffernblock`): `Ctrl+Space` → `Ctrl+Spacja`, `Alt+Left` → `Alt+Strzałka w lewo`. Ctrl, Alt and Shift are printed that way on Polish keyboards, so translating those would help nobody.

### Checks

`msgfmt --check`: 836 translated, 0 fuzzy, 0 untranslated. Placeholders, accelerator counts, shortcut tabs and the three plural forms verified per entry. Help structure verified against `doc/readme.md`: same headings at the same levels, same bullet count per section, identical shortcuts and file extensions. `cargo test -p paperback-core`: 628 pass; the 2 failures are identical on unmodified `master` (table display-length tests), so they are not from this change.

Reviewed with several independent reviewers and kept only findings that held up against the file and the code — for instance "loaded document window" is the loaded buffer rather than a UI window, so the Polish now says *fragment* rather than *okno*.

Happy to split, reword or drop any part of this if you'd prefer it shaped differently.
