### PR TITLE
Open M4B audiobooks as chaptered audio-only books

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1559,6 +1559,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "mp4ameta"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "453e991b2efe96c288cbc2d03a19e353504294559ecb6c03067fff5bd824616d"
+
+[[package]]
 name = "native-tls"
 version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1777,6 +1783,7 @@ dependencies = [
  "icu_properties",
  "libchm",
  "lofty",
+ "mp4ameta",
  "office-crypto",
  "paperback-formats",
  "patois",

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@
   - OpenDocument text files (odt/fodt)
   - OpenDocument presentations (odp/fodp)
   - RTF documents (rtf)
+  - M4B audiobooks (m4b)
   - MOBI/Kindle books (mobi/azw/azw3)
   - Markdown documents (md/markdown/mdx/mdown/mdwn/mkd/mkdn/mkdown/ronn)
   - Plain text and log files (txt/log)

--- a/crates/paperback-core/Cargo.toml
+++ b/crates/paperback-core/Cargo.toml
@@ -26,6 +26,7 @@ encoding_rs = "0.8.35"
 icu_properties = { version = "2.3.0", features = ["unicode_bidi"] }
 libchm = "0.3.0"
 lofty = "0.25.1"
+mp4ameta = "0.13.0"
 office-crypto = "0.3.0"
 paperback-formats = { path = "../paperback-formats" }
 patois = "0.2.1"

--- a/crates/paperback-core/src/parser.rs
+++ b/crates/paperback-core/src/parser.rs
@@ -20,6 +20,7 @@ pub mod daisy;
 pub mod epub;
 pub mod fb2;
 pub mod html;
+pub mod m4b;
 pub mod markdown;
 pub mod mobi;
 pub mod odp;
@@ -142,6 +143,7 @@ impl ParserRegistry {
 				HTML => html::HtmlParser,
 				PDF => pdf::PdfParser,
 				MARKDOWN => markdown::MarkdownParser,
+				M4B => m4b::M4bParser,
 				MOBI => mobi::MobiParser,
 				FODP => odp::FodpParser,
 				ODP => odp::OdpParser,
@@ -532,6 +534,9 @@ mod tests {
 	#[case("txt", true)]
 	#[case(".TXT", true)]
 	#[case("log", true)]
+	#[case("m4b", true)]
+	#[case(".M4B", true)]
+	#[case("m4a", false)]
 	#[case("", false)]
 	#[case(".", false)]
 	#[case("notarealextension", false)]
@@ -635,6 +640,15 @@ mod tests {
 	fn get_parser_flags_for_context_returns_none_for_unknown_extension() {
 		let context = ParserContext::new("doc.unknown_ext".to_string());
 		assert_eq!(get_parser_flags_for_context(&context), ParserFlags::NONE);
+	}
+
+	#[test]
+	fn m4b_parser_advertises_audio_book_navigation() {
+		let context = ParserContext::new("book.m4b".to_string());
+		assert_eq!(
+			get_parser_flags_for_context(&context),
+			ParserFlags::SUPPORTS_SECTIONS | ParserFlags::SUPPORTS_TOC | ParserFlags::SUPPORTS_AUDIO
+		);
 	}
 
 	/// Guards against a format being declared in `paperback-formats` with no parser wired up

--- a/crates/paperback-core/src/parser/m4b.rs
+++ b/crates/paperback-core/src/parser/m4b.rs
@@ -1,0 +1,214 @@
+use std::collections::HashSet;
+
+use anyhow::{Context, Result, bail};
+use mp4ameta::{Chapter, ChplTimescale, ReadConfig, Tag};
+
+use crate::{
+	audio::{AudioLocation, AudioTimelineBuilder},
+	document::{Document, DocumentBuffer, Marker, MarkerType, ParserContext, TocItem},
+	parser::{Parser, util::path::extract_title_from_path},
+	t,
+};
+
+pub struct M4bParser;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct NormalizedChapter {
+	start_ms: u64,
+	end_ms: u64,
+	title: String,
+}
+
+impl Parser for M4bParser {
+	fn parse(&self, context: &ParserContext) -> Result<Document> {
+		let read_config = ReadConfig {
+			read_meta_items: true,
+			read_image_data: false,
+			read_chapter_list: true,
+			read_chapter_track: true,
+			read_audio_info: true,
+			chpl_timescale: ChplTimescale::DEFAULT,
+		};
+		let tag = Tag::read_with_path(&context.file_path, &read_config)
+			.with_context(|| format!("failed to read M4B metadata from {}", context.file_path))?;
+		let duration_ms = u64::try_from(tag.duration().as_millis()).context("M4B duration is too large")?;
+		if duration_ms == 0 {
+			bail!("M4B file has no positive audio duration");
+		}
+
+		let (title, author) = document_metadata(&tag, &context.file_path);
+		let chapters = normalize_chapters(tag.chapters(), duration_ms, &title);
+
+		Ok(build_document(&context.file_path, title, author, duration_ms, &chapters))
+	}
+}
+
+fn first_nonempty<'a>(values: impl IntoIterator<Item = Option<&'a str>>) -> Option<&'a str> {
+	values.into_iter().flatten().map(str::trim).find(|value| !value.is_empty())
+}
+
+fn document_metadata(tag: &Tag, file_path: &str) -> (String, String) {
+	let fallback_title = extract_title_from_path(file_path);
+	let title = first_nonempty([tag.title(), tag.album()]).unwrap_or(&fallback_title).to_string();
+	let author = first_nonempty([tag.album_artist(), tag.artist()]).unwrap_or_default().to_string();
+	(title, author)
+}
+
+fn normalize_chapters(chapters: &[Chapter], duration_ms: u64, document_title: &str) -> Vec<NormalizedChapter> {
+	let mut starts: Vec<(u64, String)> = chapters
+		.iter()
+		.filter_map(|chapter| {
+			let start_ms = u64::try_from(chapter.start.as_millis()).ok()?;
+			(start_ms < duration_ms).then(|| (start_ms, chapter.title.trim().to_string()))
+		})
+		.collect();
+	starts.sort_by_key(|(start_ms, _)| *start_ms);
+	let mut seen = HashSet::new();
+	starts.retain(|(start_ms, _)| seen.insert(*start_ms));
+
+	if starts.is_empty() {
+		return vec![NormalizedChapter { start_ms: 0, end_ms: duration_ms, title: document_title.to_string() }];
+	}
+	starts[0].0 = 0;
+	starts
+		.iter()
+		.enumerate()
+		.map(|(index, (start_ms, title))| {
+			let title = if title.is_empty() {
+				// TRANSLATORS: Fallback label for an audiobook chapter whose embedded title is empty; {} is the chapter number
+				t("Chapter {}").replace("{}", &(index + 1).to_string())
+			} else {
+				title.clone()
+			};
+			let end_ms = starts.get(index + 1).map_or(duration_ms, |(next_start_ms, _)| *next_start_ms);
+			NormalizedChapter { start_ms: *start_ms, end_ms, title }
+		})
+		.collect()
+}
+
+fn build_document(
+	file_path: &str,
+	title: String,
+	author: String,
+	duration_ms: u64,
+	chapters: &[NormalizedChapter],
+) -> Document {
+	let mut buffer = DocumentBuffer::new();
+	let mut toc_items = Vec::with_capacity(chapters.len());
+	let mut audio_builder = AudioTimelineBuilder::new();
+	let source = audio_builder.add_source(AudioLocation::File(file_path.to_string()), Some(duration_ms));
+
+	for chapter in chapters {
+		let position = buffer.current_position();
+		buffer.append("\n");
+		buffer.add_marker(Marker::new(MarkerType::SectionBreak, position).with_text(chapter.title.clone()));
+		audio_builder.add_clip(source, chapter.start_ms, chapter.end_ms, position, position + 1);
+		toc_items.push(TocItem::new(chapter.title.clone(), chapter.start_ms.to_string(), position));
+	}
+
+	Document {
+		title,
+		author,
+		buffer,
+		toc_items,
+		audio: Some(audio_builder.build()),
+		audio_only: true,
+		..Document::default()
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use std::time::Duration;
+
+	use mp4ameta::Chapter;
+
+	use super::*;
+
+	fn chapter(start_ms: u64, title: &str) -> Chapter {
+		Chapter::new(Duration::from_millis(start_ms), title)
+	}
+
+	#[test]
+	fn first_nonempty_trims_and_uses_the_first_present_value() {
+		assert_eq!(first_nonempty([Some("  "), None, Some(" Book "), Some("Album")]), Some("Book"));
+		assert_eq!(first_nonempty([None, Some(" ")]), None);
+	}
+
+	#[test]
+	fn document_metadata_uses_tag_priority_and_path_fallbacks() {
+		let mut tag = Tag::default();
+		assert_eq!(document_metadata(&tag, "/books/fallback.m4b"), ("fallback".to_string(), String::new()));
+
+		tag.set_album(" Album ");
+		tag.set_artist("Artist");
+		assert_eq!(document_metadata(&tag, "fallback.m4b"), ("Album".to_string(), "Artist".to_string()));
+
+		tag.set_title("Title");
+		tag.set_album_artist("Album Artist");
+		assert_eq!(document_metadata(&tag, "fallback.m4b"), ("Title".to_string(), "Album Artist".to_string()));
+	}
+
+	#[test]
+	fn normalizes_chapters_into_sorted_contiguous_clips() {
+		let chapters = vec![
+			chapter(5000, "Second"),
+			chapter(1000, " First "),
+			chapter(5000, "Duplicate"),
+			chapter(9000, ""),
+			chapter(12_000, "Past end"),
+		];
+		assert_eq!(
+			normalize_chapters(&chapters, 10_000, "Book"),
+			vec![
+				NormalizedChapter { start_ms: 0, end_ms: 5000, title: "First".to_string() },
+				NormalizedChapter { start_ms: 5000, end_ms: 9000, title: "Second".to_string() },
+				NormalizedChapter { start_ms: 9000, end_ms: 10_000, title: "Chapter 3".to_string() },
+			]
+		);
+	}
+
+	#[test]
+	fn accepts_chapter_tracks_and_prefers_chapter_lists_when_both_exist() {
+		let mut tag = Tag::default();
+		tag.chapter_track_mut().extend([chapter(0, "Track One"), chapter(5000, "Track Two")]);
+		assert_eq!(normalize_chapters(tag.chapters(), 10_000, "Book")[0].title, "Track One");
+
+		tag.chapter_list_mut().extend([chapter(0, "List One"), chapter(4000, "List Two")]);
+		let chapters = normalize_chapters(tag.chapters(), 10_000, "Book");
+		assert_eq!(chapters[0].title, "List One");
+		assert_eq!(chapters[0].end_ms, 4000);
+	}
+
+	#[test]
+	fn chapterless_book_becomes_one_full_length_section() {
+		assert_eq!(
+			normalize_chapters(&[], 10_000, "Book"),
+			vec![NormalizedChapter { start_ms: 0, end_ms: 10_000, title: "Book".to_string() }]
+		);
+	}
+
+	#[test]
+	fn builds_audio_only_document_with_navigation_anchors() {
+		let chapters = vec![
+			NormalizedChapter { start_ms: 0, end_ms: 4000, title: "One".to_string() },
+			NormalizedChapter { start_ms: 4000, end_ms: 10_000, title: "Two".to_string() },
+		];
+		let document = build_document("book.m4b", "Book".to_string(), "Author".to_string(), 10_000, &chapters);
+		let audio = document.audio.as_ref().expect("audio timeline");
+		assert_eq!(document.title, "Book");
+		assert_eq!(document.author, "Author");
+		assert_eq!(document.buffer.content, "\n\n");
+		assert_eq!(document.toc_items.len(), 2);
+		assert_eq!(document.toc_items[0].name, "One");
+		assert_eq!(document.toc_items[1].offset, 1);
+		assert!(document.audio_only);
+		assert_eq!(audio.sources().len(), 1);
+		assert_eq!(audio.clips().len(), 2);
+		assert_eq!(audio.clips()[0].clip_end_ms, 4000);
+		assert_eq!(audio.clips()[1].clip_begin_ms, 4000);
+		assert_eq!(audio.total_duration_ms(), 10_000);
+		assert_eq!(audio.source(0).and_then(|source| source.duration_ms), Some(10_000));
+		assert_eq!(audio.source(0).map(|source| &source.location), Some(&AudioLocation::File("book.m4b".to_string())));
+	}
+}

--- a/crates/paperback-formats/src/lib.rs
+++ b/crates/paperback-formats/src/lib.rs
@@ -138,6 +138,11 @@ formats! {
 		extensions: ["md", "markdown", "mdx", "mdown", "mdwn", "mkd", "mkdn", "mkdown", "ronn"],
 		flags: SUPPORTS_TOC | SUPPORTS_LISTS,
 	},
+	M4B {
+		name: "M4B Audiobooks",
+		extensions: ["m4b"],
+		flags: SUPPORTS_SECTIONS | SUPPORTS_TOC | SUPPORTS_AUDIO,
+	},
 	MOBI {
 		name: "MOBI Books",
 		extensions: ["mobi", "azw", "azw3"],
@@ -209,6 +214,7 @@ mod tests {
 		assert_eq!(RTF.flags, ParserFlags::SUPPORTS_PAGES);
 		assert_eq!(TEXT.flags, ParserFlags::NONE);
 		assert!(HTML.flags.contains(ParserFlags::SUPPORTS_TOC | ParserFlags::SUPPORTS_LISTS));
+		assert_eq!(M4B.flags, ParserFlags::SUPPORTS_SECTIONS | ParserFlags::SUPPORTS_TOC | ParserFlags::SUPPORTS_AUDIO);
 		assert!(!HTML.flags.contains(ParserFlags::SUPPORTS_PAGES));
 		assert!(!TEXT.installer.default_checked, "unspecified installer settings default to OPT_IN");
 		assert!(EPUB.installer.default_checked && EPUB.installer.default_handler);

--- a/doc/readme.md
+++ b/doc/readme.md
@@ -41,6 +41,7 @@ Paperback supports the following formats and extensions:
 * HTML documents (`.htm`, `.html`, `.xhtml`)
 * Markdown documents (`.md`, `.markdown`, `.mdx`, `.mdown`, `.mdwn`, `.mkd`, `.mkdn`, `.mkdown`, `.ronn`)
 * Microsoft Word documents (`.docx`, `.docm`, `.doc`)
+* M4B audiobooks (`.m4b`)
 * MOBI/Kindle books (`.mobi`, `.azw`, `.azw3`)
 * OpenDocument presentations (`.odp`, `.fodp`)
 * OpenDocument text files (`.odt`, `.fodt`)

--- a/po/paperback.pot
+++ b/po/paperback.pot
@@ -2433,6 +2433,10 @@ msgstr ""
 msgid "Failed to convert HTML to text: {}"
 msgstr ""
 
+#. TRANSLATORS: Fallback label for an audiobook chapter whose embedded title is empty; {} is the chapter number
+msgid "Chapter {}"
+msgstr ""
+
 #. TRANSLATORS: Error shown when a Markdown file fails to convert to plain text; {} is the file path
 msgid "Failed to convert Markdown to text: {}"
 msgstr ""

--- a/web/index.md
+++ b/web/index.md
@@ -23,6 +23,7 @@ Paperback is a fully accessible, fast, and native ebook and document reader for 
 - EPUB
 - FB2
 - HTML
+- M4B audiobooks
 - Markdown
 - MOBI, AZW, and AZW3 (Kindle)
 - ODP and FODP (OpenDocument Presentations)


### PR DESCRIPTION
Paperback already has an audio timeline and native playback for direct local sources, but standalone .m4b files stop at format routing. This adds an M4B parser backed by mp4ameta and reads metadata without pulling embedded cover bytes into memory.

Both MP4 chapter lists and chapter tracks become normalized clips with named section and table-of-contents anchors. A blank line per chapter gives the audio-only document a caret spine, matching plain-audio ZIP books; empty chapter titles get a translated fallback, and chapterless files open as one full-duration section.

The shared format table now carries .m4b with audio, section and TOC support, so desktop associations, file dialogs, the CLI and mobile extension filters all receive it. The English format lists and translation template are updated alongside it; .m4a remains unclaimed.

Verified with cargo test -p paperback-core --no-default-features, cargo test -p paperback-formats, cargo check --workspace, the focused seven-test M4B suite, Clippy under the repository lint policy, and an end-to-end pb smoke test against a real MPEG-4 audiobook.