### PR TITLE
Use Control-Space for audio playback on macOS

### DIFF
--- a/crates/paperback-core/src/config/shortcuts.rs
+++ b/crates/paperback-core/src/config/shortcuts.rs
@@ -155,6 +155,15 @@ mod tests {
 		assert_eq!(sc.get_chord(ActionId::Open), default_open);
 	}
 
+	#[cfg(target_os = "macos")]
+	#[test]
+	fn play_pause_audio_uses_physical_control_on_macos() {
+		let chord = ActionId::PlayPauseAudio.default_chord().unwrap();
+		assert!(!chord.ctrl);
+		assert!(chord.raw_ctrl);
+		assert_eq!(chord.key, "Space");
+	}
+
 	#[test]
 	fn shortcut_category_actions_coverage() {
 		let mut total_actions = 0;

--- a/crates/paperback-core/src/config/shortcuts/action_id.rs
+++ b/crates/paperback-core/src/config/shortcuts/action_id.rs
@@ -534,7 +534,7 @@ impl ActionId {
 			Self::ToggleBookmark => Some(KeyChord::new(true, false, true, "B")),
 			Self::BookmarkWithNote => Some(KeyChord::new(true, false, true, "N")),
 			Self::ToggleWordWrap => Some(KeyChord::new(true, true, false, "W")),
-			Self::PlayPauseAudio => Some(KeyChord::new(true, false, false, "Space")),
+			Self::PlayPauseAudio => Some(KeyChord::new_raw_ctrl(true, false, false, "Space")),
 			Self::SeekAudioForward => Some(KeyChord::new(false, false, false, "'")),
 			Self::SeekAudioBackward => Some(KeyChord::new(false, false, false, ";")),
 			Self::IncreaseAudioSeekAmount => Some(KeyChord::new(false, false, true, "'")),


### PR DESCRIPTION
## Summary

- use wxWidgets RawCtrl for the macOS play/pause default so it binds the physical Control key
- keep the existing Ctrl+Space default on Windows and Linux
- add a macOS regression test for the modifier distinction

## Testing

- cargo fmt --all -- --check
- cargo test -p paperback-core
- cargo check -p paperback