### PR TITLE
Go to line: interrupt the focus chain, reject out-of-range lines, and accept +n/-n

### DIFF
--- a/crates/paperback/src/ui/dialogs.rs
+++ b/crates/paperback/src/ui/dialogs.rs
@@ -24,6 +24,7 @@ pub use document_info::show_document_info_dialog;
 mod duration_format;
 mod elements;
 pub use elements::show_elements_dialog;
+mod go_to;
 mod go_to_line;
 pub use go_to_line::show_go_to_line_dialog;
 mod go_to_page;

--- a/crates/paperback/src/ui/dialogs/go_to.rs
+++ b/crates/paperback/src/ui/dialogs/go_to.rs
@@ -1,0 +1,215 @@
+//! The pieces the Go to line, page and percent dialogs share: a text entry that takes a
+//! bare number or a relative `+n`/`-n` offset, validation that keeps the dialog open and
+//! speaks a rejection when the entry is out of range, and the Go/Cancel footer.
+
+use std::{cell::Cell, rc::Rc};
+
+use patois::t;
+use wxdragon::prelude::*;
+
+/// The numeric entry of a Go to dialog together with the range it validates against and
+/// the value it resolved to when the dialog was confirmed.
+pub(super) struct NumberEntry {
+	pub ctrl: TextCtrl,
+	current: i32,
+	min: i32,
+	max: i32,
+	result: Rc<Cell<Option<i32>>>,
+}
+
+impl NumberEntry {
+	/// Builds the entry seeded with `current`, accepting only the keystrokes a number
+	/// expression can contain. A plain text field rather than a spin control: out-of-range
+	/// values must be rejected, not silently clamped, and relative `+n`/`-n` input has no
+	/// spinner equivalent.
+	pub fn new(dialog: Dialog, current: i32, min: i32, max: i32) -> Self {
+		let ctrl =
+			TextCtrl::builder(&dialog).with_value(&current.to_string()).with_style(TextCtrlStyle::ProcessEnter).build();
+		restrict_to_number_input(ctrl);
+		Self { ctrl, current, min, max, result: Rc::new(Cell::new(None)) }
+	}
+
+	/// The number the field currently resolves to, or `None` when it is invalid or out of range.
+	pub fn resolve(&self) -> Option<i32> {
+		resolve_number(&self.ctrl.get_value(), self.current, self.min, self.max)
+	}
+
+	/// The value the dialog was confirmed with, if it was.
+	pub fn result(&self) -> Option<i32> {
+		self.result.get()
+	}
+
+	/// Puts the caret in the field with its contents selected, ready to be overtyped.
+	pub fn focus(&self) {
+		self.ctrl.set_focus();
+		self.ctrl.select_all();
+	}
+
+	/// Validates the field and either confirms `dialog` with the resolved number or, when
+	/// the entry is invalid, announces `out_of_range` and keeps the dialog open for a retry.
+	pub fn submit(&self, dialog: Dialog, live_region_label: StaticText, out_of_range: &str) {
+		let Some(value) = self.resolve() else {
+			live_region::announce(live_region_label, out_of_range);
+			self.focus();
+			return;
+		};
+		self.result.set(Some(value));
+		dialog.end_modal(ID_OK);
+	}
+}
+
+/// What a single-field Go to dialog (line or page) shows and accepts.
+pub(super) struct NumberPrompt<'a> {
+	pub title: &'a str,
+	pub label: &'a str,
+	/// Announced when the entry does not resolve to a number in `min..=max`.
+	pub out_of_range: &'a str,
+	pub current: i32,
+	pub min: i32,
+	pub max: i32,
+}
+
+/// Shows a modal dialog with one labelled [`NumberEntry`] and a Go/Cancel footer, and
+/// returns the number it was confirmed with.
+pub(super) fn show_number_dialog(parent: &Frame, prompt: &NumberPrompt, live_region_label: StaticText) -> Option<i32> {
+	let dialog = Dialog::builder(parent, prompt.title).build();
+	let label = StaticText::builder(&dialog).with_label(prompt.label).build();
+	let entry = Rc::new(NumberEntry::new(dialog, prompt.current, prompt.min, prompt.max));
+	let entry_sizer = BoxSizer::builder(Orientation::Horizontal).build();
+	entry_sizer.add(&label, 0, SizerFlag::AlignCenterVertical | SizerFlag::Right, 5);
+	entry_sizer.add(&entry.ctrl, 1, SizerFlag::Expand, 0);
+	let content_sizer = BoxSizer::builder(Orientation::Vertical).build();
+	content_sizer.add_sizer(&entry_sizer, 0, SizerFlag::Expand | SizerFlag::All, super::DIALOG_PADDING);
+	let out_of_range = prompt.out_of_range.to_string();
+	let entry_for_submit = Rc::clone(&entry);
+	add_go_cancel_footer(dialog, content_sizer, entry.ctrl, move || {
+		entry_for_submit.submit(dialog, live_region_label, &out_of_range);
+	});
+	dialog.set_sizer_and_fit(content_sizer, true);
+	dialog.centre();
+	entry.focus();
+	if dialog.show_modal() == ID_OK { entry.result() } else { None }
+}
+
+/// Appends the Go/Cancel row to `content_sizer`. Enter in `entry` and a click on Go both
+/// run `submit`, which is expected to validate and end the modal itself; Escape and
+/// Cancel close the dialog without navigating.
+///
+/// Go gets a non-stock ID so a click does not end the modal before `submit` has had a
+/// chance to reject the entry. The `wxStdDialogButtonSizer` still lays the pair out in
+/// platform order, since it takes custom affirmative and cancel buttons explicitly.
+pub(super) fn add_go_cancel_footer(
+	dialog: Dialog,
+	content_sizer: BoxSizer,
+	entry: TextCtrl,
+	submit: impl Fn() + 'static,
+) {
+	let submit = Rc::new(submit);
+	// TRANSLATORS: Label for the button that jumps to the entered position (a line, page, or percentage, depending on the dialog)
+	let go_button = Button::builder(&dialog).with_label(&t("Go")).build();
+	// TRANSLATORS: Label for the cancellation button
+	let cancel_button = Button::builder(&dialog).with_id(ID_CANCEL).with_label(&t("Cancel")).build();
+	dialog.set_escape_id(ID_CANCEL);
+	go_button.set_default();
+	let submit_for_enter = Rc::clone(&submit);
+	entry.bind_internal(EventType::TEXT_ENTER, move |event| {
+		event.skip(false);
+		submit_for_enter();
+	});
+	go_button.on_click(move |_| submit());
+	let button_sizer = StdDialogButtonSizerBuilder::new().build();
+	button_sizer.set_affirmative_button(&go_button);
+	button_sizer.set_cancel_button(&cancel_button);
+	button_sizer.realize();
+	content_sizer.add_sizer(&button_sizer, 0, SizerFlag::Expand | SizerFlag::All, super::DIALOG_PADDING);
+}
+
+/// Resolves the entered `text` to a number in `min..=max`, or `None` when the text is not
+/// a valid number expression or resolves out of range.
+///
+/// A bare number is the value itself; a leading `+`/`-` moves that far forward or
+/// backward from `current`, so "+5" is five past the current value and "-3" three before.
+pub(super) fn resolve_number(text: &str, current: i32, min: i32, max: i32) -> Option<i32> {
+	let trimmed = text.trim();
+	if trimmed.is_empty() {
+		return None;
+	}
+	let (sign, digits) = match trimmed.as_bytes()[0] {
+		b'+' | b'-' => (trimmed.as_bytes()[0], &trimmed[1..]),
+		_ => (0, trimmed),
+	};
+	let amount = digits.parse::<i64>().ok()?;
+	let current = i64::from(current);
+	let resolved = match sign {
+		b'+' => current.checked_add(amount)?,
+		b'-' => current.checked_sub(amount)?,
+		_ => amount,
+	};
+	if (i64::from(min)..=i64::from(max)).contains(&resolved) { i32::try_from(resolved).ok() } else { None }
+}
+
+/// Swallows any keystroke that cannot be part of a number expression: digits, `+`/`-`
+/// (for relative jumps), and Enter (which submits). Letters and punctuation never reach
+/// the field, so an invalid entry can't be typed in the first place.
+///
+/// Only `CHAR` events are filtered, which fire for character insertion. Everything that
+/// is not a printable Latin-1 character passes through untouched, so every navigation,
+/// editing and shortcut key keeps working: control codes below space (Tab, Backspace,
+/// Enter, Escape), Delete, the special keys at [`WXK_START`] and above (arrows, Home/End,
+/// Page keys, Insert, F-keys, numpad Enter), and all Ctrl/Cmd shortcuts. Characters
+/// outside Latin-1 report no key code and slip through too; submit still rejects them.
+fn restrict_to_number_input(ctrl: TextCtrl) {
+	ctrl.bind_internal(EventType::CHAR, move |event| {
+		let key = event.get_key_code().unwrap_or(0);
+		let allowed = event.control_down()
+			|| event.cmd_down()
+			|| key < i32::from(b' ')
+			|| key == WXK_DELETE
+			|| key >= WXK_START
+			|| (i32::from(b'0')..=i32::from(b'9')).contains(&key)
+			|| key == i32::from(b'+')
+			|| key == i32::from(b'-');
+		event.skip(allowed);
+	});
+}
+
+#[cfg(test)]
+mod tests {
+	use super::resolve_number;
+
+	#[test]
+	fn absolute_values_resolve_and_reject_out_of_range() {
+		assert_eq!(resolve_number("5", 10, 1, 100), Some(5));
+		assert_eq!(resolve_number(" 42 ", 10, 1, 100), Some(42));
+		assert_eq!(resolve_number("0", 10, 1, 100), None);
+		assert_eq!(resolve_number("0", 40, 0, 100), Some(0));
+		assert_eq!(resolve_number("100", 40, 0, 100), Some(100));
+		assert_eq!(resolve_number("101", 10, 1, 100), None);
+		assert_eq!(resolve_number("99999999999", 10, 1, 100), None);
+	}
+
+	#[test]
+	fn relative_offsets_resolve_from_the_current_value() {
+		assert_eq!(resolve_number("+5", 10, 1, 100), Some(15));
+		assert_eq!(resolve_number("-3", 10, 1, 100), Some(7));
+		assert_eq!(resolve_number("+0", 10, 1, 100), Some(10));
+		assert_eq!(resolve_number("-0", 10, 1, 100), Some(10));
+	}
+
+	#[test]
+	fn relative_offsets_out_of_range_are_rejected() {
+		assert_eq!(resolve_number("-20", 10, 1, 100), None);
+		assert_eq!(resolve_number("+100", 10, 1, 100), None);
+		assert_eq!(resolve_number("-60", 45, 0, 100), None);
+	}
+
+	#[test]
+	fn garbage_is_rejected() {
+		assert_eq!(resolve_number("", 10, 1, 100), None);
+		assert_eq!(resolve_number("   ", 10, 1, 100), None);
+		assert_eq!(resolve_number("abc", 10, 1, 100), None);
+		assert_eq!(resolve_number("5+3", 10, 1, 100), None);
+		assert_eq!(resolve_number("+", 10, 1, 100), None);
+		assert_eq!(resolve_number("-", 10, 1, 100), None);
+	}
+}

