### PR TITLE
Go to percent: land on the entry, cut the focus chain, reject bad percentages, and accept +n/-n

### DIFF
--- a/crates/paperback/src/ui/dialogs/go_to_percent.rs
+++ b/crates/paperback/src/ui/dialogs/go_to_percent.rs
@@ -74,6 +74,9 @@ pub fn show_go_to_percent_dialog(parent: &Frame, current_percent: i32) -> Option
 	add_ok_cancel_footer(main_sizer, ok_button, cancel_button);
 	dialog.set_sizer_and_fit(main_sizer, true);
 	dialog.centre();
-	percent_slider.set_focus();
+	// Focus the numeric entry so a screen-reader user can type a percentage directly.
+	// Tab order is untouched (it follows widget creation order), so the slider remains the
+	// first tab stop, matching the order the controls appear on screen.
+	input_ctrl.set_focus();
 	if dialog.show_modal() == ID_OK { Some(input_ctrl.value().clamp(0, 100)) } else { None }
 }

--- a/crates/paperback/src/ui/dialogs/go_to_percent.rs
+++ b/crates/paperback/src/ui/dialogs/go_to_percent.rs
@@ -1,9 +1,9 @@
-use std::{cell::Cell, rc::Rc};
+use std::rc::Rc;
 
 use patois::t;
 use wxdragon::prelude::*;
 
