### PR TITLE
Polish: translate the word-count many-forms from #746

### DIFF
--- a/po/pl.po
+++ b/po/pl.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: paperback 0.8.5\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-30 23:46+0200\n"
+"POT-Creation-Date: 2026-08-31 15:15+0000\n"
 "PO-Revision-Date: 2026-06-08 13:45+0200\n"
 "Last-Translator: Michał Dziwisz <michal@dziwisz.net>\n"
 "Language-Team: Polish\n"
@@ -1067,7 +1067,6 @@ msgstr[2] "Wyłącznik czasowy ustawiony na %d minut."
 msgid "Paperback"
 msgstr "Paperback"
 
-#. TRANSLATORS: Announced by screen readers after a document was automatically reloaded because its file changed on disk
 msgid "Document reloaded."
 msgstr "Dokument został przeładowany."
 
@@ -3287,7 +3286,7 @@ msgstr "Rozwiń"
 
 #: kt
 msgid "This document contains {} words."
-msgstr "Ten dokument zawiera {} słów."
+msgstr "Ten dokument zawiera {} słowa."
 
 #: kt
 msgid "words"
@@ -3518,6 +3517,14 @@ msgstr "{} sekunda"
 #: kt
 msgid "{} seconds⁣"
 msgstr "{} sekund"
+
+#: kt
+msgid "This document contains {} words.⁣"
+msgstr "Ten dokument zawiera {} słów."
+
+#: kt
+msgid "words⁣"
+msgstr "słów"
 
 #~ msgid "&Locate…"
 #~ msgstr "&Zlokalizuj…"


### PR DESCRIPTION
Thanks for fixing `WordCountDialog.kt` in #746 — this fills in the Polish side of it.

Two new keys had no Polish text, so the word-count dialog fell back to English for counts like 5 or 25. With the marked key now carrying the "many" text, the unmarked `This document contains {} words.` is the "few" form (2, 3, 4, 22, ...), so it needed "słowa" instead of "słów".

`msgfmt --check --statistics`: 849 translated, 0 untranslated, 0 fuzzy. No other entry changed; the only other diff is the POT date and a TRANSLATORS comment that #748 dropped from the pot itself.

While verifying this I found a separate bug that a catalogue change cannot fix, so I'm reporting it rather than sneaking it in here: `nt()` in `Translations.kt` picks the "one" form for any count ending in 1 except 11, which is right for Bosnian, Serbian and Russian but wrong for Polish — Polish uses the singular for 1 only, so the dialog currently says "21 słowo" and "121 słowo" where it should say "21 słów". Measured by compiling the real `nt()` body and comparing its choice against `gettext` on `pl.po` for 0–10000: 899 counts disagree, while Serbian and Russian disagree on none. Happy to open a code PR if you'd like a fix.