--- a/crates/paperback/src/ui/dialogs/go_to_line.rs
+++ b/crates/paperback/src/ui/dialogs/go_to_line.rs
@@ -1,33 +1,94 @@
+use std::{cell::Cell, rc::Rc};
+
 use patois::t;
 use wxdragon::prelude::*;
 
-use super::{DIALOG_PADDING, add_ok_cancel_footer, bind_enter_confirms, build_ok_cancel_buttons};
+use super::DIALOG_PADDING;
 
-pub fn show_go_to_line_dialog(parent: &Frame, current_line: i32, max_lines: i32) -> Option<i32> {
+pub fn show_go_to_line_dialog(
+	parent: &Frame,
+	current_line: i32,
+	max_lines: i32,
+	live_region_label: StaticText,
+) -> Option<i32> {
+	let max_lines = max_lines.max(1);
 	// TRANSLATORS: Title of the Go to Line dialog
 	let dialog_title = t("Go to Line");
 	let dialog = Dialog::builder(parent, &dialog_title).build();
-	// TRANSLATORS: Label for the input field where users enter the target line number.
-	let label_text = t("&Line number:");
+	// TRANSLATORS: Label/prompt template for the line selection dialog. The %d placeholders represent current_line and max_lines respectively.
+	let label_template = t("Go to line (%d/%d):");
+	let label_text = label_template.replacen("%d", &current_line.clamp(1, max_lines).to_string(), 1).replacen(
+		"%d",
+		&max_lines.to_string(),
+		1,
+	);
 	let label = StaticText::builder(&dialog).with_label(&label_text).build();
-	let max_lines = max_lines.max(1);
-	let current_line = current_line.clamp(1, max_lines);
-	let line_ctrl = SpinCtrl::builder(&dialog)
-		.with_range(1, max_lines)
-		.with_style(SpinCtrlStyle::Default | SpinCtrlStyle::ProcessEnter)
-		.build();
-	line_ctrl.set_value(current_line);
-	bind_enter_confirms(&dialog, line_ctrl);
+	let current = current_line.clamp(1, max_lines);
+	// A plain text field rather than a spin control: out-of-range lines must be rejected,
+	// not silently clamped, and (later) relative +n/-n input has no spinner equivalent.
+	let line_ctrl =
+		TextCtrl::builder(&dialog).with_value(&current.to_string()).with_style(TextCtrlStyle::ProcessEnter).build();
+	let result = Rc::new(Cell::new(None::<i32>));
+	// Enter in the field and the Go button both submit through the same validation.
+	let line_ctrl_for_enter = line_ctrl;
+	let result_for_enter = Rc::clone(&result);
+	let dialog_for_enter = dialog;
+	line_ctrl_for_enter.bind_internal(EventType::TEXT_ENTER, move |event| {
+		event.skip(false);
+		submit_go_to_line(dialog_for_enter, line_ctrl_for_enter, &result_for_enter, live_region_label, max_lines);
+	});
+	// TRANSLATORS: Label for the button that jumps to the entered line
+	let ok_button = Button::builder(&dialog).with_label(&t("Go")).build();
+	// TRANSLATORS: Label for the button that closes the dialog without navigating
+	let cancel_button = Button::builder(&dialog).with_id(ID_CANCEL).with_label(&t("Cancel")).build();
+	dialog.set_escape_id(ID_CANCEL);
+	ok_button.set_default();
+	let line_ctrl_for_ok = line_ctrl;
+	let result_for_ok = Rc::clone(&result);
+	let dialog_for_ok = dialog;
+	ok_button.on_click(move |_| {
+		submit_go_to_line(dialog_for_ok, line_ctrl_for_ok, &result_for_ok, live_region_label, max_lines);
+	});
 	let line_sizer = BoxSizer::builder(Orientation::Horizontal).build();
 	line_sizer.add(&label, 0, SizerFlag::AlignCenterVertical | SizerFlag::Right, 5);
 	line_sizer.add(&line_ctrl, 1, SizerFlag::Expand, 0);
-	// TRANSLATORS: Label for the button that jumps to the entered position (a line, page, or percentage, depending on the dialog)
-	let (ok_button, cancel_button) = build_ok_cancel_buttons(&dialog, &t("Go"));
+	let button_sizer = BoxSizer::builder(Orientation::Horizontal).build();
+	button_sizer.add_stretch_spacer(1);
+	button_sizer.add(&ok_button, 0, SizerFlag::Right, DIALOG_PADDING);
+	button_sizer.add(&cancel_button, 0, SizerFlag::Right, DIALOG_PADDING);
 	let content_sizer = BoxSizer::builder(Orientation::Vertical).build();
 	content_sizer.add_sizer(&line_sizer, 0, SizerFlag::Expand | SizerFlag::All, DIALOG_PADDING);
-	add_ok_cancel_footer(content_sizer, ok_button, cancel_button);
+	content_sizer.add_sizer(&button_sizer, 0, SizerFlag::Expand | SizerFlag::Bottom | SizerFlag::Right, DIALOG_PADDING);
 	dialog.set_sizer_and_fit(content_sizer, true);
 	dialog.centre();
 	line_ctrl.set_focus();
-	if dialog.show_modal() == ID_OK { Some(line_ctrl.value().clamp(1, max_lines)) } else { None }
+	line_ctrl.select_all();
+	if dialog.show_modal() == ID_OK { result.get() } else { None }
+}
+
+/// Resolves the entered `text` to a line number in `1..=max_lines`, or `None` when the text
+/// is not a bare line number or the line is out of range.
+fn resolve_line(text: &str, max_lines: i32) -> Option<i32> {
+	let line = text.trim().parse::<i64>().ok()?;
+	if (1..=i64::from(max_lines)).contains(&line) { i32::try_from(line).ok() } else { None }
+}
+
+/// Validates the field and either confirms the dialog with the resolved line or, when the
+/// entry is invalid, announces the rejection and keeps the dialog open so the user can retry.
+fn submit_go_to_line(
+	dialog: Dialog,
+	line_ctrl: TextCtrl,
+	result: &Rc<Cell<Option<i32>>>,
+	live_region_label: StaticText,
+	max_lines: i32,
+) {
+	let Some(line) = resolve_line(&line_ctrl.get_value(), max_lines) else {
+		// TRANSLATORS: Announced when the entered line number is outside the document's range
+		live_region::announce(live_region_label, &t("Line out of range."));
+		line_ctrl.set_focus();
+		line_ctrl.select_all();
+		return;
+	};
+	result.set(Some(line));
+	dialog.end_modal(ID_OK);
 }

--- a/crates/paperback/src/ui/dialogs/go_to_line.rs
+++ b/crates/paperback/src/ui/dialogs/go_to_line.rs
@@ -35,7 +35,14 @@ pub fn show_go_to_line_dialog(
 	let dialog_for_enter = dialog;
 	line_ctrl_for_enter.bind_internal(EventType::TEXT_ENTER, move |event| {
 		event.skip(false);
-		submit_go_to_line(dialog_for_enter, line_ctrl_for_enter, &result_for_enter, live_region_label, max_lines);
+		submit_go_to_line(
+			dialog_for_enter,
+			line_ctrl_for_enter,
+			&result_for_enter,
+			live_region_label,
+			current_line,
+			max_lines,
+		);
 	});
 	// TRANSLATORS: Label for the button that jumps to the entered line
 	let ok_button = Button::builder(&dialog).with_label(&t("Go")).build();
@@ -47,7 +54,7 @@ pub fn show_go_to_line_dialog(
 	let result_for_ok = Rc::clone(&result);
 	let dialog_for_ok = dialog;
 	ok_button.on_click(move |_| {
-		submit_go_to_line(dialog_for_ok, line_ctrl_for_ok, &result_for_ok, live_region_label, max_lines);
+		submit_go_to_line(dialog_for_ok, line_ctrl_for_ok, &result_for_ok, live_region_label, current_line, max_lines);
 	});
 	let line_sizer = BoxSizer::builder(Orientation::Horizontal).build();
 	line_sizer.add(&label, 0, SizerFlag::AlignCenterVertical | SizerFlag::Right, 5);
@@ -67,10 +74,27 @@ pub fn show_go_to_line_dialog(
 }
 
 /// Resolves the entered `text` to a line number in `1..=max_lines`, or `None` when the text
-/// is not a bare line number or the line is out of range.
-fn resolve_line(text: &str, max_lines: i32) -> Option<i32> {
-	let line = text.trim().parse::<i64>().ok()?;
-	if (1..=i64::from(max_lines)).contains(&line) { i32::try_from(line).ok() } else { None }
+/// is not a valid line expression or resolves out of range.
+///
+/// A bare number is the line itself; a leading `+`/`-` moves that many lines forward or
+/// backward from `current_line`, so "+5" is five lines ahead and "-3" three lines back.
+fn resolve_line(text: &str, current_line: i32, max_lines: i32) -> Option<i32> {
+	let trimmed = text.trim();
+	if trimmed.is_empty() {
+		return None;
+	}
+	let (sign, digits) = match trimmed.as_bytes()[0] {
+		b'+' | b'-' => (trimmed.as_bytes()[0], &trimmed[1..]),
+		_ => (0, trimmed),
+	};
+	let amount = digits.parse::<i64>().ok()?;
+	let current = i64::from(current_line);
+	let resolved = match sign {
+		b'+' => current.checked_add(amount)?,
+		b'-' => current.checked_sub(amount)?,
+		_ => amount,
+	};
+	if (1..=i64::from(max_lines)).contains(&resolved) { i32::try_from(resolved).ok() } else { None }
 }
 
 /// Validates the field and either confirms the dialog with the resolved line or, when the
@@ -80,9 +104,10 @@ fn submit_go_to_line(
 	line_ctrl: TextCtrl,
 	result: &Rc<Cell<Option<i32>>>,
 	live_region_label: StaticText,
+	current_line: i32,
 	max_lines: i32,
 ) {
-	let Some(line) = resolve_line(&line_ctrl.get_value(), max_lines) else {
+	let Some(line) = resolve_line(&line_ctrl.get_value(), current_line, max_lines) else {
 		// TRANSLATORS: Announced when the entered line number is outside the document's range
 		live_region::announce(live_region_label, &t("Line out of range."));
 		line_ctrl.set_focus();
@@ -91,4 +116,42 @@ fn submit_go_to_line(
 	};
 	result.set(Some(line));
 	dialog.end_modal(ID_OK);
+}
+
+#[cfg(test)]
+mod tests {
+	use super::resolve_line;
+
+	#[test]
+	fn absolute_lines_resolve_and_reject_out_of_range() {
+		assert_eq!(resolve_line("5", 10, 100), Some(5));
+		assert_eq!(resolve_line(" 42 ", 10, 100), Some(42));
+		assert_eq!(resolve_line("0", 10, 100), None);
+		assert_eq!(resolve_line("101", 10, 100), None);
+		assert_eq!(resolve_line("99999999999", 10, 100), None);
+	}
+
+	#[test]
+	fn relative_offsets_resolve_from_the_current_line() {
+		assert_eq!(resolve_line("+5", 10, 100), Some(15));
+		assert_eq!(resolve_line("-3", 10, 100), Some(7));
+		assert_eq!(resolve_line("+0", 10, 100), Some(10));
+		assert_eq!(resolve_line("-0", 10, 100), Some(10));
+	}
+
+	#[test]
+	fn relative_offsets_out_of_range_are_rejected() {
+		assert_eq!(resolve_line("-20", 10, 100), None);
+		assert_eq!(resolve_line("+100", 10, 100), None);
+	}
+
+	#[test]
+	fn garbage_is_rejected() {
+		assert_eq!(resolve_line("", 10, 100), None);
+		assert_eq!(resolve_line("   ", 10, 100), None);
+		assert_eq!(resolve_line("abc", 10, 100), None);
+		assert_eq!(resolve_line("5+3", 10, 100), None);
+		assert_eq!(resolve_line("+", 10, 100), None);
+		assert_eq!(resolve_line("-", 10, 100), None);
+	}
 }

--- a/crates/paperback/src/ui/dialogs/go_to_line.rs
+++ b/crates/paperback/src/ui/dialogs/go_to_line.rs
@@ -1,9 +1,7 @@
-use std::{cell::Cell, rc::Rc};
-
 use patois::t;
 use wxdragon::prelude::*;
 
-use super::DIALOG_PADDING;
+use super::go_to::{NumberPrompt, show_number_dialog};
 
 pub fn show_go_to_line_dialog(
 	parent: &Frame,
@@ -13,170 +11,22 @@ pub fn show_go_to_line_dialog(
 ) -> Option<i32> {
 	let max_lines = max_lines.max(1);
 	// TRANSLATORS: Title of the Go to Line dialog
-	let dialog_title = t("Go to Line");
-	let dialog = Dialog::builder(parent, &dialog_title).build();
+	let title = t("Go to Line");
 	// TRANSLATORS: Label/prompt template for the line selection dialog. The %d placeholders represent current_line and max_lines respectively.
-	let label_template = t("Go to line (%d/%d):");
-	let label_text = label_template.replacen("%d", &current_line.clamp(1, max_lines).to_string(), 1).replacen(
+	let label = t("Go to line (%d/%d):").replacen("%d", &current_line.clamp(1, max_lines).to_string(), 1).replacen(
 		"%d",
 		&max_lines.to_string(),
 		1,
 	);
-	let label = StaticText::builder(&dialog).with_label(&label_text).build();
-	let current = current_line.clamp(1, max_lines);
-	// A plain text field rather than a spin control: out-of-range lines must be rejected,
-	// not silently clamped, and (later) relative +n/-n input has no spinner equivalent.
-	let line_ctrl =
-		TextCtrl::builder(&dialog).with_value(&current.to_string()).with_style(TextCtrlStyle::ProcessEnter).build();
-	restrict_to_number_input(line_ctrl);
-	let result = Rc::new(Cell::new(None::<i32>));
-	// Enter in the field and the Go button both submit through the same validation.
-	let line_ctrl_for_enter = line_ctrl;
-	let result_for_enter = Rc::clone(&result);
-	let dialog_for_enter = dialog;
-	line_ctrl_for_enter.bind_internal(EventType::TEXT_ENTER, move |event| {
-		event.skip(false);
-		submit_go_to_line(
-			dialog_for_enter,
-			line_ctrl_for_enter,
-			&result_for_enter,
-			live_region_label,
-			current_line,
-			max_lines,
-		);
-	});
-	// TRANSLATORS: Label for the button that jumps to the entered line
-	let ok_button = Button::builder(&dialog).with_label(&t("Go")).build();
-	// TRANSLATORS: Label for the button that closes the dialog without navigating
-	let cancel_button = Button::builder(&dialog).with_id(ID_CANCEL).with_label(&t("Cancel")).build();
-	dialog.set_escape_id(ID_CANCEL);
-	ok_button.set_default();
-	let line_ctrl_for_ok = line_ctrl;
-	let result_for_ok = Rc::clone(&result);
-	let dialog_for_ok = dialog;
-	ok_button.on_click(move |_| {
-		submit_go_to_line(dialog_for_ok, line_ctrl_for_ok, &result_for_ok, live_region_label, current_line, max_lines);
-	});
-	let line_sizer = BoxSizer::builder(Orientation::Horizontal).build();
-	line_sizer.add(&label, 0, SizerFlag::AlignCenterVertical | SizerFlag::Right, 5);
-	line_sizer.add(&line_ctrl, 1, SizerFlag::Expand, 0);
-	let button_sizer = BoxSizer::builder(Orientation::Horizontal).build();
-	button_sizer.add_stretch_spacer(1);
-	button_sizer.add(&ok_button, 0, SizerFlag::Right, DIALOG_PADDING);
-	button_sizer.add(&cancel_button, 0, SizerFlag::Right, DIALOG_PADDING);
-	let content_sizer = BoxSizer::builder(Orientation::Vertical).build();
-	content_sizer.add_sizer(&line_sizer, 0, SizerFlag::Expand | SizerFlag::All, DIALOG_PADDING);
-	content_sizer.add_sizer(&button_sizer, 0, SizerFlag::Expand | SizerFlag::Bottom | SizerFlag::Right, DIALOG_PADDING);
-	dialog.set_sizer_and_fit(content_sizer, true);
-	dialog.centre();
-	line_ctrl.set_focus();
-	line_ctrl.select_all();
-	if dialog.show_modal() == ID_OK { result.get() } else { None }
-}
-
-/// Resolves the entered `text` to a line number in `1..=max_lines`, or `None` when the text
-/// is not a valid line expression or resolves out of range.
-///
-/// A bare number is the line itself; a leading `+`/`-` moves that many lines forward or
-/// backward from `current_line`, so "+5" is five lines ahead and "-3" three lines back.
-fn resolve_line(text: &str, current_line: i32, max_lines: i32) -> Option<i32> {
-	let trimmed = text.trim();
-	if trimmed.is_empty() {
-		return None;
-	}
-	let (sign, digits) = match trimmed.as_bytes()[0] {
-		b'+' | b'-' => (trimmed.as_bytes()[0], &trimmed[1..]),
-		_ => (0, trimmed),
+	// TRANSLATORS: Announced when the entered line number is outside the document's range
+	let out_of_range = t("Line out of range.");
+	let prompt = NumberPrompt {
+		title: &title,
+		label: &label,
+		out_of_range: &out_of_range,
+		current: current_line,
+		min: 1,
+		max: max_lines,
 	};
-	let amount = digits.parse::<i64>().ok()?;
-	let current = i64::from(current_line);
-	let resolved = match sign {
-		b'+' => current.checked_add(amount)?,
-		b'-' => current.checked_sub(amount)?,
-		_ => amount,
-	};
-	if (1..=i64::from(max_lines)).contains(&resolved) { i32::try_from(resolved).ok() } else { None }
-}
-
-/// Swallows any keystroke that cannot be part of a line expression: digits, `+`/`-` (for
-/// relative jumps), and Enter (which submits). Letters and punctuation never reach the
-/// field, so an invalid entry can't be typed in the first place.
-///
-/// Only `CHAR` events are filtered, which fire for character insertion. Everything that
-/// is not a printable character passes through untouched, so every navigation, editing
-/// and shortcut key keeps working: control codes below space (Tab, Backspace, Enter,
-/// Escape), Delete, the special keys at [`WXK_START`] and above (arrows, Home/End, Page
-/// keys, Insert, F-keys, numpad Enter), and all Ctrl/Cmd shortcuts.
-fn restrict_to_number_input(ctrl: TextCtrl) {
-	ctrl.bind_internal(EventType::CHAR, move |event| {
-		let key = event.get_key_code().unwrap_or(0);
-		let allowed = event.control_down()
-			|| event.cmd_down()
-			|| key < i32::from(b' ')
-			|| key == WXK_DELETE
-			|| key >= WXK_START
-			|| (i32::from(b'0')..=i32::from(b'9')).contains(&key)
-			|| key == i32::from(b'+')
-			|| key == i32::from(b'-');
-		event.skip(allowed);
-	});
-}
-
-/// Validates the field and either confirms the dialog with the resolved line or, when the
-/// entry is invalid, announces the rejection and keeps the dialog open so the user can retry.
-fn submit_go_to_line(
-	dialog: Dialog,
-	line_ctrl: TextCtrl,
-	result: &Rc<Cell<Option<i32>>>,
-	live_region_label: StaticText,
-	current_line: i32,
-	max_lines: i32,
-) {
-	let Some(line) = resolve_line(&line_ctrl.get_value(), current_line, max_lines) else {
-		// TRANSLATORS: Announced when the entered line number is outside the document's range
-		live_region::announce(live_region_label, &t("Line out of range."));
-		line_ctrl.set_focus();
-		line_ctrl.select_all();
-		return;
-	};
-	result.set(Some(line));
-	dialog.end_modal(ID_OK);
-}
-
-#[cfg(test)]
-mod tests {
-	use super::resolve_line;
-
-	#[test]
-	fn absolute_lines_resolve_and_reject_out_of_range() {
-		assert_eq!(resolve_line("5", 10, 100), Some(5));
-		assert_eq!(resolve_line(" 42 ", 10, 100), Some(42));
-		assert_eq!(resolve_line("0", 10, 100), None);
-		assert_eq!(resolve_line("101", 10, 100), None);
-		assert_eq!(resolve_line("99999999999", 10, 100), None);
-	}
-
-	#[test]
-	fn relative_offsets_resolve_from_the_current_line() {
-		assert_eq!(resolve_line("+5", 10, 100), Some(15));
-		assert_eq!(resolve_line("-3", 10, 100), Some(7));
-		assert_eq!(resolve_line("+0", 10, 100), Some(10));
-		assert_eq!(resolve_line("-0", 10, 100), Some(10));
-	}
-
-	#[test]
-	fn relative_offsets_out_of_range_are_rejected() {
-		assert_eq!(resolve_line("-20", 10, 100), None);
-		assert_eq!(resolve_line("+100", 10, 100), None);
-	}
-
-	#[test]
-	fn garbage_is_rejected() {
-		assert_eq!(resolve_line("", 10, 100), None);
-		assert_eq!(resolve_line("   ", 10, 100), None);
-		assert_eq!(resolve_line("abc", 10, 100), None);
-		assert_eq!(resolve_line("5+3", 10, 100), None);
-		assert_eq!(resolve_line("+", 10, 100), None);
-		assert_eq!(resolve_line("-", 10, 100), None);
-	}
+	show_number_dialog(parent, &prompt, live_region_label)
 }

--- a/crates/paperback/src/ui/dialogs/go_to_line.rs
+++ b/crates/paperback/src/ui/dialogs/go_to_line.rs
@@ -28,6 +28,7 @@ pub fn show_go_to_line_dialog(
 	// not silently clamped, and (later) relative +n/-n input has no spinner equivalent.
 	let line_ctrl =
 		TextCtrl::builder(&dialog).with_value(&current.to_string()).with_style(TextCtrlStyle::ProcessEnter).build();
+	restrict_to_number_input(line_ctrl);
 	let result = Rc::new(Cell::new(None::<i32>));
 	// Enter in the field and the Go button both submit through the same validation.
 	let line_ctrl_for_enter = line_ctrl;
@@ -95,6 +96,30 @@ fn resolve_line(text: &str, current_line: i32, max_lines: i32) -> Option<i32> {
 		_ => amount,
 	};
 	if (1..=i64::from(max_lines)).contains(&resolved) { i32::try_from(resolved).ok() } else { None }
+}
+
+/// Swallows any keystroke that cannot be part of a line expression: digits, `+`/`-` (for
+/// relative jumps), and Enter (which submits). Letters and punctuation never reach the
+/// field, so an invalid entry can't be typed in the first place.
+///
+/// Only `CHAR` events are filtered, which fire for character insertion. Everything that
+/// is not a printable character passes through untouched, so every navigation, editing
+/// and shortcut key keeps working: control codes below space (Tab, Backspace, Enter,
+/// Escape), Delete, the special keys at [`WXK_START`] and above (arrows, Home/End, Page
+/// keys, Insert, F-keys, numpad Enter), and all Ctrl/Cmd shortcuts.
+fn restrict_to_number_input(ctrl: TextCtrl) {
+	ctrl.bind_internal(EventType::CHAR, move |event| {
+		let key = event.get_key_code().unwrap_or(0);
+		let allowed = event.control_down()
+			|| event.cmd_down()
+			|| key < i32::from(b' ')
+			|| key == WXK_DELETE
+			|| key >= WXK_START
+			|| (i32::from(b'0')..=i32::from(b'9')).contains(&key)
+			|| key == i32::from(b'+')
+			|| key == i32::from(b'-');
+		event.skip(allowed);
+	});
 }
 
 /// Validates the field and either confirms the dialog with the resolved line or, when the

--- a/crates/paperback/src/ui/dialogs/go_to_page.rs
+++ b/crates/paperback/src/ui/dialogs/go_to_page.rs
@@ -1,9 +1,7 @@
-use std::{cell::Cell, rc::Rc};
-
 use patois::t;
 use wxdragon::prelude::*;
 
-use super::DIALOG_PADDING;
+use super::go_to::{NumberPrompt, show_number_dialog};
 
 pub fn show_go_to_page_dialog(
 	parent: &Frame,
@@ -13,170 +11,22 @@ pub fn show_go_to_page_dialog(
 ) -> Option<i32> {
 	let max_page = max_page.max(1);
 	// TRANSLATORS: Title of the Go to page dialog
-	let dialog_title = t("Go to page");
-	let dialog = Dialog::builder(parent, &dialog_title).build();
-	// TRANSLATORS: Label/prompt template for the page selection dialog. The %d placeholders represent current_page and max_pages respectively.
-	let label_template = t("Go to page (%d/%d):");
-	let label_text = label_template.replacen("%d", &current_page.clamp(1, max_page).to_string(), 1).replacen(
+	let title = t("Go to page");
+	// TRANSLATORS: Label/prompt template for the page selection dialog. The %d placeholders represent current_page and max_page respectively.
+	let label = t("Go to page (%d/%d):").replacen("%d", &current_page.clamp(1, max_page).to_string(), 1).replacen(
 		"%d",
 		&max_page.to_string(),
 		1,
 	);
-	let label = StaticText::builder(&dialog).with_label(&label_text).build();
-	let current = current_page.clamp(1, max_page);
-	// A plain text field rather than a spin control: out-of-range pages must be rejected,
-	// not silently clamped, and (later) relative +n/-n input has no spinner equivalent.
-	let page_ctrl =
-		TextCtrl::builder(&dialog).with_value(&current.to_string()).with_style(TextCtrlStyle::ProcessEnter).build();
-	restrict_to_number_input(page_ctrl);
-	let result = Rc::new(Cell::new(None::<i32>));
-	// Enter in the field and the Go button both submit through the same validation.
-	let page_ctrl_for_enter = page_ctrl;
-	let result_for_enter = Rc::clone(&result);
-	let dialog_for_enter = dialog;
-	page_ctrl_for_enter.bind_internal(EventType::TEXT_ENTER, move |event| {
-		event.skip(false);
-		submit_go_to_page(
-			dialog_for_enter,
-			page_ctrl_for_enter,
-			&result_for_enter,
-			live_region_label,
-			current_page,
-			max_page,
-		);
-	});
-	// TRANSLATORS: Label for the button that jumps to the entered page
-	let ok_button = Button::builder(&dialog).with_label(&t("Go")).build();
-	// TRANSLATORS: Label for the button that closes the dialog without navigating
-	let cancel_button = Button::builder(&dialog).with_id(ID_CANCEL).with_label(&t("Cancel")).build();
-	dialog.set_escape_id(ID_CANCEL);
-	ok_button.set_default();
-	let page_ctrl_for_ok = page_ctrl;
-	let result_for_ok = Rc::clone(&result);
-	let dialog_for_ok = dialog;
-	ok_button.on_click(move |_| {
-		submit_go_to_page(dialog_for_ok, page_ctrl_for_ok, &result_for_ok, live_region_label, current_page, max_page);
-	});
-	let page_sizer = BoxSizer::builder(Orientation::Horizontal).build();
-	page_sizer.add(&label, 0, SizerFlag::AlignCenterVertical | SizerFlag::Right, 5);
-	page_sizer.add(&page_ctrl, 1, SizerFlag::Expand, 0);
-	let button_sizer = BoxSizer::builder(Orientation::Horizontal).build();
-	button_sizer.add_stretch_spacer(1);
-	button_sizer.add(&ok_button, 0, SizerFlag::Right, DIALOG_PADDING);
-	button_sizer.add(&cancel_button, 0, SizerFlag::Right, DIALOG_PADDING);
-	let content_sizer = BoxSizer::builder(Orientation::Vertical).build();
-	content_sizer.add_sizer(&page_sizer, 0, SizerFlag::Expand | SizerFlag::All, DIALOG_PADDING);
-	content_sizer.add_sizer(&button_sizer, 0, SizerFlag::Expand | SizerFlag::Bottom | SizerFlag::Right, DIALOG_PADDING);
-	dialog.set_sizer_and_fit(content_sizer, true);
-	dialog.centre();
-	page_ctrl.set_focus();
-	page_ctrl.select_all();
-	if dialog.show_modal() == ID_OK { result.get() } else { None }
-}
-
-/// Resolves the entered `text` to a page number in `1..=max_page`, or `None` when the text
-/// is not a valid page expression or resolves out of range.
-///
-/// A bare number is the page itself; a leading `+`/`-` moves that many pages forward or
-/// backward from `current_page`, so "+5" is five pages ahead and "-3" three pages back.
-fn resolve_page(text: &str, current_page: i32, max_page: i32) -> Option<i32> {
-	let trimmed = text.trim();
-	if trimmed.is_empty() {
-		return None;
-	}
-	let (sign, digits) = match trimmed.as_bytes()[0] {
-		b'+' | b'-' => (trimmed.as_bytes()[0], &trimmed[1..]),
-		_ => (0, trimmed),
+	// TRANSLATORS: Announced when the entered page number is outside the document's range
+	let out_of_range = t("Page out of range.");
+	let prompt = NumberPrompt {
+		title: &title,
+		label: &label,
+		out_of_range: &out_of_range,
+		current: current_page,
+		min: 1,
+		max: max_page,
 	};
-	let amount = digits.parse::<i64>().ok()?;
-	let current = i64::from(current_page);
-	let resolved = match sign {
-		b'+' => current.checked_add(amount)?,
-		b'-' => current.checked_sub(amount)?,
-		_ => amount,
-	};
-	if (1..=i64::from(max_page)).contains(&resolved) { i32::try_from(resolved).ok() } else { None }
-}
-
-/// Swallows any keystroke that cannot be part of a page expression: digits, `+`/`-` (for
-/// relative jumps), and Enter (which submits). Letters and punctuation never reach the
-/// field, so an invalid entry can't be typed in the first place.
-///
-/// Only `CHAR` events are filtered, which fire for character insertion. Everything that
-/// is not a printable character passes through untouched, so every navigation, editing
-/// and shortcut key keeps working: control codes below space (Tab, Backspace, Enter,
-/// Escape), Delete, the special keys at [`WXK_START`] and above (arrows, Home/End, Page
-/// keys, Insert, F-keys, numpad Enter), and all Ctrl/Cmd shortcuts.
-fn restrict_to_number_input(ctrl: TextCtrl) {
-	ctrl.bind_internal(EventType::CHAR, move |event| {
-		let key = event.get_key_code().unwrap_or(0);
-		let allowed = event.control_down()
-			|| event.cmd_down()
-			|| key < i32::from(b' ')
-			|| key == WXK_DELETE
-			|| key >= WXK_START
-			|| (i32::from(b'0')..=i32::from(b'9')).contains(&key)
-			|| key == i32::from(b'+')
-			|| key == i32::from(b'-');
-		event.skip(allowed);
-	});
-}
-
-/// Validates the field and either confirms the dialog with the resolved page or, when the
-/// entry is invalid, announces the rejection and keeps the dialog open so the user can retry.
-fn submit_go_to_page(
-	dialog: Dialog,
-	page_ctrl: TextCtrl,
-	result: &Rc<Cell<Option<i32>>>,
-	live_region_label: StaticText,
-	current_page: i32,
-	max_page: i32,
-) {
-	let Some(page) = resolve_page(&page_ctrl.get_value(), current_page, max_page) else {
-		// TRANSLATORS: Announced when the entered page number is outside the document's range
-		live_region::announce(live_region_label, &t("Page out of range."));
-		page_ctrl.set_focus();
-		page_ctrl.select_all();
-		return;
-	};
-	result.set(Some(page));
-	dialog.end_modal(ID_OK);
-}
-
-#[cfg(test)]
-mod tests {
-	use super::resolve_page;
-
-	#[test]
-	fn absolute_pages_resolve_and_reject_out_of_range() {
-		assert_eq!(resolve_page("5", 10, 100), Some(5));
-		assert_eq!(resolve_page(" 42 ", 10, 100), Some(42));
-		assert_eq!(resolve_page("0", 10, 100), None);
-		assert_eq!(resolve_page("101", 10, 100), None);
-		assert_eq!(resolve_page("99999999999", 10, 100), None);
-	}
-
-	#[test]
-	fn relative_offsets_resolve_from_the_current_page() {
-		assert_eq!(resolve_page("+5", 10, 100), Some(15));
-		assert_eq!(resolve_page("-3", 10, 100), Some(7));
-		assert_eq!(resolve_page("+0", 10, 100), Some(10));
-		assert_eq!(resolve_page("-0", 10, 100), Some(10));
-	}
-
-	#[test]
-	fn relative_offsets_out_of_range_are_rejected() {
-		assert_eq!(resolve_page("-20", 10, 100), None);
-		assert_eq!(resolve_page("+100", 10, 100), None);
-	}
-
-	#[test]
-	fn garbage_is_rejected() {
-		assert_eq!(resolve_page("", 10, 100), None);
-		assert_eq!(resolve_page("   ", 10, 100), None);
-		assert_eq!(resolve_page("abc", 10, 100), None);
-		assert_eq!(resolve_page("5+3", 10, 100), None);
-		assert_eq!(resolve_page("+", 10, 100), None);
-		assert_eq!(resolve_page("-", 10, 100), None);
-	}
+	show_number_dialog(parent, &prompt, live_region_label)
 }

--- a/crates/paperback/src/ui/main_window.rs
+++ b/crates/paperback/src/ui/main_window.rs
@@ -661,7 +661,7 @@ impl MainWindow {
 					}
 				}
 				menu_ids::GO_TO_LINE => {
-					menu_go::handle_go_to_line(&frame_copy, &dm, &config);
+					menu_go::handle_go_to_line(&frame_copy, &dm, &config, live_region_label);
 				}
 				menu_ids::GO_TO_PAGE => {
 					menu_go::handle_go_to_page(&frame_copy, &dm, &config, live_region_label);

--- a/crates/paperback/src/ui/main_window/menu_go.rs
+++ b/crates/paperback/src/ui/main_window/menu_go.rs
@@ -33,7 +33,7 @@ pub(super) fn handle_go_to_line(
 		drop(dm_guard);
 		(current_line, max_lines)
 	};
-	if let Some(line) = dialogs::show_go_to_line_dialog(frame, current_line, max_lines) {
+	if let Some(line) = dialogs::show_go_to_line_dialog(frame, current_line, max_lines, live_region_label) {
 		let (message, update) = {
 			let mut dm_guard = dm.lock().unwrap();
 			let (message, update) = {

--- a/crates/paperback/src/ui/main_window/menu_go.rs
+++ b/crates/paperback/src/ui/main_window/menu_go.rs
@@ -10,7 +10,12 @@ use wxdragon::prelude::*;
 
 use super::{DocumentManager, dialogs, navigation};
 
-pub(super) fn handle_go_to_line(frame: &Frame, dm: &Rc<Mutex<DocumentManager>>, config: &Rc<Mutex<ConfigManager>>) {
+pub(super) fn handle_go_to_line(
+	frame: &Frame,
+	dm: &Rc<Mutex<DocumentManager>>,
+	config: &Rc<Mutex<ConfigManager>>,
+	live_region_label: StaticText,
+) {
 	let (current_line, max_lines) = {
 		let mut dm_guard = dm.lock().unwrap();
 		let (current_line, max_lines) = {
@@ -29,19 +34,41 @@ pub(super) fn handle_go_to_line(frame: &Frame, dm: &Rc<Mutex<DocumentManager>>, 
 		(current_line, max_lines)
 	};
 	if let Some(line) = dialogs::show_go_to_line_dialog(frame, current_line, max_lines) {
-		let update = {
+		let (message, update) = {
 			let mut dm_guard = dm.lock().unwrap();
-			let update = {
+			let (message, update) = {
 				let Some(tab) = dm_guard.active_tab_mut() else {
 					return;
 				};
 				let target_pos = tab.session.position_from_line(i64::from(line));
-				navigation::move_to_offset_and_record_history(tab, target_pos)
+				// Capture the line's announcement while the document lock is held; it is
+				// spoken after focus has returned to the book, cutting off the focus chain.
+				let content = tab.session.get_line_text(target_pos);
+				let message = line_announcement(line, &content);
+				let update = navigation::move_to_offset_and_record_history(tab, target_pos);
+				(message, update)
 			};
 			drop(dm_guard);
-			update
+			(message, update)
 		};
 		navigation::persist_navigation_history(config, Some(&update));
+		navigation::announce_after_delay(frame, live_region_label, message);
+	}
+}
+
+/// The announcement for landing on line `line`, whose text is `content` (possibly blank).
+///
+/// Unlike Go to Page, the line number is not prefixed to the text: page numbers carry
+/// external meaning and there are few of them, but line numbers can be huge and say
+/// nothing on their own, so the user hears the line's text, as Find does. A blank line
+/// falls back to the bare line number so the jump is still confirmed.
+fn line_announcement(line: i32, content: &str) -> String {
+	let content = content.trim();
+	if content.is_empty() {
+		// TRANSLATORS: Announced when landing on a blank line; %d is the line number
+		t("Line %d").replacen("%d", &line.to_string(), 1)
+	} else {
+		content.to_string()
 	}
 }
 


### PR DESCRIPTION
# Go to line: interrupt the focus chain, reject out-of-range lines, and accept +n/-n

Four improvements to the Go to line dialog (Ctrl+G, or Go → "Go to line"), parallel to the Go to page PR (#766). Four commits, one per change.

## 1. Interrupt the focus-chain announcement

Closing Go to Line made NVDA announce the whole focus chain ("Paperback, tab control, edit read only multi line") before the line was spoken — the same problem Find and Go to Page had. The shared delay-announce helper (`announce_after_delay` in `navigation.rs`, the same one #766 moves there) raises the line's text ~30ms after the dialog closes, cutting off all but a sliver of the chain.

**A deliberate difference from Go to Page:** the line number is *not* prefixed to the announcement ("Line 42: …"). Page numbers carry external meaning and there are few of them; line numbers can be huge and say nothing on their own, so the user just hears the line's text, as Find does. A blank line falls back to the bare "Line 42" so the jump is still confirmed.

## 2. Reject out-of-range lines

Typing a line number beyond the last line was silently clamped by the spin control, so a huge number jumped to the last line — or, depending on how the native control parsed the out-of-range text, to the first. The dialog now validates on submit: out-of-range or unparseable input announces "Line out of range." and keeps the dialog open, mirroring Find's "Not found." and Go to Page's "Page out of range." The label now shows the current and total line counts, "Go to line (123/456):", matching Go to Page.

## 3. Accept +n and -n

`+n` advances n lines and `-n` moves back n lines from the current line, so skimming no longer requires doing the arithmetic. A bare number still means the line itself. Relative results are held to the same out-of-range check, so `+5` on line 298 of a 300-line document says "Line out of range." rather than clamping. Unit tests cover the parser.

## 4. Block non-numeric keystrokes

Letters and punctuation used to be typeable, only to be rejected on submit. A `CHAR`-event filter now swallows anything that can't be part of a line expression — digits, `+`/`-`, and Enter — so an invalid entry can't be typed by hand. Only character-insertion events are filtered, so everything else keeps working: control codes (Tab, Backspace, Enter, Escape), Delete, the special keys at `WXK_START` and above (arrows, Home/End, Page keys, Insert, F-keys, numpad Enter), and all Ctrl/Cmd shortcuts.

## Notes / tradeoffs

- `announce_after_delay` is added to `navigation.rs` here exactly as in #766; both PRs carry the identical addition, which git auto-merges when the first one lands.
- The dialog switched from a `SpinCtrl` to a plain text field (the native control rendered as a number-only edit anyway, so nothing visually changes) — that's what makes rejection, relative input, and the keystroke filter possible.
- New translatable strings: "Go to line (%d/%d):", "Line out of range.", "Line %d" (removed the old "&Line number:"). Pot regeneration left to the usual maintenance pass.
- Only NVDA is verified, same caveat as the other PRs.

## Testing

Tested with NVDA on Windows 11: Ctrl+G → line → Enter reads the line's text with no focus chain after it; out-of-range and garbage input speak "Line out of range." and stay in the dialog; `+5`/`-3` land where expected; letters can't be typed while Tab, arrows, Backspace and shortcuts all still work; ESC/Cancel unchanged; the four parser unit tests pass.
