### PR TITLE
Find: interrupt the focus-chain announcement so you just hear the found line

### DIFF
--- a/crates/paperback/src/ui/find.rs
+++ b/crates/paperback/src/ui/find.rs
@@ -1,4 +1,8 @@
-use std::{cell::Cell, rc::Rc, sync::Mutex};
+use std::{
+	cell::{Cell, RefCell},
+	rc::Rc,
+	sync::Mutex,
+};
 
 use bitflags::bitflags;
 use paperback_core::{config::ConfigManager, reader_core, util::text::display_len};
@@ -395,10 +399,11 @@ pub fn handle_find_action(
 		show_find_dialog(frame, doc_manager, config, find_dialog, live_region_label);
 		return;
 	}
-	do_find(forward, &state, doc_manager, config, live_region_label);
+	do_find(frame, forward, &state, doc_manager, config, live_region_label);
 }
 
 fn do_find(
+	frame: &Frame,
 	forward: bool,
 	state: &FindDialogState,
 	doc_manager: &Rc<Mutex<DocumentManager>>,
@@ -465,7 +470,43 @@ fn do_find(
 	let len = i64::try_from(display_len(&query)).unwrap_or(i64::MAX);
 	let start = result.position.clamp(0, doc_len);
 	let end = (start + len).min(doc_len);
+	// Capture the line containing the match while the document lock is held; it is
+	// announced later, after focus has returned to the book.
+	let found_line = tab.session.get_line_text(start);
 	navigation::select_doc_range(tab, start, end);
 	drop(dm);
 	state.dialog.show(false);
+	// NVDA starts reading the "Paperback, tab control, ..." ancestor chain the moment
+	// focus returns to the book. Delay the found-line announcement by 100ms so it lands
+	// mid-sentence: live-region's High priority maps to UIA
+	// NotificationProcessing_ImportantMostRecent, which NVDA handles as
+	// cancelSpeech() + speak — the same interrupt NVDA itself uses for its own find
+	// dialog. (During a say-all NVDA speaks at Spri.NOW instead of cancelling, so
+	// continuous reading is not chopped up.)
+	if !found_line.trim().is_empty() {
+		announce_found_line_after_delay(frame, live_region_label, found_line);
+	}
+}
+
+/// Announces `found_line` about 100ms after the Find dialog closes, so it cuts off the
+/// focus-chain announcement the screen reader starts when focus returns to the book.
+///
+/// The one-shot `wxTimer` is kept alive through its single tick by the `Rc`/`RefCell`
+/// it hands its own callback: the tick clears the cell, which drops the timer and
+/// destroys the native timer. If the timer cannot be armed, fall back to announcing
+/// immediately rather than silently dropping the result.
+fn announce_found_line_after_delay(frame: &Frame, live_region_label: StaticText, found_line: String) {
+	let timer_holder: Rc<RefCell<Option<Timer<Frame>>>> = Rc::new(RefCell::new(None));
+	let holder = Rc::clone(&timer_holder);
+	let timer = Timer::new(frame);
+	let announce_found_line = found_line.clone();
+	timer.on_tick(move |_event| {
+		live_region::announce(live_region_label, &announce_found_line);
+		*holder.borrow_mut() = None;
+	});
+	if !timer.start(100, true) {
+		live_region::announce(live_region_label, &found_line);
+		return;
+	}
+	*timer_holder.borrow_mut() = Some(timer);
 }

--- a/crates/paperback/src/ui/find.rs
+++ b/crates/paperback/src/ui/find.rs
@@ -466,7 +466,11 @@ fn do_find(
 		state.focus_find_text();
 		return;
 	}
-	if result.wrapped {
+	// Whether the dialog was on screen matters: hiding a visible dialog makes NVDA
+	// start the focus-return chain, which the found line must interrupt; a closed
+	// dialog produces no chain to cut.
+	let dialog_was_shown = state.dialog.is_shown();
+	if result.wrapped && !dialog_was_shown {
 		// TRANSLATORS: Announced when a search reaches the end of the document and wraps back to the start
 		live_region::announce(live_region_label, &t("No more results. Wrapping search."));
 	}
@@ -481,20 +485,41 @@ fn do_find(
 	let start = result.position.clamp(0, doc_len);
 	let end = (start + len).min(doc_len);
 	// Capture the line containing the match while the document lock is held; it is
-	// announced later, after focus has returned to the book.
+	// announced after focus has returned to the book.
 	let found_line = tab.session.get_line_text(start);
 	navigation::select_doc_range(tab, start, end);
 	drop(dm);
 	state.dialog.show(false);
-	// NVDA starts reading the "Paperback, tab control, ..." ancestor chain the moment
-	// focus returns to the book. Delay the found-line announcement so it cuts the chain
-	// right as it begins: live-region's High priority maps to UIA
-	// NotificationProcessing_ImportantMostRecent, which NVDA handles as
-	// cancelSpeech() + speak — the same interrupt NVDA itself uses for its own find
-	// dialog. (During a say-all NVDA speaks at Spri.NOW instead of cancelling, so
-	// continuous reading is not chopped up.)
-	if !found_line.trim().is_empty() {
-		announce_found_line_after_delay(frame, live_region_label, found_line);
+	if dialog_was_shown {
+		// NVDA starts reading the "Paperback, tab control, ..." ancestor chain the
+		// moment focus returns to the book. Delay the found-line announcement so it
+		// cuts the chain right as it begins: live-region's High priority maps to UIA
+		// NotificationProcessing_ImportantMostRecent, which NVDA handles as
+		// cancelSpeech() + speak — the same interrupt NVDA itself uses for its own
+		// find dialog. (During a say-all NVDA speaks at Spri.NOW instead of
+		// cancelling, so continuous reading is not chopped up.)
+		// When the search wrapped, the wrap notice was deferred above so it can be
+		// folded into this same announcement and cannot be cut off by it.
+		let message = if result.wrapped {
+			let notice = t("No more results. Wrapping search.");
+			if found_line.trim().is_empty() { notice } else { format!("{notice} {}", found_line.trim()) }
+		} else {
+			found_line
+		};
+		if !message.trim().is_empty() {
+			announce_found_line_after_delay(frame, live_region_label, message);
+		}
+	} else if result.wrapped {
+		// Find-next / Find-previous with the dialog closed. There is no focus chain
+		// to cut, and the wrap notice was announced above, so announce at Medium to
+		// queue the found line behind it rather than cutting it off.
+		if !found_line.trim().is_empty() {
+			live_region::announce_with_priority(live_region_label, &found_line, live_region::Priority::Medium);
+		}
+	} else if !found_line.trim().is_empty() {
+		// Find-next / Find-previous with the dialog closed and no wrap: no chain, so
+		// announce the found line directly.
+		live_region::announce(live_region_label, &found_line);
 	}
 }
 

--- a/crates/paperback/src/ui/find.rs
+++ b/crates/paperback/src/ui/find.rs
@@ -14,6 +14,16 @@ use super::{dialogs::DIALOG_PADDING, document_manager::DocumentManager, navigati
 
 const MAX_FIND_HISTORY_SIZE: usize = 10;
 
+/// How long after the Find dialog closes the found line is announced.
+///
+/// The interrupt must land after NVDA has started the focus-return chain — if it fires
+/// before, the chain reads over the found line instead — but as close to the chain's
+/// start as possible, so as little of it escapes before the cut. NVDA's own find dialog
+/// uses 100ms; Paperback's chain starts quickly, and 30ms was chosen by binary search
+/// (60ms left a barely-audible sliver of the chain, 10ms occasionally let the full chain
+/// through after the found line, 0ms always did).
+const FIND_RESULT_INTERRUPT_DELAY_MS: i32 = 30;
+
 #[derive(Clone, Debug, Default)]
 pub struct SearchResult {
 	pub found: bool,
@@ -477,8 +487,8 @@ fn do_find(
 	drop(dm);
 	state.dialog.show(false);
 	// NVDA starts reading the "Paperback, tab control, ..." ancestor chain the moment
-	// focus returns to the book. Delay the found-line announcement by 100ms so it lands
-	// mid-sentence: live-region's High priority maps to UIA
+	// focus returns to the book. Delay the found-line announcement so it cuts the chain
+	// right as it begins: live-region's High priority maps to UIA
 	// NotificationProcessing_ImportantMostRecent, which NVDA handles as
 	// cancelSpeech() + speak — the same interrupt NVDA itself uses for its own find
 	// dialog. (During a say-all NVDA speaks at Spri.NOW instead of cancelling, so
@@ -488,7 +498,7 @@ fn do_find(
 	}
 }
 
-/// Announces `found_line` about 100ms after the Find dialog closes, so it cuts off the
+/// Announces `found_line` shortly after the Find dialog closes, so it cuts off the
 /// focus-chain announcement the screen reader starts when focus returns to the book.
 ///
 /// The one-shot `wxTimer` is kept alive through its single tick by the `Rc`/`RefCell`
@@ -504,7 +514,7 @@ fn announce_found_line_after_delay(frame: &Frame, live_region_label: StaticText,
 		live_region::announce(live_region_label, &announce_found_line);
 		*holder.borrow_mut() = None;
 	});
-	if !timer.start(100, true) {
+	if !timer.start(FIND_RESULT_INTERRUPT_DELAY_MS, true) {
 		live_region::announce(live_region_label, &found_line);
 		return;
 	}


### PR DESCRIPTION
# Find: interrupt the focus-chain announcement so you just hear the found line

The notification approach the maintainer suggested on #726, tried out as its own PR.

## The problem

Closing Find makes NVDA announce the whole focus chain. Pressing Enter closes the Find dialog, focus returns to the book text, and NVDA reads "Paperback, book title, tab control, edit read only multi line" every time. That's standard NVDA behavior for a focus move across a window boundary, and it's most disruptive for Find, where you just want to hear the found text.

## How NVDA's own find dialog avoids it

Reading NVDA's source (`cursorManager.py`, `FindDialog.onOk`): NVDA doesn't *avoid* the chain announcement — it *interrupts* it. The dialog is destroyed, focus returns, NVDA starts reading the chain, and 100ms later `doFindText` runs, calls `speech.cancelSpeech()`, and speaks the found line. The preamble is cut off mid-word before you really hear it.

NVDA exposes the same lever to external apps: a UI Automation notification event with processing mode `ImportantMostRecent` makes NVDA do exactly that `cancelSpeech()` + speak. 

## What changed

Find stays a real `wxDialog` — role=dialog, tab trapping, ESC, default-button handling all intact. The change is in `find.rs` only:

- On a successful search, capture the line containing the match, close the dialog as usual, then ~30ms later raise a **High-priority** notification carrying that line.
- live-region 0.3.0 (already on master) provides the machinery: a server-side UIA provider on the announcer window, and `Priority::High` → `NotificationProcessing_ImportantMostRecent`, which NVDA handles as `cancelSpeech()` + speak at `Spri.NOW`. The interrupt lands right as the chain begins, cutting off all but a sliver of it.
- During a say-all NVDA speaks at `Spri.NOW` instead of cancelling, so continuous reading is not chopped up.

This is one ~50-line change to `do_find` plus a small helper that keeps a one-shot `wxTimer` alive through its single tick.

## The 30ms delay: why, and how it was chosen

The interrupt must land *after* NVDA has started the chain — if it fires too early, the chain reads over the found line instead — but as close to the chain's start as possible, so as little of it escapes before the cut. NVDA's own find dialog uses 100ms. Paperback's chain starts quickly, so we binary-searched it with NVDA on Windows 11:

| delay | result |
| --- | --- |
| 100ms | full "Paperback" sliver then found line (NVDA's own choice) |
| 60ms | barely-audible sliver, clean after |
| 10ms | tiny sliver, but the full chain *sometimes* read after the found line (the precipice) |
| 0ms | found line, then the full chain, always (too early) |
| **30ms** | **tiny sliver, nothing after the found line — the compromise** |

## Notes / tradeoffs

- **Only Find is addressed here.** Go to Line, Sleep Timer, and the rest still get the standard focus-return announcement; the same pattern would generalize to them in a future pass.
- **Only NVDA is verified.** JAWS and Narrator honour the same UIA notification contract but their exact behavior is untested (same caveat as the live-region crate).
- **No dependency bump in this PR** — live-region 0.3.0 is already on master.
- The accelerator / in-window-strip work from #726 is intentionally *not* included; that stays its own discussion.

## Testing

Tested with NVDA on Windows 11: Ctrl+F → type → Enter reads a sliver of the chain cut off by the found line; no chain after the found line; ESC/Cancel unchanged; say-all continuous reading is not interrupted; "Not found." still spoken while the dialog stays open.
