### PR TITLE
Give every embedded readme a lang attribute

### DIFF
--- a/crates/paperback/build/docs.rs
+++ b/crates/paperback/build/docs.rs
@@ -30,6 +30,7 @@ pub fn build() {
 		let out_output = out_dir.join("readme.html");
 		let status = Command::new("pandoc")
 			.arg(format!("--defaults={}", config.display()))
+			.args(["-M", "lang=en"])
 			.arg(&readme)
 			.arg("-o")
 			.arg(&out_output)
@@ -56,8 +57,14 @@ pub fn build() {
 				};
 				println!("cargo:rerun-if-changed={}", path.display());
 				let lang_output = out_dir.join(format!("readme-{lang_code}.html"));
+				// Pandoc needs the language as BCP 47 to emit a usable `lang` attribute, but our
+				// locale codes use gettext's underscore form (zh_CN). Without this metadata every
+				// readme ships with `lang=""`, so a screen reader has no idea which language the
+				// help is in and may read a translated page with an English voice.
+				let bcp47 = lang_code.replace('_', "-");
 				let status = Command::new("pandoc")
 					.arg(format!("--defaults={}", config.display()))
+					.args(["-M", &format!("lang={bcp47}")])
 					.arg(&path)
 					.arg("-o")
 					.arg(&lang_output)


### PR DESCRIPTION
`docs.rs` invokes pandoc without a `lang` metadata value, so every readme in every language is embedded with `lang=""`:

```html
<html xmlns="http://www.w3.org/1999/xhtml" lang="" xml:lang="">
```

A screen reader then has no idea what language the help is in. It may read the Polish, German or Japanese help with an English voice, mispronouncing the entire document — and the help is the one place in the app where a user reads continuous prose rather than short labels, so it is where this hurts most. It affects all 14 locales, not just one, which is why I'm sending it as a code change rather than working around it in a single translation.

Passing the locale as metadata fixes it. The conversion matters: our locale codes use gettext's underscore form and pandoc wants BCP 47, so `zh_CN` has to become `zh-CN` — otherwise that one readme gets an *invalid* language tag instead of a missing one.

### Verification

Rendered every `doc/readme*.md` exactly the way this function does. All 14 languages come out with the correct tag:

```
readme        lang=en        readme-nl     lang=nl
readme-bs     lang=bs        readme-pl     lang=pl
readme-cs     lang=cs        readme-pt_br  lang=pt-br
readme-de     lang=de        readme-ru     lang=ru
readme-es     lang=es        readme-sr     lang=sr
readme-fi     lang=fi        readme-vi     lang=vi
readme-fr     lang=fr        readme-zh_CN  lang=zh-CN
```

As a negative control, the same render *without* the metadata still produces an empty tag, so the change is doing the work rather than the defaults having been fixed elsewhere. Also confirmed on a built `paperback.exe` from CI: the embedded Polish help carries `lang="pl"` and no embedded readme has an empty one.

Note this is deliberately independent of my translation PR (730) — neither needs the other, so you can take or leave them separately.