-use super::DIALOG_PADDING;
+use super::go_to::{NumberEntry, add_go_cancel_footer};
 
 pub fn show_go_to_percent_dialog(parent: &Frame, current_percent: i32, live_region_label: StaticText) -> Option<i32> {
 	let current_percent = current_percent.clamp(0, 100);
@@ -18,70 +18,40 @@ pub fn show_go_to_percent_dialog(parent: &Frame, current_percent: i32, live_regi
 	let slider_label = StaticText::builder(&dialog).with_label(&t("&Percent")).build();
 	let percent_slider =
 		Slider::builder(&dialog).with_value(current_percent).with_min_value(0).with_max_value(100).build();
-	// A plain text field rather than a spin control: out-of-range percentages must be
-	// rejected, not silently clamped, and (later) relative +n/-n input has no spinner
-	// equivalent.
-	let input_ctrl = TextCtrl::builder(&dialog)
-		.with_value(&current_percent.to_string())
-		.with_style(TextCtrlStyle::ProcessEnter)
-		.build();
-	restrict_to_number_input(input_ctrl);
-	let result = Rc::new(Cell::new(None::<i32>));
+	let entry = Rc::new(NumberEntry::new(dialog, current_percent, 0, 100));
 	// Keep the slider and the field in step. Dragging the slider rewrites the field
 	// (`change_value` fires no event, so there is no loop); typing moves the slider to the
 	// number that was entered.
-	let input_for_slider = input_ctrl;
+	let input_for_slider = entry.ctrl;
 	percent_slider.on_slider(move |event| {
 		input_for_slider.change_value(&event.get_value().to_string());
 	});
+	let entry_for_text = Rc::clone(&entry);
 	let slider_for_input = percent_slider;
-	input_ctrl.bind_internal(EventType::TEXT, move |_event| {
-		if let Some(resolved) = resolve_percent(&input_ctrl.get_value(), current_percent) {
+	entry.ctrl.bind_internal(EventType::TEXT, move |_event| {
+		if let Some(resolved) = entry_for_text.resolve() {
 			slider_for_input.set_value(resolved);
 		}
 	});
 	// Enter in the field, Enter on the slider, and the Go button all submit through the
 	// same validation.
-	let input_for_enter = input_ctrl;
-	let result_for_enter = Rc::clone(&result);
-	let dialog_for_enter = dialog;
-	input_for_enter.bind_internal(EventType::TEXT_ENTER, move |event| {
-		event.skip(false);
-		submit_go_to_percent(dialog_for_enter, input_for_enter, &result_for_enter, live_region_label, current_percent);
-	});
-	// TRANSLATORS: Label for the button that jumps to the entered percentage
-	let ok_button = Button::builder(&dialog).with_label(&t("Go")).build();
-	// TRANSLATORS: Label for the button that closes the dialog without navigating
-	let cancel_button = Button::builder(&dialog).with_id(ID_CANCEL).with_label(&t("Cancel")).build();
-	dialog.set_escape_id(ID_CANCEL);
-	ok_button.set_default();
-	let input_for_ok = input_ctrl;
-	let result_for_ok = Rc::clone(&result);
-	let dialog_for_ok = dialog;
-	ok_button.on_click(move |_| {
-		submit_go_to_percent(dialog_for_ok, input_for_ok, &result_for_ok, live_region_label, current_percent);
-	});
+	// TRANSLATORS: Announced when the entered percentage is outside the 0 to 100 range
+	let out_of_range = t("Percent out of range.");
+	let entry_for_submit = Rc::clone(&entry);
+	let submit = Rc::new(move || entry_for_submit.submit(dialog, live_region_label, &out_of_range));
 	// Keyboard control of the slider: arrows/Page/Home/End move it, Enter submits.
-	let input_for_slider_enter = input_ctrl;
-	let result_for_slider_enter = Rc::clone(&result);
-	let dialog_for_slider_enter = dialog;
+	let submit_for_slider = Rc::clone(&submit);
 	percent_slider.bind_internal(EventType::KEY_DOWN, move |event| {
 		let key = event.get_key_code().unwrap_or(0);
 		if key == WXK_RETURN || key == WXK_NUMPAD_ENTER {
 			event.skip(false);
-			submit_go_to_percent(
-				dialog_for_slider_enter,
-				input_for_slider_enter,
-				&result_for_slider_enter,
-				live_region_label,
-				current_percent,
-			);
+			submit_for_slider();
 			return;
 		}
 		event.skip(true);
 	});
 	let percent_slider_for_keys = percent_slider;
-	let input_for_char = input_ctrl;
+	let input_for_char = entry.ctrl;
 	percent_slider.bind_internal(EventType::CHAR, move |event| {
 		let key = event.get_key_code().unwrap_or(0);
 		let current = percent_slider_for_keys.value();
@@ -108,124 +78,13 @@ pub fn show_go_to_percent_dialog(parent: &Frame, current_percent: i32, live_regi
 	content_sizer.add(&slider_label, 0, SizerFlag::Left | SizerFlag::Top, 5);
 	content_sizer.add(&percent_slider, 0, SizerFlag::Expand | SizerFlag::Bottom, 5);
 	content_sizer.add(&label, 0, SizerFlag::Left, 5);
-	content_sizer.add(&input_ctrl, 0, SizerFlag::Expand | SizerFlag::Bottom, 5);
-	let button_sizer = BoxSizer::builder(Orientation::Horizontal).build();
-	button_sizer.add_stretch_spacer(1);
-	button_sizer.add(&ok_button, 0, SizerFlag::Right, DIALOG_PADDING);
-	button_sizer.add(&cancel_button, 0, SizerFlag::Right, DIALOG_PADDING);
-	content_sizer.add_sizer(&button_sizer, 0, SizerFlag::Expand | SizerFlag::Bottom | SizerFlag::Right, DIALOG_PADDING);
+	content_sizer.add(&entry.ctrl, 0, SizerFlag::Expand | SizerFlag::Bottom, 5);
+	add_go_cancel_footer(dialog, content_sizer, entry.ctrl, move || submit());
 	dialog.set_sizer_and_fit(content_sizer, true);
 	dialog.centre();
 	// Focus the numeric entry so a screen-reader user can type a percentage directly.
 	// Tab order is untouched (it follows widget creation order), so the slider remains the
 	// first tab stop, matching the order the controls appear on screen.
-	input_ctrl.set_focus();
-	input_ctrl.select_all();
-	if dialog.show_modal() == ID_OK { result.get() } else { None }
-}
-
-/// Resolves the entered `text` to a percentage in `0..=100`, or `None` when the text is
-/// not a valid percentage expression or resolves out of range.
-///
-/// A bare number is the percentage itself; a leading `+`/`-` moves that many percentage
-/// points forward or backward from `current_percent`, so "+10" is ten points ahead and
-/// "-5" five points back.
-fn resolve_percent(text: &str, current_percent: i32) -> Option<i32> {
-	let trimmed = text.trim();
-	if trimmed.is_empty() {
-		return None;
-	}
-	let (sign, digits) = match trimmed.as_bytes()[0] {
-		b'+' | b'-' => (trimmed.as_bytes()[0], &trimmed[1..]),
-		_ => (0, trimmed),
-	};
-	let amount = digits.parse::<i64>().ok()?;
-	let current = i64::from(current_percent);
-	let resolved = match sign {
-		b'+' => current.checked_add(amount)?,
-		b'-' => current.checked_sub(amount)?,
-		_ => amount,
-	};
-	if (0..=100).contains(&resolved) { i32::try_from(resolved).ok() } else { None }
-}
-
-/// Swallows any keystroke that cannot be part of a percentage expression: digits, `+`/`-`
-/// (for relative jumps), and Enter (which submits). Letters and punctuation never reach
-/// the field, so an invalid entry can't be typed in the first place.
-///
-/// Only `CHAR` events are filtered, which fire for character insertion. Everything that
-/// is not a printable character passes through untouched, so every navigation, editing
-/// and shortcut key keeps working: control codes below space (Tab, Backspace, Enter,
-/// Escape), Delete, the special keys at [`WXK_START`] and above (arrows, Home/End, Page
-/// keys, Insert, F-keys, numpad Enter), and all Ctrl/Cmd shortcuts.
-fn restrict_to_number_input(ctrl: TextCtrl) {
-	ctrl.bind_internal(EventType::CHAR, move |event| {
-		let key = event.get_key_code().unwrap_or(0);
-		let allowed = event.control_down()
-			|| event.cmd_down()
-			|| key < i32::from(b' ')
-			|| key == WXK_DELETE
-			|| key >= WXK_START
-			|| (i32::from(b'0')..=i32::from(b'9')).contains(&key)
-			|| key == i32::from(b'+')
-			|| key == i32::from(b'-');
-		event.skip(allowed);
-	});
-}
-
-/// Validates the field and either confirms the dialog with the resolved percentage or, when
-/// the entry is invalid, announces the rejection and keeps the dialog open so the user can retry.
-fn submit_go_to_percent(
-	dialog: Dialog,
-	input_ctrl: TextCtrl,
-	result: &Rc<Cell<Option<i32>>>,
-	live_region_label: StaticText,
-	current_percent: i32,
-) {
-	let Some(percent) = resolve_percent(&input_ctrl.get_value(), current_percent) else {
-		// TRANSLATORS: Announced when the entered percentage is outside the 0 to 100 range
-		live_region::announce(live_region_label, &t("Percent out of range."));
-		input_ctrl.set_focus();
-		input_ctrl.select_all();
-		return;
-	};
-	result.set(Some(percent));
-	dialog.end_modal(ID_OK);
-}
-
-#[cfg(test)]
-mod tests {
-	use super::resolve_percent;
-
-	#[test]
-	fn absolute_percentages_resolve_and_reject_out_of_range() {
-		assert_eq!(resolve_percent("45", 40), Some(45));
-		assert_eq!(resolve_percent(" 0 ", 40), Some(0));
-		assert_eq!(resolve_percent("100", 40), Some(100));
-		assert_eq!(resolve_percent("101", 40), None);
-		assert_eq!(resolve_percent("99999999999", 40), None);
-	}
-
-	#[test]
-	fn relative_offsets_resolve_from_the_current_percentage() {
-		assert_eq!(resolve_percent("+10", 45), Some(55));
-		assert_eq!(resolve_percent("-5", 45), Some(40));
-		assert_eq!(resolve_percent("+0", 45), Some(45));
-	}
-
-	#[test]
-	fn relative_offsets_out_of_range_are_rejected() {
-		assert_eq!(resolve_percent("+60", 45), None);
-		assert_eq!(resolve_percent("-60", 45), None);
-	}
-
-	#[test]
-	fn garbage_is_rejected() {
-		assert_eq!(resolve_percent("", 45), None);
-		assert_eq!(resolve_percent("   ", 45), None);
-		assert_eq!(resolve_percent("abc", 45), None);
-		assert_eq!(resolve_percent("4+5", 45), None);
-		assert_eq!(resolve_percent("+", 45), None);
-		assert_eq!(resolve_percent("-", 45), None);
-	}
+	entry.focus();
+	if dialog.show_modal() == ID_OK { entry.result() } else { None }
 }

--- a/crates/paperback/src/ui/dialogs/go_to_percent.rs
+++ b/crates/paperback/src/ui/dialogs/go_to_percent.rs
@@ -1,45 +1,85 @@
+use std::{cell::Cell, rc::Rc};
+
 use patois::t;
 use wxdragon::prelude::*;
 
-use super::{DIALOG_PADDING, add_ok_cancel_footer, bind_enter_confirms, build_ok_cancel_buttons};
+use super::DIALOG_PADDING;
 
-pub fn show_go_to_percent_dialog(parent: &Frame, current_percent: i32) -> Option<i32> {
+pub fn show_go_to_percent_dialog(parent: &Frame, current_percent: i32, live_region_label: StaticText) -> Option<i32> {
+	let current_percent = current_percent.clamp(0, 100);
 	// TRANSLATORS: Title of the Go to Percent dialog
 	let dialog_title = t("Go to Percent");
 	let dialog = Dialog::builder(parent, &dialog_title).build();
-	let current_percent = current_percent.clamp(0, 100);
+	// TRANSLATORS: Label/prompt template for the percentage selection dialog. The %d placeholders represent current_percent and 100 respectively.
+	let label_template = t("Go to percent (%d/%d):");
+	let label_text = label_template.replacen("%d", &current_percent.to_string(), 1).replacen("%d", "100", 1);
+	let label = StaticText::builder(&dialog).with_label(&label_text).build();
 	// TRANSLATORS: Label for the percentage selection slider
 	let slider_label = StaticText::builder(&dialog).with_label(&t("&Percent")).build();
 	let percent_slider =
 		Slider::builder(&dialog).with_value(current_percent).with_min_value(0).with_max_value(100).build();
-	// TRANSLATORS: Label for the numeric percentage entry field
-	let input_label = StaticText::builder(&dialog).with_label(&t("P&ercent:")).build();
-	let input_ctrl = SpinCtrl::builder(&dialog)
-		.with_range(0, 100)
-		.with_style(SpinCtrlStyle::Default | SpinCtrlStyle::ProcessEnter)
+	// A plain text field rather than a spin control: out-of-range percentages must be
+	// rejected, not silently clamped, and (later) relative +n/-n input has no spinner
+	// equivalent.
+	let input_ctrl = TextCtrl::builder(&dialog)
+		.with_value(&current_percent.to_string())
+		.with_style(TextCtrlStyle::ProcessEnter)
 		.build();
-	input_ctrl.set_value(current_percent);
-	let input_ctrl_for_slider = input_ctrl;
+	let result = Rc::new(Cell::new(None::<i32>));
+	// Keep the slider and the field in step. Dragging the slider rewrites the field
+	// (`change_value` fires no event, so there is no loop); typing moves the slider to the
+	// number that was entered.
+	let input_for_slider = input_ctrl;
 	percent_slider.on_slider(move |event| {
-		input_ctrl_for_slider.set_value(event.get_value());
+		input_for_slider.change_value(&event.get_value().to_string());
 	});
-	let percent_slider_for_spin = percent_slider;
-	input_ctrl.on_value_changed(move |event| {
-		percent_slider_for_spin.set_value(event.get_value());
+	let slider_for_input = percent_slider;
+	input_ctrl.bind_internal(EventType::TEXT, move |_event| {
+		if let Ok(value) = input_ctrl.get_value().trim().parse::<i32>() {
+			slider_for_input.set_value(value.clamp(0, 100));
+		}
 	});
-	bind_enter_confirms(&dialog, input_ctrl);
+	// Enter in the field, Enter on the slider, and the Go button all submit through the
+	// same validation.
+	let input_for_enter = input_ctrl;
+	let result_for_enter = Rc::clone(&result);
+	let dialog_for_enter = dialog;
+	input_for_enter.bind_internal(EventType::TEXT_ENTER, move |event| {
+		event.skip(false);
+		submit_go_to_percent(dialog_for_enter, input_for_enter, &result_for_enter, live_region_label);
+	});
+	// TRANSLATORS: Label for the button that jumps to the entered percentage
+	let ok_button = Button::builder(&dialog).with_label(&t("Go")).build();
+	// TRANSLATORS: Label for the button that closes the dialog without navigating
+	let cancel_button = Button::builder(&dialog).with_id(ID_CANCEL).with_label(&t("Cancel")).build();
+	dialog.set_escape_id(ID_CANCEL);
+	ok_button.set_default();
+	let input_for_ok = input_ctrl;
+	let result_for_ok = Rc::clone(&result);
+	let dialog_for_ok = dialog;
+	ok_button.on_click(move |_| {
+		submit_go_to_percent(dialog_for_ok, input_for_ok, &result_for_ok, live_region_label);
+	});
+	// Keyboard control of the slider: arrows/Page/Home/End move it, Enter submits.
+	let input_for_slider_enter = input_ctrl;
+	let result_for_slider_enter = Rc::clone(&result);
 	let dialog_for_slider_enter = dialog;
 	percent_slider.bind_internal(EventType::KEY_DOWN, move |event| {
 		let key = event.get_key_code().unwrap_or(0);
 		if key == WXK_RETURN || key == WXK_NUMPAD_ENTER {
 			event.skip(false);
-			dialog_for_slider_enter.end_modal(ID_OK);
+			submit_go_to_percent(
+				dialog_for_slider_enter,
+				input_for_slider_enter,
+				&result_for_slider_enter,
+				live_region_label,
+			);
 			return;
 		}
 		event.skip(true);
 	});
 	let percent_slider_for_keys = percent_slider;
-	let input_ctrl_for_keys = input_ctrl;
+	let input_for_char = input_ctrl;
 	percent_slider.bind_internal(EventType::CHAR, move |event| {
 		let key = event.get_key_code().unwrap_or(0);
 		let current = percent_slider_for_keys.value();
@@ -56,7 +96,7 @@ pub fn show_go_to_percent_dialog(parent: &Frame, current_percent: i32) -> Option
 		};
 		if let Some(val) = new_value {
 			percent_slider_for_keys.set_value(val);
-			input_ctrl_for_keys.set_value(val);
+			input_for_char.change_value(&val.to_string());
 			event.skip(false);
 		} else {
 			event.skip(true);
@@ -65,18 +105,45 @@ pub fn show_go_to_percent_dialog(parent: &Frame, current_percent: i32) -> Option
 	let content_sizer = BoxSizer::builder(Orientation::Vertical).build();
 	content_sizer.add(&slider_label, 0, SizerFlag::Left | SizerFlag::Top, 5);
 	content_sizer.add(&percent_slider, 0, SizerFlag::Expand | SizerFlag::Bottom, 5);
-	content_sizer.add(&input_label, 0, SizerFlag::Left, 5);
-	content_sizer.add(&input_ctrl, 0, SizerFlag::Expand, 0);
-	// TRANSLATORS: Label for the button that jumps to the entered position (a line, page, or percentage, depending on the dialog)
-	let (ok_button, cancel_button) = build_ok_cancel_buttons(&dialog, &t("Go"));
-	let main_sizer = BoxSizer::builder(Orientation::Vertical).build();
-	main_sizer.add_sizer(&content_sizer, 0, SizerFlag::Expand | SizerFlag::All, DIALOG_PADDING);
-	add_ok_cancel_footer(main_sizer, ok_button, cancel_button);
-	dialog.set_sizer_and_fit(main_sizer, true);
+	content_sizer.add(&label, 0, SizerFlag::Left, 5);
+	content_sizer.add(&input_ctrl, 0, SizerFlag::Expand | SizerFlag::Bottom, 5);
+	let button_sizer = BoxSizer::builder(Orientation::Horizontal).build();
+	button_sizer.add_stretch_spacer(1);
+	button_sizer.add(&ok_button, 0, SizerFlag::Right, DIALOG_PADDING);
+	button_sizer.add(&cancel_button, 0, SizerFlag::Right, DIALOG_PADDING);
+	content_sizer.add_sizer(&button_sizer, 0, SizerFlag::Expand | SizerFlag::Bottom | SizerFlag::Right, DIALOG_PADDING);
+	dialog.set_sizer_and_fit(content_sizer, true);
 	dialog.centre();
 	// Focus the numeric entry so a screen-reader user can type a percentage directly.
 	// Tab order is untouched (it follows widget creation order), so the slider remains the
 	// first tab stop, matching the order the controls appear on screen.
 	input_ctrl.set_focus();
-	if dialog.show_modal() == ID_OK { Some(input_ctrl.value().clamp(0, 100)) } else { None }
+	input_ctrl.select_all();
+	if dialog.show_modal() == ID_OK { result.get() } else { None }
+}
+
+/// Resolves the entered `text` to a percentage in `0..=100`, or `None` when the text is
+/// not a bare percentage or the value is out of range.
+fn resolve_percent(text: &str) -> Option<i32> {
+	let percent = text.trim().parse::<i64>().ok()?;
+	if (0..=100).contains(&percent) { i32::try_from(percent).ok() } else { None }
+}
+
+/// Validates the field and either confirms the dialog with the resolved percentage or, when
+/// the entry is invalid, announces the rejection and keeps the dialog open so the user can retry.
+fn submit_go_to_percent(
+	dialog: Dialog,
+	input_ctrl: TextCtrl,
+	result: &Rc<Cell<Option<i32>>>,
+	live_region_label: StaticText,
+) {
+	let Some(percent) = resolve_percent(&input_ctrl.get_value()) else {
+		// TRANSLATORS: Announced when the entered percentage is outside the 0 to 100 range
+		live_region::announce(live_region_label, &t("Percent out of range."));
+		input_ctrl.set_focus();
+		input_ctrl.select_all();
+		return;
+	};
+	result.set(Some(percent));
+	dialog.end_modal(ID_OK);
 }

--- a/crates/paperback/src/ui/dialogs/go_to_percent.rs
+++ b/crates/paperback/src/ui/dialogs/go_to_percent.rs
@@ -25,6 +25,7 @@ pub fn show_go_to_percent_dialog(parent: &Frame, current_percent: i32, live_regi
 		.with_value(&current_percent.to_string())
 		.with_style(TextCtrlStyle::ProcessEnter)
 		.build();
+	restrict_to_number_input(input_ctrl);
 	let result = Rc::new(Cell::new(None::<i32>));
 	// Keep the slider and the field in step. Dragging the slider rewrites the field
 	// (`change_value` fires no event, so there is no loop); typing moves the slider to the
@@ -146,6 +147,30 @@ fn resolve_percent(text: &str, current_percent: i32) -> Option<i32> {
 		_ => amount,
 	};
 	if (0..=100).contains(&resolved) { i32::try_from(resolved).ok() } else { None }
+}
+
+/// Swallows any keystroke that cannot be part of a percentage expression: digits, `+`/`-`
+/// (for relative jumps), and Enter (which submits). Letters and punctuation never reach
+/// the field, so an invalid entry can't be typed in the first place.
+///
+/// Only `CHAR` events are filtered, which fire for character insertion. Everything that
+/// is not a printable character passes through untouched, so every navigation, editing
+/// and shortcut key keeps working: control codes below space (Tab, Backspace, Enter,
+/// Escape), Delete, the special keys at [`WXK_START`] and above (arrows, Home/End, Page
+/// keys, Insert, F-keys, numpad Enter), and all Ctrl/Cmd shortcuts.
+fn restrict_to_number_input(ctrl: TextCtrl) {
+	ctrl.bind_internal(EventType::CHAR, move |event| {
+		let key = event.get_key_code().unwrap_or(0);
+		let allowed = event.control_down()
+			|| event.cmd_down()
+			|| key < i32::from(b' ')
+			|| key == WXK_DELETE
+			|| key >= WXK_START
+			|| (i32::from(b'0')..=i32::from(b'9')).contains(&key)
+			|| key == i32::from(b'+')
+			|| key == i32::from(b'-');
+		event.skip(allowed);
+	});
 }
 
 /// Validates the field and either confirms the dialog with the resolved percentage or, when

--- a/crates/paperback/src/ui/dialogs/go_to_percent.rs
+++ b/crates/paperback/src/ui/dialogs/go_to_percent.rs
@@ -35,8 +35,8 @@ pub fn show_go_to_percent_dialog(parent: &Frame, current_percent: i32, live_regi
 	});
 	let slider_for_input = percent_slider;
 	input_ctrl.bind_internal(EventType::TEXT, move |_event| {
-		if let Ok(value) = input_ctrl.get_value().trim().parse::<i32>() {
-			slider_for_input.set_value(value.clamp(0, 100));
+		if let Some(resolved) = resolve_percent(&input_ctrl.get_value(), current_percent) {
+			slider_for_input.set_value(resolved);
 		}
 	});
 	// Enter in the field, Enter on the slider, and the Go button all submit through the
@@ -46,7 +46,7 @@ pub fn show_go_to_percent_dialog(parent: &Frame, current_percent: i32, live_regi
 	let dialog_for_enter = dialog;
 	input_for_enter.bind_internal(EventType::TEXT_ENTER, move |event| {
 		event.skip(false);
-		submit_go_to_percent(dialog_for_enter, input_for_enter, &result_for_enter, live_region_label);
+		submit_go_to_percent(dialog_for_enter, input_for_enter, &result_for_enter, live_region_label, current_percent);
 	});
 	// TRANSLATORS: Label for the button that jumps to the entered percentage
 	let ok_button = Button::builder(&dialog).with_label(&t("Go")).build();
@@ -58,7 +58,7 @@ pub fn show_go_to_percent_dialog(parent: &Frame, current_percent: i32, live_regi
 	let result_for_ok = Rc::clone(&result);
 	let dialog_for_ok = dialog;
 	ok_button.on_click(move |_| {
-		submit_go_to_percent(dialog_for_ok, input_for_ok, &result_for_ok, live_region_label);
+		submit_go_to_percent(dialog_for_ok, input_for_ok, &result_for_ok, live_region_label, current_percent);
 	});
 	// Keyboard control of the slider: arrows/Page/Home/End move it, Enter submits.
 	let input_for_slider_enter = input_ctrl;
@@ -73,6 +73,7 @@ pub fn show_go_to_percent_dialog(parent: &Frame, current_percent: i32, live_regi
 				input_for_slider_enter,
 				&result_for_slider_enter,
 				live_region_label,
+				current_percent,
 			);
 			return;
 		}
@@ -123,10 +124,28 @@ pub fn show_go_to_percent_dialog(parent: &Frame, current_percent: i32, live_regi
 }
 
 /// Resolves the entered `text` to a percentage in `0..=100`, or `None` when the text is
-/// not a bare percentage or the value is out of range.
-fn resolve_percent(text: &str) -> Option<i32> {
-	let percent = text.trim().parse::<i64>().ok()?;
-	if (0..=100).contains(&percent) { i32::try_from(percent).ok() } else { None }
+/// not a valid percentage expression or resolves out of range.
+///
+/// A bare number is the percentage itself; a leading `+`/`-` moves that many percentage
+/// points forward or backward from `current_percent`, so "+10" is ten points ahead and
+/// "-5" five points back.
+fn resolve_percent(text: &str, current_percent: i32) -> Option<i32> {
+	let trimmed = text.trim();
+	if trimmed.is_empty() {
+		return None;
+	}
+	let (sign, digits) = match trimmed.as_bytes()[0] {
+		b'+' | b'-' => (trimmed.as_bytes()[0], &trimmed[1..]),
+		_ => (0, trimmed),
+	};
+	let amount = digits.parse::<i64>().ok()?;
+	let current = i64::from(current_percent);
+	let resolved = match sign {
+		b'+' => current.checked_add(amount)?,
+		b'-' => current.checked_sub(amount)?,
+		_ => amount,
+	};
+	if (0..=100).contains(&resolved) { i32::try_from(resolved).ok() } else { None }
 }
 
 /// Validates the field and either confirms the dialog with the resolved percentage or, when
@@ -136,8 +155,9 @@ fn submit_go_to_percent(
 	input_ctrl: TextCtrl,
 	result: &Rc<Cell<Option<i32>>>,
 	live_region_label: StaticText,
+	current_percent: i32,
 ) {
-	let Some(percent) = resolve_percent(&input_ctrl.get_value()) else {
+	let Some(percent) = resolve_percent(&input_ctrl.get_value(), current_percent) else {
 		// TRANSLATORS: Announced when the entered percentage is outside the 0 to 100 range
 		live_region::announce(live_region_label, &t("Percent out of range."));
 		input_ctrl.set_focus();
@@ -146,4 +166,41 @@ fn submit_go_to_percent(
 	};
 	result.set(Some(percent));
 	dialog.end_modal(ID_OK);
+}
+
+#[cfg(test)]
+mod tests {
+	use super::resolve_percent;
+
+	#[test]
+	fn absolute_percentages_resolve_and_reject_out_of_range() {
+		assert_eq!(resolve_percent("45", 40), Some(45));
+		assert_eq!(resolve_percent(" 0 ", 40), Some(0));
+		assert_eq!(resolve_percent("100", 40), Some(100));
+		assert_eq!(resolve_percent("101", 40), None);
+		assert_eq!(resolve_percent("99999999999", 40), None);
+	}
+
+	#[test]
+	fn relative_offsets_resolve_from_the_current_percentage() {
+		assert_eq!(resolve_percent("+10", 45), Some(55));
+		assert_eq!(resolve_percent("-5", 45), Some(40));
+		assert_eq!(resolve_percent("+0", 45), Some(45));
+	}
+
+	#[test]
+	fn relative_offsets_out_of_range_are_rejected() {
+		assert_eq!(resolve_percent("+60", 45), None);
+		assert_eq!(resolve_percent("-60", 45), None);
+	}
+
+	#[test]
+	fn garbage_is_rejected() {
+		assert_eq!(resolve_percent("", 45), None);
+		assert_eq!(resolve_percent("   ", 45), None);
+		assert_eq!(resolve_percent("abc", 45), None);
+		assert_eq!(resolve_percent("4+5", 45), None);
+		assert_eq!(resolve_percent("+", 45), None);
+		assert_eq!(resolve_percent("-", 45), None);
+	}
 }

--- a/crates/paperback/src/ui/main_window.rs
+++ b/crates/paperback/src/ui/main_window.rs
@@ -667,7 +667,7 @@ impl MainWindow {
 					menu_go::handle_go_to_page(&frame_copy, &dm, &config, live_region_label);
 				}
 				menu_ids::GO_TO_PERCENT => {
-					menu_go::handle_go_to_percent(&frame_copy, &dm, &config);
+					menu_go::handle_go_to_percent(&frame_copy, &dm, &config, live_region_label);
 				}
 				menu_ids::TOGGLE_WORD_WRAP => {
 					let new_state = {

--- a/crates/paperback/src/ui/main_window/menu_go.rs
+++ b/crates/paperback/src/ui/main_window/menu_go.rs
@@ -120,7 +120,13 @@ pub(super) fn handle_go_to_page(
 		navigation::announce_after_delay(frame, live_region_label, message);
 	}
 }
-pub(super) fn handle_go_to_percent(frame: &Frame, dm: &Rc<Mutex<DocumentManager>>, config: &Rc<Mutex<ConfigManager>>) {
+
+pub(super) fn handle_go_to_percent(
+	frame: &Frame,
+	dm: &Rc<Mutex<DocumentManager>>,
+	config: &Rc<Mutex<ConfigManager>>,
+	live_region_label: StaticText,
+) {
 	let current_percent = {
 		let mut dm_guard = dm.lock().unwrap();
 		let current_percent = {
@@ -134,9 +140,9 @@ pub(super) fn handle_go_to_percent(frame: &Frame, dm: &Rc<Mutex<DocumentManager>
 		current_percent
 	};
 	if let Some(percent) = dialogs::show_go_to_percent_dialog(frame, current_percent) {
-		let update = {
+		let (message, update) = {
 			let mut dm_guard = dm.lock().unwrap();
-			let update = {
+			let (message, update) = {
 				let Some(tab) = dm_guard.active_tab_mut() else {
 					return;
 				};
@@ -144,11 +150,21 @@ pub(super) fn handle_go_to_percent(frame: &Frame, dm: &Rc<Mutex<DocumentManager>
 				// on. Everything else maps the percentage through the text as before.
 				let target_pos = navigation::seek_audio_to_percent(tab, percent)
 					.unwrap_or_else(|| tab.session.position_from_percent(percent));
-				navigation::move_to_offset_and_record_history(tab, target_pos)
+				// Announce the line the jump lands on, as Go to Line does; a percentage alone
+				// says nothing about where it points. Fall back to the percentage when that
+				// line is blank.
+				let content = tab.session.get_line_text(target_pos);
+				let message =
+					if content.trim().is_empty() { format!("{percent}%") } else { content.trim().to_string() };
+				let update = navigation::move_to_offset_and_record_history(tab, target_pos);
+				(message, update)
 			};
 			drop(dm_guard);
-			update
+			(message, update)
 		};
 		navigation::persist_navigation_history(config, Some(&update));
+		// Same interrupt as Find/Go to Line/Go to Page: raise the announcement ~30ms after the
+		// dialog closes so the focus-return chain is cut off.
+		navigation::announce_after_delay(frame, live_region_label, message);
 	}
 }

--- a/crates/paperback/src/ui/main_window/menu_go.rs
+++ b/crates/paperback/src/ui/main_window/menu_go.rs
@@ -139,7 +139,7 @@ pub(super) fn handle_go_to_percent(
 		drop(dm_guard);
 		current_percent
 	};
-	if let Some(percent) = dialogs::show_go_to_percent_dialog(frame, current_percent) {
+	if let Some(percent) = dialogs::show_go_to_percent_dialog(frame, current_percent, live_region_label) {
 		let (message, update) = {
 			let mut dm_guard = dm.lock().unwrap();
 			let (message, update) = {


### PR DESCRIPTION
# Go to percent: land on the entry, cut the focus chain, reject bad percentages, and accept +n/-n

Improvements to the Go to percent dialog (Ctrl+Shift+G, or Go → "Go to percent"), parallel to the Go to page (#766) and Go to line (#767) PRs. Five commits. Unlike those two, the 0-100 slider stays — it makes sense for percentage selection even though it doesn't for pages or lines.

## 1. Land initial focus on the numeric entry

The dialog opened with focus on the slider, so a screen-reader user had to tab past it to reach the percentage field every time. Focus now lands on the entry so a percentage can be typed directly. Tab order is unchanged (it follows widget creation order), so the slider remains the first tab stop, matching on-screen order.

## 2. Interrupt the focus-chain announcement

Closing Go to percent made NVDA announce the whole focus chain ("Paperback, tab control, ...") before the jump was spoken. The shared delay-announce helper (`announce_after_delay` in `navigation.rs`, the same one the other two PRs add) raises the announcement ~30ms after the dialog closes, cutting off all but a sliver of the chain.

The announcement reads **the line the jump lands on**, as Go to Line does — a percentage alone says nothing about where it points. A blank line falls back to the percentage itself ("8%").

## 3. Reject out-of-range percentages

Typing a percentage outside 0-100 was silently clamped by the spin control, so a huge number jumped to 100%. The entry is now a plain text field that validates on submit: out-of-range or unparseable input announces "Percent out of range." and keeps the dialog open, mirroring the other Go dialogs. The slider is kept and stays in step with the field both ways (dragging rewrites the field; typing moves the slider), and the label now reads "Go to percent (45/100):".

## 4. Accept +n and -n

For consistency with Go to line and Go to page, `+n` moves n percentage points forward and `-n` back from the current percentage ("+10" from 45% is 55%). A bare number still means the percentage itself. Relative results are held to the same 0-100 rejection, and the slider follows the resolved value as it's typed. Unit tests cover the parser.

## 5. Block non-numeric keystrokes

A `CHAR`-event filter swallows anything that can't be part of a percentage expression — digits, `+`/`-`, and Enter — so letters can't be typed. Only character-insertion events are filtered, so control codes (Tab, Backspace, Enter, Escape), Delete, the special keys at `WXK_START` and above (arrows, Home/End, Page keys, Insert, F-keys, numpad Enter), and all Ctrl/Cmd shortcuts keep working.

## Notes / tradeoffs

- `announce_after_delay` is added to `navigation.rs` here exactly as in #766 and #767; all three PRs carry the identical addition, which git auto-merges when the first one lands.
- The entry switched from a `SpinCtrl` to a plain text field (nothing visually changes) — that's what makes rejection, relative input, and the keystroke filter possible.
- New translatable strings: "Go to percent (%d/%d):", "Percent out of range." (removed the old "P&ercent:"). Pot regeneration left to the usual maintenance pass.
- Only NVDA is verified, same caveat as the other PRs.

## Testing

Tested with NVDA on Windows 11: Ctrl+Shift+G lands in the entry and reads the line you jump to with no focus chain after it; out-of-range and garbage input speak "Percent out of range." and stay in the dialog; `+10`/`-5` land where expected; letters can't be typed while Tab, arrows, Backspace and shortcuts all still work; the slider still controls the value and tab order is unchanged; ESC/Cancel unchanged; the four parser unit tests pass.
