### PR TITLE
Let VoiceOver turn text pages during continuous reading

### DIFF
--- a/ios/Paperback/UI/TextModeView.swift
+++ b/ios/Paperback/UI/TextModeView.swift
@@ -119,6 +119,9 @@ struct TextModeView: View {
 			.onAppear {
 				proxy.scrollTo(tab.lineScrollIndex, anchor: .top)
 			}
+			// Keep the ScrollView's native accessibility scrolling so VoiceOver announces its
+			// page state, while asking it to turn that page automatically during read-all.
+			.accessibilityAddTraits(.causesPageTurn)
 			.environment(\.openURL, OpenURLAction { url in
 				guard let session = tab.session else { return .systemAction }
 				return activate(url, in: session, scrollingWith: proxy)


### PR DESCRIPTION
## Summary

- mark the iOS text reader as causing an automatic page turn when VoiceOver finishes the visible text during read-all
- retain the native ScrollView accessibility action so manual three-finger scrolling keeps the standard iOS page-state and boundary feedback

Fixes #772

## Testing

- unsigned iOS device build with Xcode 17.6 succeeded
- tested on a physical device with VoiceOver: read-all advances through the document, and manual three-finger scrolling retains the standard iOS page-state and boundary feedback