### PR TITLE
Polish: be definite about the JAWS option labels

### DIFF
--- a/doc/readme-pl.md
+++ b/doc/readme-pl.md
@@ -30,7 +30,7 @@ Jeśli używasz JAWS z linijką brajlowską, możesz zauważyć, że długie aka
 
 Obejście, które po miesiącach oczekiwania wyszło w końcu na grupie dyskusyjnej JAWS, polega na edycji pliku `paperback.jcf` i ustawieniu opcji „Braille Presentation and Panning” na „Always use DOM if available”. Warto też włączyć „Pan Text by Paragraph”, bo inaczej linijka pozostanie na aktywnym akapicie, zamiast przesuwać się dalej. Przy obu ustawieniach przesuwanie linijki powinno działać poprawnie.
 
-Nazwy tych opcji podano po angielsku, bo tak brzmią w pliku konfiguracyjnym. W polskiej wersji JAWS ich etykiety w okienku ustawień mogą być przetłumaczone.
+Nazwy tych opcji podano po angielsku, bo w takiej postaci występują w pliku konfiguracyjnym. Polska wersja JAWS ma odpowiadające im etykiety przetłumaczone, więc w okienku ustawień będą brzmiały inaczej.
 
 ## Aktualnie obsługiwane typy plików
 


### PR DESCRIPTION
Small follow-up to #730. The note I added about the JAWS braille settings hedged, saying the Polish labels "may be" translated. They are: Polish JAWS ships a translated interface, so someone looking for these options in the settings dialog will not find the English strings there.

The option names stay in English in the text, since that is the form they take in `paperback.jcf` — the file the reader is actually editing — but the note now says plainly that the dialog will read differently.