### PR TITLE
Go to page: interrupt the focus chain, reject out-of-range pages, and accept +n/-n

### DIFF
--- a/crates/paperback/src/ui/dialogs/go_to_page.rs
+++ b/crates/paperback/src/ui/dialogs/go_to_page.rs
@@ -35,7 +35,14 @@ pub fn show_go_to_page_dialog(
 	let dialog_for_enter = dialog;
 	page_ctrl_for_enter.bind_internal(EventType::TEXT_ENTER, move |event| {
 		event.skip(false);
-		submit_go_to_page(dialog_for_enter, page_ctrl_for_enter, &result_for_enter, live_region_label, max_page);
+		submit_go_to_page(
+			dialog_for_enter,
+			page_ctrl_for_enter,
+			&result_for_enter,
+			live_region_label,
+			current_page,
+			max_page,
+		);
 	});
 	// TRANSLATORS: Label for the button that jumps to the entered page
 	let ok_button = Button::builder(&dialog).with_label(&t("Go")).build();
@@ -47,7 +54,7 @@ pub fn show_go_to_page_dialog(
 	let result_for_ok = Rc::clone(&result);
 	let dialog_for_ok = dialog;
 	ok_button.on_click(move |_| {
-		submit_go_to_page(dialog_for_ok, page_ctrl_for_ok, &result_for_ok, live_region_label, max_page);
+		submit_go_to_page(dialog_for_ok, page_ctrl_for_ok, &result_for_ok, live_region_label, current_page, max_page);
 	});
 	let page_sizer = BoxSizer::builder(Orientation::Horizontal).build();
 	page_sizer.add(&label, 0, SizerFlag::AlignCenterVertical | SizerFlag::Right, 5);
@@ -67,10 +74,27 @@ pub fn show_go_to_page_dialog(
 }
 
 /// Resolves the entered `text` to a page number in `1..=max_page`, or `None` when the text
-/// is not a bare page number or the page is out of range.
-fn resolve_page(text: &str, max_page: i32) -> Option<i32> {
-	let page = text.trim().parse::<i64>().ok()?;
-	if (1..=i64::from(max_page)).contains(&page) { i32::try_from(page).ok() } else { None }
+/// is not a valid page expression or resolves out of range.
+///
+/// A bare number is the page itself; a leading `+`/`-` moves that many pages forward or
+/// backward from `current_page`, so "+5" is five pages ahead and "-3" three pages back.
+fn resolve_page(text: &str, current_page: i32, max_page: i32) -> Option<i32> {
+	let trimmed = text.trim();
+	if trimmed.is_empty() {
+		return None;
+	}
+	let (sign, digits) = match trimmed.as_bytes()[0] {
+		b'+' | b'-' => (trimmed.as_bytes()[0], &trimmed[1..]),
+		_ => (0, trimmed),
+	};
+	let amount = digits.parse::<i64>().ok()?;
+	let current = i64::from(current_page);
+	let resolved = match sign {
+		b'+' => current.checked_add(amount)?,
+		b'-' => current.checked_sub(amount)?,
+		_ => amount,
+	};
+	if (1..=i64::from(max_page)).contains(&resolved) { i32::try_from(resolved).ok() } else { None }
 }
 
 /// Validates the field and either confirms the dialog with the resolved page or, when the
@@ -80,9 +104,10 @@ fn submit_go_to_page(
 	page_ctrl: TextCtrl,
 	result: &Rc<Cell<Option<i32>>>,
 	live_region_label: StaticText,
+	current_page: i32,
 	max_page: i32,
 ) {
-	let Some(page) = resolve_page(&page_ctrl.get_value(), max_page) else {
+	let Some(page) = resolve_page(&page_ctrl.get_value(), current_page, max_page) else {
 		// TRANSLATORS: Announced when the entered page number is outside the document's range
 		live_region::announce(live_region_label, &t("Page out of range."));
 		page_ctrl.set_focus();
@@ -91,4 +116,42 @@ fn submit_go_to_page(
 	};
 	result.set(Some(page));
 	dialog.end_modal(ID_OK);
+}
+
+#[cfg(test)]
+mod tests {
+	use super::resolve_page;
+
+	#[test]
+	fn absolute_pages_resolve_and_reject_out_of_range() {
+		assert_eq!(resolve_page("5", 10, 100), Some(5));
+		assert_eq!(resolve_page(" 42 ", 10, 100), Some(42));
+		assert_eq!(resolve_page("0", 10, 100), None);
+		assert_eq!(resolve_page("101", 10, 100), None);
+		assert_eq!(resolve_page("99999999999", 10, 100), None);
+	}
+
+	#[test]
+	fn relative_offsets_resolve_from_the_current_page() {
+		assert_eq!(resolve_page("+5", 10, 100), Some(15));
+		assert_eq!(resolve_page("-3", 10, 100), Some(7));
+		assert_eq!(resolve_page("+0", 10, 100), Some(10));
+		assert_eq!(resolve_page("-0", 10, 100), Some(10));
+	}
+
+	#[test]
+	fn relative_offsets_out_of_range_are_rejected() {
+		assert_eq!(resolve_page("-20", 10, 100), None);
+		assert_eq!(resolve_page("+100", 10, 100), None);
+	}
+
+	#[test]
+	fn garbage_is_rejected() {
+		assert_eq!(resolve_page("", 10, 100), None);
+		assert_eq!(resolve_page("   ", 10, 100), None);
+		assert_eq!(resolve_page("abc", 10, 100), None);
+		assert_eq!(resolve_page("5+3", 10, 100), None);
+		assert_eq!(resolve_page("+", 10, 100), None);
+		assert_eq!(resolve_page("-", 10, 100), None);
+	}
 }

--- a/crates/paperback/src/ui/dialogs/go_to_page.rs
+++ b/crates/paperback/src/ui/dialogs/go_to_page.rs
@@ -1,9 +1,16 @@
+use std::{cell::Cell, rc::Rc};
+
 use patois::t;
 use wxdragon::prelude::*;
 
-use super::{DIALOG_PADDING, add_ok_cancel_footer, bind_enter_confirms, build_ok_cancel_buttons};
+use super::DIALOG_PADDING;
 
-pub fn show_go_to_page_dialog(parent: &Frame, current_page: i32, max_page: i32) -> Option<i32> {
+pub fn show_go_to_page_dialog(
+	parent: &Frame,
+	current_page: i32,
+	max_page: i32,
+	live_region_label: StaticText,
+) -> Option<i32> {
 	let max_page = max_page.max(1);
 	// TRANSLATORS: Title of the Go to page dialog
 	let dialog_title = t("Go to page");
@@ -17,32 +24,71 @@ pub fn show_go_to_page_dialog(parent: &Frame, current_page: i32, max_page: i32) 
 	);
 	let label = StaticText::builder(&dialog).with_label(&label_text).build();
 	let current = current_page.clamp(1, max_page);
-	let page_ctrl = SpinCtrl::builder(&dialog)
-		.with_range(1, max_page)
-		.with_style(SpinCtrlStyle::Default | SpinCtrlStyle::ProcessEnter)
-		.build();
-	page_ctrl.set_value(current);
-	bind_enter_confirms(&dialog, page_ctrl);
-	let label_for_update = label;
-	let label_template_for_update = label_template;
-	page_ctrl.on_value_changed(move |event| {
-		let text = label_template_for_update.replacen("%d", &event.get_value().to_string(), 1).replacen(
-			"%d",
-			&max_page.to_string(),
-			1,
-		);
-		label_for_update.set_label(&text);
+	// A plain text field rather than a spin control: out-of-range pages must be rejected,
+	// not silently clamped, and (later) relative +n/-n input has no spinner equivalent.
+	let page_ctrl =
+		TextCtrl::builder(&dialog).with_value(&current.to_string()).with_style(TextCtrlStyle::ProcessEnter).build();
+	let result = Rc::new(Cell::new(None::<i32>));
+	// Enter in the field and the Go button both submit through the same validation.
+	let page_ctrl_for_enter = page_ctrl;
+	let result_for_enter = Rc::clone(&result);
+	let dialog_for_enter = dialog;
+	page_ctrl_for_enter.bind_internal(EventType::TEXT_ENTER, move |event| {
+		event.skip(false);
+		submit_go_to_page(dialog_for_enter, page_ctrl_for_enter, &result_for_enter, live_region_label, max_page);
+	});
+	// TRANSLATORS: Label for the button that jumps to the entered page
+	let ok_button = Button::builder(&dialog).with_label(&t("Go")).build();
+	// TRANSLATORS: Label for the button that closes the dialog without navigating
+	let cancel_button = Button::builder(&dialog).with_id(ID_CANCEL).with_label(&t("Cancel")).build();
+	dialog.set_escape_id(ID_CANCEL);
+	ok_button.set_default();
+	let page_ctrl_for_ok = page_ctrl;
+	let result_for_ok = Rc::clone(&result);
+	let dialog_for_ok = dialog;
+	ok_button.on_click(move |_| {
+		submit_go_to_page(dialog_for_ok, page_ctrl_for_ok, &result_for_ok, live_region_label, max_page);
 	});
 	let page_sizer = BoxSizer::builder(Orientation::Horizontal).build();
 	page_sizer.add(&label, 0, SizerFlag::AlignCenterVertical | SizerFlag::Right, 5);
 	page_sizer.add(&page_ctrl, 1, SizerFlag::Expand, 0);
-	// TRANSLATORS: Label for the button that jumps to the entered position (a line, page, or percentage, depending on the dialog)
-	let (ok_button, cancel_button) = build_ok_cancel_buttons(&dialog, &t("Go"));
+	let button_sizer = BoxSizer::builder(Orientation::Horizontal).build();
+	button_sizer.add_stretch_spacer(1);
+	button_sizer.add(&ok_button, 0, SizerFlag::Right, DIALOG_PADDING);
+	button_sizer.add(&cancel_button, 0, SizerFlag::Right, DIALOG_PADDING);
 	let content_sizer = BoxSizer::builder(Orientation::Vertical).build();
 	content_sizer.add_sizer(&page_sizer, 0, SizerFlag::Expand | SizerFlag::All, DIALOG_PADDING);
-	add_ok_cancel_footer(content_sizer, ok_button, cancel_button);
+	content_sizer.add_sizer(&button_sizer, 0, SizerFlag::Expand | SizerFlag::Bottom | SizerFlag::Right, DIALOG_PADDING);
 	dialog.set_sizer_and_fit(content_sizer, true);
 	dialog.centre();
 	page_ctrl.set_focus();
-	if dialog.show_modal() == ID_OK { Some(page_ctrl.value().clamp(1, max_page)) } else { None }
+	page_ctrl.select_all();
+	if dialog.show_modal() == ID_OK { result.get() } else { None }
+}
+
+/// Resolves the entered `text` to a page number in `1..=max_page`, or `None` when the text
+/// is not a bare page number or the page is out of range.
+fn resolve_page(text: &str, max_page: i32) -> Option<i32> {
+	let page = text.trim().parse::<i64>().ok()?;
+	if (1..=i64::from(max_page)).contains(&page) { i32::try_from(page).ok() } else { None }
+}
+
+/// Validates the field and either confirms the dialog with the resolved page or, when the
+/// entry is invalid, announces the rejection and keeps the dialog open so the user can retry.
+fn submit_go_to_page(
+	dialog: Dialog,
+	page_ctrl: TextCtrl,
+	result: &Rc<Cell<Option<i32>>>,
+	live_region_label: StaticText,
+	max_page: i32,
+) {
+	let Some(page) = resolve_page(&page_ctrl.get_value(), max_page) else {
+		// TRANSLATORS: Announced when the entered page number is outside the document's range
+		live_region::announce(live_region_label, &t("Page out of range."));
+		page_ctrl.set_focus();
+		page_ctrl.select_all();
+		return;
+	};
+	result.set(Some(page));
+	dialog.end_modal(ID_OK);
 }

--- a/crates/paperback/src/ui/dialogs/go_to_page.rs
+++ b/crates/paperback/src/ui/dialogs/go_to_page.rs
@@ -28,6 +28,7 @@ pub fn show_go_to_page_dialog(
 	// not silently clamped, and (later) relative +n/-n input has no spinner equivalent.
 	let page_ctrl =
 		TextCtrl::builder(&dialog).with_value(&current.to_string()).with_style(TextCtrlStyle::ProcessEnter).build();
+	restrict_to_number_input(page_ctrl);
 	let result = Rc::new(Cell::new(None::<i32>));
 	// Enter in the field and the Go button both submit through the same validation.
 	let page_ctrl_for_enter = page_ctrl;
@@ -95,6 +96,30 @@ fn resolve_page(text: &str, current_page: i32, max_page: i32) -> Option<i32> {
 		_ => amount,
 	};
 	if (1..=i64::from(max_page)).contains(&resolved) { i32::try_from(resolved).ok() } else { None }
+}
+
+/// Swallows any keystroke that cannot be part of a page expression: digits, `+`/`-` (for
+/// relative jumps), and Enter (which submits). Letters and punctuation never reach the
+/// field, so an invalid entry can't be typed in the first place.
+///
+/// Only `CHAR` events are filtered, which fire for character insertion. Everything that
+/// is not a printable character passes through untouched, so every navigation, editing
+/// and shortcut key keeps working: control codes below space (Tab, Backspace, Enter,
+/// Escape), Delete, the special keys at [`WXK_START`] and above (arrows, Home/End, Page
+/// keys, Insert, F-keys, numpad Enter), and all Ctrl/Cmd shortcuts.
+fn restrict_to_number_input(ctrl: TextCtrl) {
+	ctrl.bind_internal(EventType::CHAR, move |event| {
+		let key = event.get_key_code().unwrap_or(0);
+		let allowed = event.control_down()
+			|| event.cmd_down()
+			|| key < i32::from(b' ')
+			|| key == WXK_DELETE
+			|| key >= WXK_START
+			|| (i32::from(b'0')..=i32::from(b'9')).contains(&key)
+			|| key == i32::from(b'+')
+			|| key == i32::from(b'-');
+		event.skip(allowed);
+	});
 }
 
 /// Validates the field and either confirms the dialog with the resolved page or, when the

--- a/crates/paperback/src/ui/find.rs
+++ b/crates/paperback/src/ui/find.rs
@@ -1,8 +1,4 @@
-use std::{
-	cell::{Cell, RefCell},
-	rc::Rc,
-	sync::Mutex,
-};
+use std::{cell::Cell, rc::Rc, sync::Mutex};
 
 use bitflags::bitflags;
 use paperback_core::{config::ConfigManager, reader_core, util::text::display_len};
@@ -13,16 +9,6 @@ use wxdragon::prelude::*;
 use super::{dialogs::DIALOG_PADDING, document_manager::DocumentManager, navigation};
 
 const MAX_FIND_HISTORY_SIZE: usize = 10;
-
-/// How long after the Find dialog closes the found line is announced.
-///
-/// The interrupt must land after NVDA has started the focus-return chain — if it fires
-/// before, the chain reads over the found line instead — but as close to the chain's
-/// start as possible, so as little of it escapes before the cut. NVDA's own find dialog
-/// uses 100ms; Paperback's chain starts quickly, and 30ms was chosen by binary search
-/// (60ms left a barely-audible sliver of the chain, 10ms occasionally let the full chain
-/// through after the found line, 0ms always did).
-const FIND_RESULT_INTERRUPT_DELAY_MS: i32 = 30;
 
 #[derive(Clone, Debug, Default)]
 pub struct SearchResult {
@@ -507,7 +493,7 @@ fn do_find(
 			found_line
 		};
 		if !message.trim().is_empty() {
-			announce_found_line_after_delay(frame, live_region_label, message);
+			navigation::announce_after_delay(frame, live_region_label, message);
 		}
 	} else if result.wrapped {
 		// Find-next / Find-previous with the dialog closed. There is no focus chain
@@ -521,27 +507,4 @@ fn do_find(
 		// announce the found line directly.
 		live_region::announce(live_region_label, &found_line);
 	}
-}
-
-/// Announces `found_line` shortly after the Find dialog closes, so it cuts off the
-/// focus-chain announcement the screen reader starts when focus returns to the book.
-///
-/// The one-shot `wxTimer` is kept alive through its single tick by the `Rc`/`RefCell`
-/// it hands its own callback: the tick clears the cell, which drops the timer and
-/// destroys the native timer. If the timer cannot be armed, fall back to announcing
-/// immediately rather than silently dropping the result.
-fn announce_found_line_after_delay(frame: &Frame, live_region_label: StaticText, found_line: String) {
-	let timer_holder: Rc<RefCell<Option<Timer<Frame>>>> = Rc::new(RefCell::new(None));
-	let holder = Rc::clone(&timer_holder);
-	let timer = Timer::new(frame);
-	let announce_found_line = found_line.clone();
-	timer.on_tick(move |_event| {
-		live_region::announce(live_region_label, &announce_found_line);
-		*holder.borrow_mut() = None;
-	});
-	if !timer.start(FIND_RESULT_INTERRUPT_DELAY_MS, true) {
-		live_region::announce(live_region_label, &found_line);
-		return;
-	}
-	*timer_holder.borrow_mut() = Some(timer);
 }

--- a/crates/paperback/src/ui/main_window/menu_go.rs
+++ b/crates/paperback/src/ui/main_window/menu_go.rs
@@ -72,19 +72,39 @@ pub(super) fn handle_go_to_page(
 		(current_page, max_page)
 	};
 	if let Some(page) = dialogs::show_go_to_page_dialog(frame, current_page, max_page) {
-		let update = {
+		let (message, update) = {
 			let mut dm_guard = dm.lock().unwrap();
-			let update = {
+			let (message, update) = {
 				let Some(tab) = dm_guard.active_tab_mut() else {
 					return;
 				};
 				let target_pos = tab.session.page_offset(page);
-				navigation::move_to_offset_and_record_history(tab, target_pos)
+				// Capture the page's announcement while the document lock is held; it is
+				// spoken after focus has returned to the book, cutting off the focus chain.
+				let content = tab.session.first_content_line_after(target_pos);
+				let message = page_announcement(page, &content);
+				let update = navigation::move_to_offset_and_record_history(tab, target_pos);
+				(message, update)
 			};
 			drop(dm_guard);
-			update
+			(message, update)
 		};
 		navigation::persist_navigation_history(config, Some(&update));
+		navigation::announce_after_delay(frame, live_region_label, message);
+	}
+}
+
+/// The announcement for landing on page `page`, whose first line of real content is
+/// `content` (possibly empty for a blank or image-only page). Matches what page
+/// navigation announces, so "Go to page" and page-down read the same.
+fn page_announcement(page: i32, content: &str) -> String {
+	let page_text = page.to_string();
+	if content.is_empty() {
+		// TRANSLATORS: Announced when landing on a page with no extractable text; %d is the page number
+		t("Page %d").replacen("%d", &page_text, 1)
+	} else {
+		// TRANSLATORS: Announced when landing on a page; %d is the page number, %s is the page text
+		t("Page %d: %s").replacen("%d", &page_text, 1).replacen("%s", content, 1)
 	}
 }
 

--- a/crates/paperback/src/ui/main_window/menu_go.rs
+++ b/crates/paperback/src/ui/main_window/menu_go.rs
@@ -82,7 +82,7 @@ pub(super) fn handle_go_to_page(
 				// Capture the page's announcement while the document lock is held; it is
 				// spoken after focus has returned to the book, cutting off the focus chain.
 				let content = tab.session.first_content_line_after(target_pos);
-				let message = page_announcement(page, &content);
+				let message = navigation::page_announcement(page, &content);
 				let update = navigation::move_to_offset_and_record_history(tab, target_pos);
 				(message, update)
 			};
@@ -93,21 +93,6 @@ pub(super) fn handle_go_to_page(
 		navigation::announce_after_delay(frame, live_region_label, message);
 	}
 }
-
-/// The announcement for landing on page `page`, whose first line of real content is
-/// `content` (possibly empty for a blank or image-only page). Matches what page
-/// navigation announces, so "Go to page" and page-down read the same.
-fn page_announcement(page: i32, content: &str) -> String {
-	let page_text = page.to_string();
-	if content.is_empty() {
-		// TRANSLATORS: Announced when landing on a page with no extractable text; %d is the page number
-		t("Page %d").replacen("%d", &page_text, 1)
-	} else {
-		// TRANSLATORS: Announced when landing on a page; %d is the page number, %s is the page text
-		t("Page %d: %s").replacen("%d", &page_text, 1).replacen("%s", content, 1)
-	}
-}
-
 pub(super) fn handle_go_to_percent(frame: &Frame, dm: &Rc<Mutex<DocumentManager>>, config: &Rc<Mutex<ConfigManager>>) {
 	let current_percent = {
 		let mut dm_guard = dm.lock().unwrap();

--- a/crates/paperback/src/ui/main_window/menu_go.rs
+++ b/crates/paperback/src/ui/main_window/menu_go.rs
@@ -71,7 +71,7 @@ pub(super) fn handle_go_to_page(
 		drop(dm_guard);
 		(current_page, max_page)
 	};
-	if let Some(page) = dialogs::show_go_to_page_dialog(frame, current_page, max_page) {
+	if let Some(page) = dialogs::show_go_to_page_dialog(frame, current_page, max_page, live_region_label) {
 		let (message, update) = {
 			let mut dm_guard = dm.lock().unwrap();
 			let (message, update) = {

--- a/crates/paperback/src/ui/navigation.rs
+++ b/crates/paperback/src/ui/navigation.rs
@@ -323,14 +323,7 @@ fn format_nav_found_message(
 			format!("{wrap_prefix}{message}")
 		}
 		NavFoundFormat::PageFormat => {
-			let page_text = (context_index + 1).to_string();
-			let message = if context_text.is_empty() {
-				// TRANSLATORS: Announcement when landing on a page with no extractable text; %d is the page number
-				t("Page %d").replacen("%d", &page_text, 1)
-			} else {
-				// TRANSLATORS: Announcement when landing on a page; %d is the page number, %s is the page text
-				t("Page %d: %s").replacen("%d", &page_text, 1).replacen("%s", context_text, 1)
-			};
+			let message = page_announcement(context_index + 1, context_text);
 			format!("{wrap_prefix}{message}")
 		}
 		NavFoundFormat::LinkFormat => {
@@ -342,6 +335,20 @@ fn format_nav_found_message(
 			let message = context_text.to_string();
 			format!("{wrap_prefix}{message}")
 		}
+	}
+}
+
+/// The announcement for landing on page `page`, whose first line of real content is
+/// `content` (empty for a blank or image-only page). Shared by page navigation and the
+/// Go to page dialog so both read the same.
+pub fn page_announcement(page: i32, content: &str) -> String {
+	let page_text = page.to_string();
+	if content.is_empty() {
+		// TRANSLATORS: Announcement when landing on a page with no extractable text; %d is the page number
+		t("Page %d").replacen("%d", &page_text, 1)
+	} else {
+		// TRANSLATORS: Announcement when landing on a page; %d is the page number, %s is the page text
+		t("Page %d: %s").replacen("%d", &page_text, 1).replacen("%s", content, 1)
 	}
 }
 

--- a/crates/paperback/src/ui/navigation.rs
+++ b/crates/paperback/src/ui/navigation.rs
@@ -1,4 +1,4 @@
-use std::{rc::Rc, sync::Mutex};
+use std::{cell::RefCell, rc::Rc, sync::Mutex};
 
 use paperback_core::{config::ConfigManager, session::NavigationResult};
 use patois::t;
@@ -512,4 +512,38 @@ pub fn selected_range(text_ctrl: TextCtrl) -> (i64, i64) {
 	} else {
 		(end, start)
 	}
+}
+
+/// How long after a jump the interrupting announcement is raised.
+///
+/// The interrupt must land after NVDA has started the focus-return chain — if it fires
+/// before, the chain reads over the announcement instead — but as close to the chain's
+/// start as possible, so as little of it escapes before the cut. NVDA's own find dialog
+/// uses 100ms; Paperback's chain starts quickly, and 30ms was chosen by binary search on
+/// the Find dialog (60ms left a barely-audible sliver of the chain, 10ms occasionally let
+/// the full chain through after the announcement, 0ms always did).
+const FOCUS_CHAIN_INTERRUPT_DELAY_MS: i32 = 30;
+
+/// Announces `message` shortly after a dialog closes, so it cuts off the focus-chain
+/// announcement the screen reader starts when focus returns to the book.
+///
+/// The one-shot `wxTimer` is kept alive through its single tick by the `Rc`/`RefCell` it
+/// hands its own callback: the tick clears the cell, which drops the timer and destroys
+/// the native timer. If the timer cannot be armed, fall back to announcing immediately
+/// rather than silently dropping the message.
+#[allow(clippy::needless_pass_by_value)]
+pub fn announce_after_delay(frame: &Frame, live_region_label: StaticText, message: String) {
+	let timer_holder: Rc<RefCell<Option<Timer<Frame>>>> = Rc::new(RefCell::new(None));
+	let holder = Rc::clone(&timer_holder);
+	let timer = Timer::new(frame);
+	let announce = message.clone();
+	timer.on_tick(move |_event| {
+		live_region::announce(live_region_label, &announce);
+		*holder.borrow_mut() = None;
+	});
+	if !timer.start(FOCUS_CHAIN_INTERRUPT_DELAY_MS, true) {
+		live_region::announce(live_region_label, &message);
+		return;
+	}
+	*timer_holder.borrow_mut() = Some(timer);
 }


### PR DESCRIPTION
# Go to page: interrupt the focus chain, reject out-of-range pages, and accept +n/-n

Three improvements to the Go to page dialog (Ctrl+P, or Go → "Go to page"), built on the speech-chain enhancement from the Find PR (#750). Three commits, one per change.

## 1. Interrupt the focus-chain announcement

Closing Go to Page made NVDA announce the whole focus chain ("Paperback, tab control, edit read only multi line") before the page was spoken — the same problem Find had. This generalizes the Find fix: the delay-announce helper moves out of `find.rs` into `navigation.rs` as `announce_after_delay`, and Go to Page raises the same High-priority UIA notification ~30ms after the dialog closes, cutting off all but a sliver of the chain. You just hear "Page 42: \<first line of content\>" — the same wording page-down navigation reads.

## 2. Reject out-of-range pages

Typing a page number beyond the last page was silently clamped by the spin control, so a huge number jumped to the last page — or, depending on how the native control parsed the out-of-range text, to the first. The dialog now validates on submit: out-of-range or unparseable input announces "Page out of range." and keeps the dialog open, mirroring Find's "Not found."

## 3. Accept +n and -n

`+n` advances n pages and `-n` moves back n pages from the current page, so skimming a book no longer requires doing the arithmetic. A bare number still means the page itself. Relative results are held to the same out-of-range check, so `+5` on page 298 of a 300-page book says "Page out of range." rather than clamping. Unit tests cover the parser.

## Notes / tradeoffs

- The dialog switched from a `SpinCtrl` to a plain text field so the raw input can be validated — the native control rendered as a number-only edit anyway, so nothing visually changes.
- Only NVDA is verified, same caveat as the Find PR.
- New translatable string: "Page out of range." (pot regeneration left to the usual maintenance pass).

## Testing

Tested with NVDA on Windows 11: Ctrl+P → page → Enter reads the page with no focus chain after it; out-of-range and garbage input speak "Page out of range." and stay in the dialog; `+5`/`-3` land where expected; ESC/Cancel unchanged; the four parser unit tests pass.
