### PR TITLE
Mark the word-count dialog's many-form for per-language plural splitting

### DIFF
--- a/android/app/src/main/kotlin/dev/paperback/android/ui/dialogs/WordCountDialog.kt
+++ b/android/app/src/main/kotlin/dev/paperback/android/ui/dialogs/WordCountDialog.kt
@@ -29,10 +29,11 @@ fun WordCountDialog(
 	// replaced with the number. Three forms picked by the count's last digits (see nt() in
 	// Translations.kt): one = counts ending in 1 except 11 (1, 21, 31, ...), few = counts ending
 	// in 2-4 except 12-14 (2, 3, 4, 22, 23, 24, ...), many = everything else (0, 5-20, 25-30, ...).
+	// The "many" form's trailing character isn't a typo — see PLURAL_MANY_MARKER in Translations.kt.
 	val announcement = nt(
 		t("This document contains {} word."),
 		t("This document contains {} words."),
-		t("This document contains {} words."),
+		t("This document contains {} words.⁣"),
 		stats.wordCount
 	).replaceFirst("{}", "${stats.wordCount}")
 
@@ -56,8 +57,10 @@ fun WordCountDialog(
 				Text(
 					// TRANSLATORS: Unit label shown under the large word-count number. Three forms
 					// picked by the count's last digits (see nt() in Translations.kt): one = counts
-					// ending in 1 except 11, few = counts ending in 2-4 except 12-14, many = everything else.
-					text = nt(t("word"), t("words"), t("words"), stats.wordCount),
+					// ending in 1 except 11, few = counts ending in 2-4 except 12-14, many = everything
+					// else. The "many" form's trailing character isn't a typo — see PLURAL_MANY_MARKER
+					// in Translations.kt.
+					text = nt(t("word"), t("words"), t("words⁣"), stats.wordCount),
 					style = MaterialTheme.typography.bodyMedium,
 					color = MaterialTheme.colorScheme.onSurfaceVariant
 				)

--- a/po/paperback.pot
+++ b/po/paperback.pot
@@ -3434,3 +3434,11 @@ msgstr ""
 #: kt
 msgid "{} seconds⁣"
 msgstr ""
+
+#: kt
+msgid "This document contains {} words.⁣"
+msgstr ""
+
+#: kt
+msgid "words⁣"
+msgstr ""


### PR DESCRIPTION
This marks the word-count dialog's "many" plural form the same way #737 already
did for seconds and minutes, so languages like Polish can translate it separately
from "few" instead of being stuck with one shared text for both.