### PR TITLE
Take nt()'s plural rule from the catalogue instead of hardcoding one

### DIFF
--- a/android/app/src/main/kotlin/dev/paperback/android/Translations.kt
+++ b/android/app/src/main/kotlin/dev/paperback/android/Translations.kt
@@ -172,12 +172,14 @@ internal class PluralRule private constructor(
 				?.lineSequence()
 				?.firstOrNull { it.startsWith("Plural-Forms:") }
 				?: return null
-			val nplurals = line.substringAfter("nplurals=", "")
+			val nplurals = line
+				.substringAfter("nplurals=", "")
 				.takeWhile { it.isDigit() }
 				.toIntOrNull()
 				?.takeIf { it > 0 }
 				?: return null
-			val expression = line.substringAfter("plural=", "")
+			val expression = line
+				.substringAfter("plural=", "")
 				.substringBefore(';')
 				.trim()
 				.takeIf { it.isNotEmpty() }

--- a/android/app/src/main/kotlin/dev/paperback/android/Translations.kt
+++ b/android/app/src/main/kotlin/dev/paperback/android/Translations.kt
@@ -7,6 +7,12 @@ import java.util.Locale
 object Translations {
 	internal var map: HashMap<String, String> = HashMap()
 
+	/**
+	 * How [nt] picks a plural form for the loaded catalogue, from its own `Plural-Forms` header.
+	 * Null until a catalogue is loaded, and for one whose header can't be read.
+	 */
+	internal var pluralRule: PluralRule? = null
+
 	fun load(context: Context) {
 		val match = bestLocaleMatch(assetLocaleTags(context, "translations", "", ".json"), Locale.getDefault())
 			?: return
@@ -21,6 +27,9 @@ object Translations {
 				loaded[key] = obj.getString(key)
 			}
 			map = loaded
+			// The po header comes through as the entry with the empty msgid, the same as it does
+			// for desktop, so the target language's own rule ships with its translations.
+			pluralRule = PluralRule.parse(loaded[""])
 		} catch (_: Exception) {
 			// Asset unreadable or malformed — fall back to English
 		}
@@ -129,12 +138,224 @@ fun t(
 }
 
 /**
+ * A language's gettext plural rule: how many forms it has, and which one a count takes.
+ *
+ * Read from the catalogue's own `Plural-Forms` header rather than hardcoded, because the rule
+ * differs between languages that all want three forms: Bosnian, Serbian and Croatian give 21 and
+ * 31 the same form as 1, while Polish gives the singular to 1 alone, so a single hardcoded rule
+ * cannot serve both. Desktop gets this from patois at runtime; this is the mobile equivalent.
+ *
+ * Only the shapes gettext's own catalogues use are understood — a chain of `n`-comparisons and
+ * `?:` — which covers every language Paperback ships. Anything else parses to null and [nt]
+ * falls back to its previous behaviour rather than guessing.
+ */
+internal class PluralRule private constructor(
+	private val nplurals: Int,
+	private val expression: String
+) {
+	/** The 0-based form index for [count], or null when the expression doesn't evaluate. */
+	fun formIndex(count: Long): Int? {
+		val value = evalTernary(expression, count) ?: return null
+		return if (value in 0 until nplurals) value else null
+	}
+
+	val forms: Int
+		get() = nplurals
+
+	companion object {
+		/**
+		 * Parses the `Plural-Forms: nplurals=N; plural=EXPR;` line out of a po header, or null
+		 * when the header is missing, has no such line, or states a form count below one.
+		 */
+		fun parse(header: String?): PluralRule? {
+			val line = header
+				?.lineSequence()
+				?.firstOrNull { it.startsWith("Plural-Forms:") }
+				?: return null
+			val nplurals = line.substringAfter("nplurals=", "")
+				.takeWhile { it.isDigit() }
+				.toIntOrNull()
+				?.takeIf { it > 0 }
+				?: return null
+			val expression = line.substringAfter("plural=", "")
+				.substringBefore(';')
+				.trim()
+				.takeIf { it.isNotEmpty() }
+				?: return null
+			return PluralRule(nplurals, expression)
+		}
+
+		/**
+		 * Evaluates a gettext plural expression for [n], or null on anything unrecognized.
+		 *
+		 * Deliberately narrow: `?:`, `||`, `&&`, the comparisons, `%` and integer literals, which
+		 * is the whole of what gettext plural rules use. Returning null on the unexpected keeps a
+		 * malformed header from silently selecting form 0 for every count.
+		 */
+		private fun evalTernary(
+			expr: String,
+			n: Long
+		): Int? {
+			val text = expr.trim().removeSurroundingParens()
+			val question = text.indexOfTopLevel('?')
+			if (question == -1) {
+				return text.toIntOrNull() ?: evalBoolean(text, n)?.let { if (it) 1 else 0 }
+			}
+			val colon = text.indexOfTopLevel(':', from = question + 1).takeIf { it != -1 } ?: return null
+			val condition = evalBoolean(text.substring(0, question), n) ?: return null
+			val branch = if (condition) {
+				text.substring(question + 1, colon)
+			} else {
+				text.substring(colon + 1)
+			}
+			return evalTernary(branch, n)
+		}
+
+		private fun evalBoolean(
+			expr: String,
+			n: Long
+		): Boolean? {
+			val text = expr.trim().removeSurroundingParens()
+			text.splitTopLevel("||")?.let { (left, right) ->
+				val l = evalBoolean(left, n) ?: return null
+				if (l) {
+					return true
+				}
+				return evalBoolean(right, n)
+			}
+			text.splitTopLevel("&&")?.let { (left, right) ->
+				val l = evalBoolean(left, n) ?: return null
+				if (!l) {
+					return false
+				}
+				return evalBoolean(right, n)
+			}
+			for (op in listOf("==", "!=", ">=", "<=", ">", "<")) {
+				val at = text.indexOfTopLevel(op) ?: continue
+				val left = evalArithmetic(text.substring(0, at), n) ?: return null
+				val right = evalArithmetic(text.substring(at + op.length), n) ?: return null
+				return when (op) {
+					"==" -> left == right
+					"!=" -> left != right
+					">=" -> left >= right
+					"<=" -> left <= right
+					">" -> left > right
+					else -> left < right
+				}
+			}
+			return null
+		}
+
+		private fun evalArithmetic(
+			expr: String,
+			n: Long
+		): Long? {
+			val text = expr.trim().removeSurroundingParens()
+			val modulo = text.indexOfTopLevel('%')
+			if (modulo != -1) {
+				val left = evalArithmetic(text.substring(0, modulo), n) ?: return null
+				val right = evalArithmetic(text.substring(modulo + 1), n) ?: return null
+				if (right == 0L) {
+					return null
+				}
+				return left % right
+			}
+			if (text == "n") {
+				return n
+			}
+			return text.toLongOrNull()
+		}
+
+		private fun String.removeSurroundingParens(): String {
+			var text = trim()
+			while (text.length > 1 && text.startsWith("(") && text.endsWith(")") && text.outerParenSpansAll()) {
+				text = text.substring(1, text.length - 1).trim()
+			}
+			return text
+		}
+
+		/**
+		 * Whether the parenthesis opening this string is the one the final character closes, so
+		 * that stripping both keeps the expression intact. False for `(a) && (b)`, whose outer
+		 * parentheses look enclosing but are two separate groups.
+		 */
+		private fun String.outerParenSpansAll(): Boolean {
+			var depth = 0
+			for (i in indices) {
+				when (this[i]) {
+					'(' -> depth++
+					')' -> {
+						depth--
+						if (depth == 0) {
+							return i == length - 1
+						}
+					}
+				}
+			}
+			return false
+		}
+
+		/** The index of [char] outside any parentheses, or -1. */
+		private fun String.indexOfTopLevel(
+			char: Char,
+			from: Int = 0
+		): Int {
+			var depth = 0
+			for (i in from until length) {
+				val c = this[i]
+				if (c == char && depth == 0) {
+					return i
+				}
+				when (c) {
+					'(' -> depth++
+					')' -> depth--
+				}
+			}
+			return -1
+		}
+
+		private fun String.indexOfTopLevel(token: String): Int? {
+			var depth = 0
+			var i = 0
+			while (i <= length - token.length) {
+				when (this[i]) {
+					'(' -> depth++
+					')' -> depth--
+				}
+				if (depth == 0 && startsWith(token, i)) {
+					// "<" must not match inside "<=", nor "=" inside "==".
+					val nextIsEquals = token.length == 1 && i + 1 < length && this[i + 1] == '='
+					if (!nextIsEquals) {
+						return i
+					}
+				}
+				i++
+			}
+			return null
+		}
+
+		private fun String.splitTopLevel(token: String): Pair<String, String>? {
+			val at = indexOfTopLevel(token) ?: return null
+			return substring(0, at) to substring(at + token.length)
+		}
+	}
+}
+
+/**
  * Selects among three already-translated forms for languages (e.g. Bosnian, Serbian, Croatian)
  * whose grammar needs three: [one] for a count ending in 1, except one ending in 11 (1, 21, 31,
  * ...); [few] for a count ending in 2-4, except one ending in 12-14 (2, 3, 4, 22, 23, 24, ...);
  * and [many] for everything else (0, 5-20, 25-30, ...). Desktop gets this for free from the
- * target language's own `Plural-Forms` rule via patois; mobile has no such runtime, so this
- * hardcodes the one three-form rule Paperback ships a mobile translation for.
+ * target language's own `Plural-Forms` rule via patois; mobile has no such runtime, so the rule
+ * is read from the loaded catalogue's header, which ships alongside its translations.
+ *
+ * The hardcoded fallback below is that same Bosnian/Serbian rule, used only when no catalogue is
+ * loaded or its header couldn't be parsed. It is wrong for some languages — Polish gives the
+ * singular to 1 alone, so it would read "21 sekunda" where the language wants "21 sekund" — which
+ * is why the header is preferred whenever it is there.
+ *
+ * A two-form language selects [one] or [few], and a one-form language always [one], matching how
+ * `msgstr[0]` and `msgstr[1]` are filled in its catalogue.
  *
  * Callers translate each form themselves with [t] *before* calling this — `nt(t("1 book"),
  * t("{} books"), t("{} books"), count)`, never `nt("1 book", "{} books", "{} books", count)` —
@@ -147,6 +368,12 @@ fun nt(
 	many: String,
 	count: Long
 ): String {
+	val forms = listOf(one, few, many)
+	Translations.pluralRule?.let { rule ->
+		rule.formIndex(count)?.let { index ->
+			return forms[index.coerceAtMost(forms.size - 1)]
+		}
+	}
 	val mod10 = count % 10
 	val mod100 = count % 100
 	return when {

--- a/android/app/src/main/kotlin/dev/paperback/android/ui/NavUnit.kt
+++ b/android/app/src/main/kotlin/dev/paperback/android/ui/NavUnit.kt
@@ -80,10 +80,9 @@ fun getSeekAmountName(seconds: Int): String =
 		// TRANSLATORS: Audio seek amount, shown as a navigation unit in the read-aloud bar
 		3600 -> t("1 hour")
 		// TRANSLATORS: Fallback audio seek amount label for a value outside the fixed presets
-		// above; {} is the number of seconds. Three forms picked by the count's last digits (see
-		// nt() in Translations.kt): one = counts ending in 1 except 11 (1, 21, 31, ...), few =
-		// counts ending in 2-4 except 12-14 (2, 3, 4, 22, 23, 24, ...), many = everything else
-		// (0, 5-20, 25-30, ...). The "many" form's trailing character isn't a typo — see
+		// above; {} is the number of seconds. Which of the three forms is used depends on the
+		// target language's own plural rule, read from its catalogue (see nt() in
+		// Translations.kt). The "many" form's trailing character isn't a typo — see
 		// PLURAL_MANY_MARKER in Translations.kt.
 		else -> nt(t("{} second"), t("{} seconds"), t("{} seconds⁣"), seconds.toLong()).replace("{}", seconds.toString())
 	}

--- a/android/app/src/main/kotlin/dev/paperback/android/ui/dialogs/WordCountDialog.kt
+++ b/android/app/src/main/kotlin/dev/paperback/android/ui/dialogs/WordCountDialog.kt
@@ -26,10 +26,9 @@ fun WordCountDialog(
 	onDismiss: () -> Unit
 ) {
 	// TRANSLATORS: Sentence announced to screen readers with the document's word count; {} is
-	// replaced with the number. Three forms picked by the count's last digits (see nt() in
-	// Translations.kt): one = counts ending in 1 except 11 (1, 21, 31, ...), few = counts ending
-	// in 2-4 except 12-14 (2, 3, 4, 22, 23, 24, ...), many = everything else (0, 5-20, 25-30, ...).
-	// The "many" form's trailing character isn't a typo — see PLURAL_MANY_MARKER in Translations.kt.
+	// replaced with the number. Which of the three forms is used depends on the target language's
+	// own plural rule, read from its catalogue (see nt() in Translations.kt). The "many" form's
+	// trailing character isn't a typo — see PLURAL_MANY_MARKER in Translations.kt.
 	val announcement = nt(
 		t("This document contains {} word."),
 		t("This document contains {} words."),
@@ -55,11 +54,10 @@ fun WordCountDialog(
 					style = MaterialTheme.typography.displaySmall
 				)
 				Text(
-					// TRANSLATORS: Unit label shown under the large word-count number. Three forms
-					// picked by the count's last digits (see nt() in Translations.kt): one = counts
-					// ending in 1 except 11, few = counts ending in 2-4 except 12-14, many = everything
-					// else. The "many" form's trailing character isn't a typo — see PLURAL_MANY_MARKER
-					// in Translations.kt.
+					// TRANSLATORS: Unit label shown under the large word-count number. Which of the
+					// three forms is used depends on the target language's own plural rule, read
+					// from its catalogue (see nt() in Translations.kt). The "many" form's trailing
+					// character isn't a typo — see PLURAL_MANY_MARKER in Translations.kt.
 					text = nt(t("word"), t("words"), t("words⁣"), stats.wordCount),
 					style = MaterialTheme.typography.bodyMedium,
 					color = MaterialTheme.colorScheme.onSurfaceVariant

--- a/android/app/src/test/kotlin/dev/paperback/android/TranslationsTest.kt
+++ b/android/app/src/test/kotlin/dev/paperback/android/TranslationsTest.kt
@@ -118,8 +118,11 @@ class TranslateTest {
 }
 
 /** The `Plural-Forms` headers the shipped catalogues actually carry. */
-private const val POLISH = "Plural-Forms: nplurals=3; plural=(n==1 ? 0 : n%10>=2 && n%10<=4 && (n%100<12 || n%100>14) ? 1 : 2);"
-private const val SERBIAN = "Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<12 || n%100>14) ? 1 : 2);"
+private const val POLISH =
+	"Plural-Forms: nplurals=3; plural=(n==1 ? 0 : n%10>=2 && n%10<=4 && (n%100<12 || n%100>14) ? 1 : 2);"
+private const val SERBIAN =
+	"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && " +
+		"(n%100<12 || n%100>14) ? 1 : 2);"
 private const val GERMAN = "Plural-Forms: nplurals=2; plural=(n != 1);"
 private const val CHINESE = "Plural-Forms: nplurals=1; plural=0;"
 
@@ -193,7 +196,10 @@ class PluralFormTest {
 	@Test
 	fun `more forms than slots clamps to the last slot`() {
 		Translations.pluralRule =
-			PluralRule.parse("Plural-Forms: nplurals=6; plural=(n==0 ? 0 : n==1 ? 1 : n==2 ? 2 : n%100>=3 && n%100<=10 ? 3 : n%100>=11 ? 4 : 5);")
+			PluralRule.parse(
+				"Plural-Forms: nplurals=6; plural=(n==0 ? 0 : n==1 ? 1 : n==2 ? 2 : " +
+					"n%100>=3 && n%100<=10 ? 3 : n%100>=11 ? 4 : 5);"
+			)
 		assertEquals("one", forCount(0))
 		assertEquals("few", forCount(1))
 		assertEquals("many", forCount(2))

--- a/android/app/src/test/kotlin/dev/paperback/android/TranslationsTest.kt
+++ b/android/app/src/test/kotlin/dev/paperback/android/TranslationsTest.kt
@@ -71,6 +71,7 @@ class TranslateTest {
 	@After
 	fun clearCatalogue() {
 		Translations.map = HashMap()
+		Translations.pluralRule = null
 	}
 
 	// English ships no catalogue at all, so an untranslated build has to read as the msgids.
@@ -113,5 +114,128 @@ class TranslateTest {
 		assertEquals("a and {}", t("{} and {}", "a"))
 		assertEquals("just a", t("just {}", "a", "b"))
 		assertEquals("no placeholders", t("no placeholders", "a"))
+	}
+}
+
+/** The `Plural-Forms` headers the shipped catalogues actually carry. */
+private const val POLISH = "Plural-Forms: nplurals=3; plural=(n==1 ? 0 : n%10>=2 && n%10<=4 && (n%100<12 || n%100>14) ? 1 : 2);"
+private const val SERBIAN = "Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<12 || n%100>14) ? 1 : 2);"
+private const val GERMAN = "Plural-Forms: nplurals=2; plural=(n != 1);"
+private const val CHINESE = "Plural-Forms: nplurals=1; plural=0;"
+
+class PluralFormTest {
+	@After
+	fun clearCatalogue() {
+		Translations.map = HashMap()
+		Translations.pluralRule = null
+	}
+
+	private fun forCount(count: Long) = nt("one", "few", "many", count)
+
+	// The bug this exists for: Serbian gives 21 the same form as 1, Polish does not, and a single
+	// hardcoded rule served the first while making the second read "21 sekunda" for "21 sekund".
+	@Test
+	fun `Polish gives the singular to one alone`() {
+		Translations.pluralRule = PluralRule.parse(POLISH)
+		assertEquals("one", forCount(1))
+		assertEquals("few", forCount(2))
+		assertEquals("many", forCount(5))
+		assertEquals("many", forCount(11))
+		assertEquals("many", forCount(21))
+		assertEquals("few", forCount(22))
+		assertEquals("many", forCount(101))
+		assertEquals("many", forCount(121))
+	}
+
+	// The same counts under the rule the hardcoded fallback was written for, which must keep
+	// working: this is the language the marker mechanism was introduced for.
+	@Test
+	fun `Serbian keeps giving twenty-one the singular`() {
+		Translations.pluralRule = PluralRule.parse(SERBIAN)
+		assertEquals("one", forCount(1))
+		assertEquals("one", forCount(21))
+		assertEquals("few", forCount(22))
+		assertEquals("many", forCount(11))
+	}
+
+	// A two-form language must never reach the third slot, whose text is a duplicate of the second
+	// for it, and a one-form language must never leave the first.
+	@Test
+	fun `a two-form language uses only the first two forms`() {
+		Translations.pluralRule = PluralRule.parse(GERMAN)
+		assertEquals("one", forCount(1))
+		assertEquals("few", forCount(0))
+		assertEquals("few", forCount(2))
+		assertEquals("few", forCount(21))
+	}
+
+	@Test
+	fun `a one-form language always uses the first form`() {
+		Translations.pluralRule = PluralRule.parse(CHINESE)
+		assertEquals("one", forCount(0))
+		assertEquals("one", forCount(1))
+		assertEquals("one", forCount(5))
+		assertEquals("one", forCount(21))
+	}
+
+	// Czech writes the same three-form rule with its comparisons parenthesized instead of bare,
+	// so the parser has to handle both shapes.
+	@Test
+	fun `a rule written with parenthesized comparisons parses`() {
+		Translations.pluralRule = PluralRule.parse("Plural-Forms: nplurals=3; plural=(n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2;")
+		assertEquals("one", forCount(1))
+		assertEquals("few", forCount(3))
+		assertEquals("many", forCount(9))
+	}
+
+	// A language with more forms than nt() has slots (Arabic has six) must still select a form
+	// rather than throw or fall through to the wrong one.
+	@Test
+	fun `more forms than slots clamps to the last slot`() {
+		Translations.pluralRule =
+			PluralRule.parse("Plural-Forms: nplurals=6; plural=(n==0 ? 0 : n==1 ? 1 : n==2 ? 2 : n%100>=3 && n%100<=10 ? 3 : n%100>=11 ? 4 : 5);")
+		assertEquals("one", forCount(0))
+		assertEquals("few", forCount(1))
+		assertEquals("many", forCount(2))
+		assertEquals("many", forCount(5))
+	}
+
+	// Everything below is about not making things worse than the hardcoded rule when the header
+	// can't be trusted: no catalogue, no header line, and a truncated expression.
+	@Test
+	fun `no catalogue keeps the previous behaviour`() {
+		assertEquals("one", forCount(21))
+		assertEquals("few", forCount(22))
+		assertEquals("many", forCount(11))
+	}
+
+	@Test
+	fun `a header without a plural rule parses to nothing`() {
+		assertNull(PluralRule.parse("Language: pl\nMIME-Version: 1.0\n"))
+		assertNull(PluralRule.parse(null))
+	}
+
+	@Test
+	fun `a rule with no usable form count parses to nothing`() {
+		assertNull(PluralRule.parse("Plural-Forms: nplurals=; plural=0;"))
+		assertNull(PluralRule.parse("Plural-Forms: nplurals=0; plural=0;"))
+		assertNull(PluralRule.parse("Plural-Forms: nplurals=2;"))
+	}
+
+	// A malformed expression must not silently select form 0 for every count; falling back to the
+	// hardcoded rule at least keeps three-form Slavic languages readable.
+	@Test
+	fun `an unevaluatable expression falls back instead of picking form zero`() {
+		Translations.pluralRule = PluralRule.parse("Plural-Forms: nplurals=3; plural=(n==1 ? 0 : ;")
+		assertEquals("one", forCount(1))
+		assertEquals("few", forCount(22))
+		assertEquals("many", forCount(11))
+	}
+
+	// An out-of-range index is a malformed header, not a form to index with.
+	@Test
+	fun `an index beyond the declared form count is refused`() {
+		val rule = PluralRule.parse("Plural-Forms: nplurals=2; plural=5;")
+		assertNull(rule?.formIndex(1))
 	}
 }


### PR DESCRIPTION
This is the code fix for the `nt()` bug I mentioned in #753, kept separate from the catalogue change there so you can take either on its own.

`nt()` hardcodes the Bosnian/Serbian rule — "one" for any count ending in 1 except 11 — which is right for the language the marker mechanism was added for, but wrong for other three-form languages. Polish gives the singular to 1 alone, so the word-count dialog announces "21 słowo" and the seek label reads "21 sekunda" where the language wants "21 słów" and "21 sekund".

The rule each language wants already ships with its translations: `gen_android_strings` writes the po header into the asset under the empty msgid, the same entry desktop reads through patois. So `Translations.load` parses its `Plural-Forms` line and `nt()` uses it, with the hardcoded rule kept as a fallback when there's no header or it doesn't parse — behaviour is unchanged wherever there's nothing better to go on.

It turned out not to be only Polish. Two-form and one-form languages were reaching a slot their catalogue leaves empty: with a Finnish or Chinese catalogue loaded, a count of 0 or 5 landed on the marked "many" key, which those languages don't translate, and the label fell back to English.

Measured for every shipped catalogue by comparing what `nt()` selects against gettext's own choice for 0–10000, using each language's real header:

| catalogue | visible defects before | after |
|---|---|---|
| pl | 899 | 0 |
| de | 899 | 0 |
| fi | 7300 | 0 |
| zh_CN | 6401 | 0 |
| bs, es, fr, nl, pt_br, ru, sr, vi | 0 | 0 |
| cs, ja (no `Plural-Forms` header) | unchanged from the hardcoded rule | |

"Visible defect" counts a count whose displayed string differs, not merely a different slot: for a two-form language both keys usually hold the same text, so those slot changes are invisible and aren't counted as fixes.

Also checked against rules Paperback doesn't ship yet, since catalogues keep being added — Czech's parenthesized form, Lithuanian, Latvian, Welsh, Slovenian, Irish (5 forms) and Arabic (6) all agree with gettext, and a language with more forms than `nt()` has slots clamps to the last rather than throwing.

`:app:testDebugUnitTest` is green: 46 tests, 0 failures, including the 11 new ones. I checked they can actually fail — reverting `nt()` to ignore the header fails exactly 4 of them, while the three fallback tests stay green, as they should.

The parser is deliberately narrow (`?:`, `||`, `&&`, comparisons, `%`, integer literals — the whole of what gettext plural rules use) and returns null rather than guessing, so a malformed header can't silently select form 0 for every count.
