### PR TITLE
Elements dialog (F7): cut the focus chain, keep focus in the View choice, and add a Pages view

### DIFF
--- a/crates/paperback/src/ui/dialogs.rs
+++ b/crates/paperback/src/ui/dialogs.rs
@@ -23,7 +23,7 @@ mod document_info;
 pub use document_info::show_document_info_dialog;
 mod duration_format;
 mod elements;
-pub use elements::show_elements_dialog;
+pub use elements::{ElementsKind, show_elements_dialog};
 mod go_to;
 mod go_to_line;
 pub use go_to_line::show_go_to_line_dialog;

--- a/crates/paperback/src/ui/dialogs/elements.rs
+++ b/crates/paperback/src/ui/dialogs/elements.rs
@@ -13,7 +13,32 @@ const VIEW_HEADINGS: u32 = 0;
 const VIEW_LINKS: u32 = 1;
 const VIEW_PAGES: u32 = 2;
 
-pub fn show_elements_dialog(parent: &Frame, session: &DocumentSession, current_pos: i64) -> Option<i64> {
+/// Which view of the dialog a jump came from, so the caller can announce it appropriately: a
+/// page row announces like page navigation, while a heading or link reads the line it lands on.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ElementsKind {
+	Heading,
+	Link,
+	Page,
+}
+
+impl ElementsKind {
+	/// Maps a `VIEW_*` choice index to the kind of element it lists.
+	const fn from_view(selection: u32) -> Self {
+		match selection {
+			VIEW_HEADINGS => Self::Heading,
+			VIEW_PAGES => Self::Page,
+			// Any other flat content view reads as a link until it needs its own announcement.
+			_ => Self::Link,
+		}
+	}
+}
+
+pub fn show_elements_dialog(
+	parent: &Frame,
+	session: &DocumentSession,
+	current_pos: i64,
+) -> Option<(i64, ElementsKind)> {
 	#[cfg(not(target_os = "windows"))]
 	return show_elements_dialog_dv(parent, session, current_pos);
 	#[cfg(target_os = "windows")]
@@ -116,7 +141,7 @@ struct ElementsDialogUiDv {
 }
 
 #[cfg(not(target_os = "windows"))]
-fn show_elements_dialog_dv(parent: &Frame, session: &DocumentSession, current_pos: i64) -> Option<i64> {
+fn show_elements_dialog_dv(parent: &Frame, session: &DocumentSession, current_pos: i64) -> Option<(i64, ElementsKind)> {
 	// TRANSLATORS: Title of the Elements dialog
 	let dialog = Dialog::builder(parent, &t("Elements")).build();
 	let ElementsDialogUiDv { content_sizer, view_choice, headings_tree, content_list } =
@@ -154,7 +179,8 @@ fn show_elements_dialog_dv(parent: &Frame, session: &DocumentSession, current_po
 	headings_tree.set_focus();
 	if dialog.show_modal() == wxdragon::id::ID_OK {
 		let offset = selected_offset.get();
-		if offset >= 0 { Some(offset) } else { None }
+		let kind = ElementsKind::from_view(view_choice.get_selection().unwrap_or(VIEW_HEADINGS));
+		if offset >= 0 { Some((offset, kind)) } else { None }
 	} else {
 		None
 	}
@@ -377,7 +403,7 @@ struct ElementsDialogUi {
 }
 
 #[cfg(target_os = "windows")]
-fn show_elements_dialog_wx(parent: &Frame, session: &DocumentSession, current_pos: i64) -> Option<i64> {
+fn show_elements_dialog_wx(parent: &Frame, session: &DocumentSession, current_pos: i64) -> Option<(i64, ElementsKind)> {
 	// TRANSLATORS: Title of the Elements dialog
 	let dialog = Dialog::builder(parent, &t("Elements")).build();
 	let ElementsDialogUi { content_sizer, view_choice, headings_tree, content_list } = build_elements_dialog_ui(dialog);
@@ -403,7 +429,8 @@ fn show_elements_dialog_wx(parent: &Frame, session: &DocumentSession, current_po
 	headings_tree.set_focus();
 	if dialog.show_modal() == ID_OK {
 		let offset = selected_offset.get();
-		if offset >= 0 { Some(offset) } else { None }
+		let kind = ElementsKind::from_view(view_choice.get_selection().unwrap_or(VIEW_HEADINGS));
+		if offset >= 0 { Some((offset, kind)) } else { None }
 	} else {
 		None
 	}

--- a/crates/paperback/src/ui/dialogs/elements.rs
+++ b/crates/paperback/src/ui/dialogs/elements.rs
@@ -7,11 +7,100 @@ use patois::t;
 use wx_utils::dpi;
 use wxdragon::prelude::*;
 
+/// The view choice indices for [`show_elements_dialog`]. Headings is a tree; every other
+/// view (Links, Pages, ...) is a flat list shown in the same list pane.
+const VIEW_HEADINGS: u32 = 0;
+const VIEW_LINKS: u32 = 1;
+const VIEW_PAGES: u32 = 2;
+
 pub fn show_elements_dialog(parent: &Frame, session: &DocumentSession, current_pos: i64) -> Option<i64> {
 	#[cfg(not(target_os = "windows"))]
 	return show_elements_dialog_dv(parent, session, current_pos);
 	#[cfg(target_os = "windows")]
 	return show_elements_dialog_wx(parent, session, current_pos);
+}
+
+// ── Shared helpers (both platform implementations use these) ───────────────────
+
+/// A page entry for the Pages view: the page's marker offset (where a jump lands) and the
+/// label to show, mirroring what page navigation announces for the page.
+struct PageEntry {
+	offset: i64,
+	label: String,
+}
+
+/// One entry per page, labelled "Page N: <first content line>" — the same line that page
+/// navigation (p / Shift+P) announces — or just "Page N" when the page has no readable line.
+fn page_entries(session: &DocumentSession) -> Vec<PageEntry> {
+	(0..session.page_count())
+		.map(|index| {
+			let page = i32::try_from(index).unwrap_or(0) + 1;
+			let offset = session.page_offset(page);
+			let content = session.first_content_line_after(offset);
+			PageEntry { offset, label: page_label(page, &content) }
+		})
+		.collect()
+}
+
+fn page_label(page: i32, content: &str) -> String {
+	let content = content.trim();
+	let page_text = page.to_string();
+	if content.is_empty() {
+		// TRANSLATORS: A page in the Elements list with no readable first line; %d is the page number
+		t("Page %d").replacen("%d", &page_text, 1)
+	} else {
+		// TRANSLATORS: A page in the Elements list; %d is the page number, %s is the page's first line of text
+		t("Page %d: %s").replacen("%d", &page_text, 1).replacen("%s", content, 1)
+	}
+}
+
+/// The rows for one flat (non-headings) view: what each row shows, the document offset it
+/// jumps to, and which row is nearest the current position. The Links and Pages views each
+/// have one; the shared list pane is repopulated from whichever is selected.
+struct FlatView {
+	entries: Vec<(String, i64)>,
+	closest: Option<u32>,
+}
+
+fn link_flat_view(session: &DocumentSession, position: i64) -> FlatView {
+	let data = session.link_list(position);
+	let entries =
+		data.items.iter().map(|item| (item.text.clone(), i64::try_from(item.offset).unwrap_or(i64::MAX))).collect();
+	let closest = if data.closest_index >= 0 { u32::try_from(data.closest_index).ok() } else { None };
+	FlatView { entries, closest }
+}
+
+fn page_flat_view(session: &DocumentSession, position: i64) -> FlatView {
+	let entries = page_entries(session).iter().map(|page| (page.label.clone(), page.offset)).collect();
+	let closest = {
+		let page = session.current_page(position);
+		if page >= 1 { u32::try_from(page - 1).ok() } else { None }
+	};
+	FlatView { entries, closest }
+}
+
+/// Replaces `list`'s rows with `view`'s, selecting the row nearest the current position.
+fn fill_flat_list(list: ListBox, view: &FlatView) {
+	list.clear();
+	for (label, _) in &view.entries {
+		list.append(label);
+	}
+	if let Some(index) = view.closest {
+		list.set_selection(index, true);
+	}
+}
+
+/// The offset of the row selected in the flat list pane for `view`, if any.
+fn flat_selected_offset(view: u32, list: ListBox, links: &FlatView, pages: &FlatView) -> Option<i64> {
+	let entries = match view {
+		VIEW_LINKS => &links.entries,
+		VIEW_PAGES => &pages.entries,
+		_ => return None,
+	};
+	list.get_selection()
+		.and_then(|index| usize::try_from(index).ok())
+		.and_then(|index| entries.get(index))
+		.map(|(_, offset)| *offset)
 }
 
 // ── DataViewTreeCtrl implementation (Linux + macOS) ───────────────────────────
@@ -21,37 +110,48 @@ struct ElementsDialogUiDv {
 	content_sizer: BoxSizer,
 	view_choice: Choice,
 	headings_tree: DataViewTreeCtrl,
-	links_list: ListBox,
+	// The flat-list pane, shared by every non-headings view (Links, Pages, ...): its
+	// contents are swapped in when the view changes.
+	content_list: ListBox,
 }
 
 #[cfg(not(target_os = "windows"))]
 fn show_elements_dialog_dv(parent: &Frame, session: &DocumentSession, current_pos: i64) -> Option<i64> {
 	// TRANSLATORS: Title of the Elements dialog
 	let dialog = Dialog::builder(parent, &t("Elements")).build();
-	let ElementsDialogUiDv { content_sizer, view_choice, headings_tree, links_list } =
+	let ElementsDialogUiDv { content_sizer, view_choice, headings_tree, content_list } =
 		build_elements_dialog_ui_dv(dialog);
-	let (selected_offset, item_offsets, link_offsets) =
-		populate_elements_dialog_dv(session, current_pos, headings_tree, links_list);
+	let (selected_offset, item_offsets) = populate_elements_dialog_dv(session, current_pos, headings_tree);
 	let item_offsets = Rc::new(item_offsets);
-	bind_elements_view_toggle_dv(view_choice, headings_tree, links_list, dialog);
-	bind_elements_activation_dv(dialog, headings_tree, links_list, &item_offsets, &link_offsets, &selected_offset);
+	let links = Rc::new(link_flat_view(session, current_pos));
+	let pages = Rc::new(page_flat_view(session, current_pos));
+	bind_elements_view_toggle_dv(view_choice, headings_tree, content_list, dialog, &links, &pages);
+	bind_elements_activation_dv(
+		dialog,
+		view_choice,
+		headings_tree,
+		content_list,
+		&item_offsets,
+		&links,
+		&pages,
+		&selected_offset,
+	);
 	let (ok_button, cancel_button) = build_elements_buttons(dialog);
 	bind_elements_ok_action_dv(
 		dialog,
 		view_choice,
 		headings_tree,
-		links_list,
+		content_list,
 		&item_offsets,
-		&link_offsets,
+		&links,
+		&pages,
 		&selected_offset,
 		ok_button,
 	);
 	finalize_elements_layout(dialog, content_sizer, ok_button, cancel_button);
-	if view_choice.get_selection().unwrap_or(0) == 0 {
-		headings_tree.set_focus();
-	} else {
-		links_list.set_focus();
-	}
+	// The dialog opens on Headings (the choice is set to index 0 when it is built), so the
+	// tree is the visible pane.
+	headings_tree.set_focus();
 	if dialog.show_modal() == wxdragon::id::ID_OK {
 		let offset = selected_offset.get();
 		if offset >= 0 { Some(offset) } else { None }
@@ -72,7 +172,9 @@ fn build_elements_dialog_ui_dv(dialog: Dialog) -> ElementsDialogUiDv {
 	view_choice.append(&t("Headings"));
 	// TRANSLATORS: Choice option in the view dropdown to show links list
 	view_choice.append(&t("Links"));
-	view_choice.set_selection(0);
+	// TRANSLATORS: Choice option in the view dropdown to show the list of pages
+	view_choice.append(&t("Pages"));
+	view_choice.set_selection(VIEW_HEADINGS);
 	#[cfg(target_os = "macos")]
 	view_choice.set_accessibility_label(choice_label_text.replace('&', "").trim_end_matches(':').trim());
 	choice_sizer.add(&choice_label, 0, SizerFlag::AlignCenterVertical | SizerFlag::Right, super::DIALOG_PADDING);
@@ -86,15 +188,15 @@ fn build_elements_dialog_ui_dv(dialog: Dialog) -> ElementsDialogUiDv {
 		SizerFlag::Expand | SizerFlag::Left | SizerFlag::Right | SizerFlag::Bottom,
 		super::DIALOG_PADDING,
 	);
-	let links_list = ListBox::builder(&dialog).build();
+	let content_list = ListBox::builder(&dialog).build();
 	content_sizer.add(
-		&links_list,
+		&content_list,
 		1,
 		SizerFlag::Expand | SizerFlag::Left | SizerFlag::Right | SizerFlag::Bottom,
 		super::DIALOG_PADDING,
 	);
-	links_list.show(false);
-	ElementsDialogUiDv { content_sizer, view_choice, headings_tree, links_list }
+	content_list.show(false);
+	ElementsDialogUiDv { content_sizer, view_choice, headings_tree, content_list }
 }
 
 #[cfg(not(target_os = "windows"))]
@@ -102,8 +204,7 @@ fn populate_elements_dialog_dv(
 	session: &DocumentSession,
 	current_pos: i64,
 	headings_tree: DataViewTreeCtrl,
-	links_list: ListBox,
-) -> (Rc<Cell<i64>>, HashMap<usize, i64>, Rc<Vec<i64>>) {
+) -> (Rc<Cell<i64>>, HashMap<usize, i64>) {
 	let selected_offset = Rc::new(Cell::new(-1i64));
 	let mut item_offsets: HashMap<usize, i64> = HashMap::new();
 	let tree_data = session.heading_tree(current_pos);
@@ -147,51 +248,51 @@ fn populate_elements_dialog_dv(
 			headings_tree.ensure_visible(item);
 		}
 	}
-	let link_data = session.link_list(current_pos);
-	let mut link_offsets = Vec::new();
-	for item in link_data.items {
-		links_list.append(&item.text);
-		link_offsets.push(i64::try_from(item.offset).unwrap_or(i64::MAX));
-	}
-	if !link_offsets.is_empty() {
-		let idx = if link_data.closest_index >= 0 { link_data.closest_index } else { 0 };
-		if let Ok(idx_u32) = u32::try_from(idx) {
-			links_list.set_selection(idx_u32, true);
-		}
-	}
-	(selected_offset, item_offsets, Rc::new(link_offsets))
+	(selected_offset, item_offsets)
 }
 
 #[cfg(not(target_os = "windows"))]
 fn bind_elements_view_toggle_dv(
 	view_choice: Choice,
 	headings_tree: DataViewTreeCtrl,
-	links_list: ListBox,
+	content_list: ListBox,
 	dialog: Dialog,
+	links: &Rc<FlatView>,
+	pages: &Rc<FlatView>,
 ) {
+	let headings_tree_for_choice = headings_tree;
+	let content_list_for_choice = content_list;
+	let dialog_for_layout = dialog;
+	let links_for_choice = Rc::clone(links);
+	let pages_for_choice = Rc::clone(pages);
 	view_choice.on_selection_changed(move |_| {
-		let selection = view_choice.get_selection().unwrap_or(0);
-		// Switch which pane is shown. Focus is deliberately left where it is: the change
-		// comes from the user arrowing through the view choice, and throwing them into the
-		// newly shown pane with every arrow makes the dropdown impossible to browse.
-		if selection == 0 {
-			headings_tree.show(true);
-			links_list.show(false);
+		let selection = view_choice.get_selection().unwrap_or(VIEW_HEADINGS);
+		// Switch which pane is shown, repopulating the shared flat list for a non-headings
+		// view. Focus is deliberately left where it is: the change comes from the user
+		// arrowing through the view choice, and throwing them into the newly shown pane
+		// with every arrow makes the dropdown impossible to browse.
+		if selection == VIEW_HEADINGS {
+			headings_tree_for_choice.show(true);
+			content_list_for_choice.show(false);
 		} else {
-			headings_tree.show(false);
-			links_list.show(true);
+			headings_tree_for_choice.show(false);
+			content_list_for_choice.show(true);
+			let view = if selection == VIEW_LINKS { &links_for_choice } else { &pages_for_choice };
+			fill_flat_list(content_list_for_choice, view);
 		}
-		dialog.layout();
+		dialog_for_layout.layout();
 	});
 }
 
 #[cfg(not(target_os = "windows"))]
 fn bind_elements_activation_dv(
 	dialog: Dialog,
+	view_choice: Choice,
 	headings_tree: DataViewTreeCtrl,
-	links_list: ListBox,
+	content_list: ListBox,
 	item_offsets: &Rc<HashMap<usize, i64>>,
-	link_offsets: &Rc<Vec<i64>>,
+	links: &Rc<FlatView>,
+	pages: &Rc<FlatView>,
 	selected_offset: &Rc<Cell<i64>>,
 ) {
 	let offsets_for_tree = Rc::clone(item_offsets);
@@ -207,18 +308,21 @@ fn bind_elements_activation_dv(
 			}
 		}
 	});
-	let offsets_for_list = Rc::clone(link_offsets);
+	let view_for_list = view_choice;
+	let list_for_click = content_list;
+	let links_for_click = Rc::clone(links);
+	let pages_for_click = Rc::clone(pages);
 	let selected_for_list = Rc::clone(selected_offset);
 	let dialog_for_list = dialog;
-	links_list.on_item_double_clicked(move |event| {
-		let selection = event.get_selection().unwrap_or(-1);
-		if selection >= 0 {
-			if let Ok(index) = usize::try_from(selection) {
-				if let Some(offset) = offsets_for_list.get(index) {
-					selected_for_list.set(*offset);
-					dialog_for_list.end_modal(wxdragon::id::ID_OK);
-				}
-			}
+	content_list.on_item_double_clicked(move |_| {
+		if let Some(offset) = flat_selected_offset(
+			view_for_list.get_selection().unwrap_or(VIEW_HEADINGS),
+			list_for_click,
+			&links_for_click,
+			&pages_for_click,
+		) {
+			selected_for_list.set(offset);
+			dialog_for_list.end_modal(wxdragon::id::ID_OK);
 		}
 	});
 }
@@ -228,19 +332,23 @@ fn bind_elements_ok_action_dv(
 	dialog: Dialog,
 	view_choice: Choice,
 	headings_tree: DataViewTreeCtrl,
-	links_list: ListBox,
+	content_list: ListBox,
 	item_offsets: &Rc<HashMap<usize, i64>>,
-	link_offsets: &Rc<Vec<i64>>,
+	links: &Rc<FlatView>,
+	pages: &Rc<FlatView>,
 	selected_offset: &Rc<Cell<i64>>,
 	ok_button: Button,
 ) {
 	let offsets_for_ok = Rc::clone(item_offsets);
-	let link_offsets_for_ok = Rc::clone(link_offsets);
 	let selected_for_ok = Rc::clone(selected_offset);
 	let dialog_for_ok = dialog;
+	let view_for_ok = view_choice;
+	let list_for_ok = content_list;
+	let links_for_ok = Rc::clone(links);
+	let pages_for_ok = Rc::clone(pages);
 	ok_button.on_click(move |_| {
-		let selection = view_choice.get_selection().unwrap_or(0);
-		if selection == 0 {
+		let selection = view_for_ok.get_selection().unwrap_or(VIEW_HEADINGS);
+		if selection == VIEW_HEADINGS {
 			if let Some(item) = headings_tree.get_selection() {
 				if let Some(id_ptr) = item.get_id::<c_void>() {
 					if let Some(&offset) = offsets_for_ok.get(&(id_ptr as usize)) {
@@ -249,13 +357,9 @@ fn bind_elements_ok_action_dv(
 					}
 				}
 			}
-		} else if let Some(idx) = links_list.get_selection() {
-			if let Ok(index) = usize::try_from(idx) {
-				if let Some(offset) = link_offsets_for_ok.get(index) {
-					selected_for_ok.set(*offset);
-					dialog_for_ok.end_modal(wxdragon::id::ID_OK);
-				}
-			}
+		} else if let Some(offset) = flat_selected_offset(selection, list_for_ok, &links_for_ok, &pages_for_ok) {
+			selected_for_ok.set(offset);
+			dialog_for_ok.end_modal(wxdragon::id::ID_OK);
 		}
 	});
 }
@@ -267,25 +371,36 @@ struct ElementsDialogUi {
 	content_sizer: BoxSizer,
 	view_choice: Choice,
 	headings_tree: TreeCtrl,
-	links_list: ListBox,
+	// The flat-list pane, shared by every non-headings view (Links, Pages, ...): its
+	// contents are swapped in when the view changes.
+	content_list: ListBox,
 }
 
 #[cfg(target_os = "windows")]
 fn show_elements_dialog_wx(parent: &Frame, session: &DocumentSession, current_pos: i64) -> Option<i64> {
 	// TRANSLATORS: Title of the Elements dialog
 	let dialog = Dialog::builder(parent, &t("Elements")).build();
-	let ElementsDialogUi { content_sizer, view_choice, headings_tree, links_list } = build_elements_dialog_ui(dialog);
-	let (selected_offset, link_offsets) = populate_elements_dialog(session, current_pos, headings_tree, links_list);
-	bind_elements_view_toggle(view_choice, headings_tree, links_list, dialog);
-	bind_elements_activation(dialog, headings_tree, links_list, &selected_offset, &link_offsets);
+	let ElementsDialogUi { content_sizer, view_choice, headings_tree, content_list } = build_elements_dialog_ui(dialog);
+	let selected_offset = populate_elements_dialog(session, current_pos, headings_tree);
+	let links = Rc::new(link_flat_view(session, current_pos));
+	let pages = Rc::new(page_flat_view(session, current_pos));
+	bind_elements_view_toggle(view_choice, headings_tree, content_list, dialog, &links, &pages);
+	bind_elements_activation(dialog, view_choice, headings_tree, content_list, &selected_offset, &links, &pages);
 	let (ok_button, cancel_button) = build_elements_buttons(dialog);
-	bind_elements_ok_action(dialog, view_choice, headings_tree, links_list, &link_offsets, &selected_offset, ok_button);
+	bind_elements_ok_action(
+		dialog,
+		view_choice,
+		headings_tree,
+		content_list,
+		&selected_offset,
+		&links,
+		&pages,
+		ok_button,
+	);
 	finalize_elements_layout(dialog, content_sizer, ok_button, cancel_button);
-	if view_choice.get_selection().unwrap_or(0) == 0 {
-		headings_tree.set_focus();
-	} else {
-		links_list.set_focus();
-	}
+	// The dialog opens on Headings (the choice is set to index 0 when it is built), so the
+	// tree is the visible pane.
+	headings_tree.set_focus();
 	if dialog.show_modal() == ID_OK {
 		let offset = selected_offset.get();
 		if offset >= 0 { Some(offset) } else { None }
@@ -306,7 +421,9 @@ fn build_elements_dialog_ui(dialog: Dialog) -> ElementsDialogUi {
 	view_choice.append(&t("Headings"));
 	// TRANSLATORS: Choice option in the view dropdown to show links list
 	view_choice.append(&t("Links"));
-	view_choice.set_selection(0);
+	// TRANSLATORS: Choice option in the view dropdown to show the list of pages
+	view_choice.append(&t("Pages"));
+	view_choice.set_selection(VIEW_HEADINGS);
 	#[cfg(target_os = "macos")]
 	view_choice.set_accessibility_label(choice_label_text.replace('&', "").trim_end_matches(':').trim());
 	choice_sizer.add(&choice_label, 0, SizerFlag::AlignCenterVertical | SizerFlag::Right, super::DIALOG_PADDING);
@@ -324,26 +441,21 @@ fn build_elements_dialog_ui(dialog: Dialog) -> ElementsDialogUi {
 		SizerFlag::Expand | SizerFlag::Left | SizerFlag::Right | SizerFlag::Bottom,
 		super::DIALOG_PADDING,
 	);
-	let links_sizer = BoxSizer::builder(Orientation::Vertical).build();
-	let links_list = ListBox::builder(&dialog).build();
-	links_sizer.add(&links_list, 1, SizerFlag::Expand, 0);
+	let list_sizer = BoxSizer::builder(Orientation::Vertical).build();
+	let content_list = ListBox::builder(&dialog).build();
+	list_sizer.add(&content_list, 1, SizerFlag::Expand, 0);
 	content_sizer.add_sizer(
-		&links_sizer,
+		&list_sizer,
 		1,
 		SizerFlag::Expand | SizerFlag::Left | SizerFlag::Right | SizerFlag::Bottom,
 		super::DIALOG_PADDING,
 	);
-	links_list.show(false);
-	ElementsDialogUi { content_sizer, view_choice, headings_tree, links_list }
+	content_list.show(false);
+	ElementsDialogUi { content_sizer, view_choice, headings_tree, content_list }
 }
 
 #[cfg(target_os = "windows")]
-fn populate_elements_dialog(
-	session: &DocumentSession,
-	current_pos: i64,
-	headings_tree: TreeCtrl,
-	links_list: ListBox,
-) -> (Rc<Cell<i64>>, Rc<Vec<i64>>) {
+fn populate_elements_dialog(session: &DocumentSession, current_pos: i64, headings_tree: TreeCtrl) -> Rc<Cell<i64>> {
 	let selected_offset = Rc::new(Cell::new(-1i64));
 	let root = headings_tree.add_root("Root", None, None).unwrap();
 	let tree_data = session.heading_tree(current_pos);
@@ -381,37 +493,37 @@ fn populate_elements_dialog(
 		headings_tree.select_item(&first_child);
 		headings_tree.ensure_visible(&first_child);
 	}
-	let link_data = session.link_list(current_pos);
-	let mut link_offsets = Vec::new();
-	for item in link_data.items {
-		links_list.append(&item.text);
-		link_offsets.push(i64::try_from(item.offset).unwrap_or(i64::MAX));
-	}
-	if !link_offsets.is_empty() {
-		let idx = if link_data.closest_index >= 0 { link_data.closest_index } else { 0 };
-		if let Ok(idx_u32) = u32::try_from(idx) {
-			links_list.set_selection(idx_u32, true);
-		}
-	}
-	(selected_offset, Rc::new(link_offsets))
+	selected_offset
 }
 
 #[cfg(target_os = "windows")]
-fn bind_elements_view_toggle(view_choice: Choice, headings_tree: TreeCtrl, links_list: ListBox, dialog: Dialog) {
+fn bind_elements_view_toggle(
+	view_choice: Choice,
+	headings_tree: TreeCtrl,
+	content_list: ListBox,
+	dialog: Dialog,
+	links: &Rc<FlatView>,
+	pages: &Rc<FlatView>,
+) {
 	let headings_tree_for_choice = headings_tree;
-	let links_list_for_choice = links_list;
+	let content_list_for_choice = content_list;
 	let dialog_for_layout = dialog;
+	let links_for_choice = Rc::clone(links);
+	let pages_for_choice = Rc::clone(pages);
 	view_choice.on_selection_changed(move |_| {
-		let selection = view_choice.get_selection().unwrap_or(0);
-		// Switch which pane is shown. Focus is deliberately left where it is: the change
-		// comes from the user arrowing through the view choice, and throwing them into the
-		// newly shown pane with every arrow makes the dropdown impossible to browse.
-		if selection == 0 {
+		let selection = view_choice.get_selection().unwrap_or(VIEW_HEADINGS);
+		// Switch which pane is shown, repopulating the shared flat list for a non-headings
+		// view. Focus is deliberately left where it is: the change comes from the user
+		// arrowing through the view choice, and throwing them into the newly shown pane
+		// with every arrow makes the dropdown impossible to browse.
+		if selection == VIEW_HEADINGS {
 			headings_tree_for_choice.show(true);
-			links_list_for_choice.show(false);
+			content_list_for_choice.show(false);
 		} else {
 			headings_tree_for_choice.show(false);
-			links_list_for_choice.show(true);
+			content_list_for_choice.show(true);
+			let view = if selection == VIEW_LINKS { &links_for_choice } else { &pages_for_choice };
+			fill_flat_list(content_list_for_choice, view);
 		}
 		dialog_for_layout.layout();
 	});
@@ -420,10 +532,12 @@ fn bind_elements_view_toggle(view_choice: Choice, headings_tree: TreeCtrl, links
 #[cfg(target_os = "windows")]
 fn bind_elements_activation(
 	dialog: Dialog,
+	view_choice: Choice,
 	headings_tree: TreeCtrl,
-	links_list: ListBox,
+	content_list: ListBox,
 	selected_offset: &Rc<Cell<i64>>,
-	link_offsets: &Rc<Vec<i64>>,
+	links: &Rc<FlatView>,
+	pages: &Rc<FlatView>,
 ) {
 	let selected_offset_for_tree = Rc::clone(selected_offset);
 	let tree_for_activate = headings_tree;
@@ -437,16 +551,20 @@ fn bind_elements_activation(
 			dialog_for_tree.end_modal(ID_OK);
 		}
 	});
-	let selected_offset_for_list = Rc::clone(selected_offset);
-	let offsets_for_list = Rc::clone(link_offsets);
+	let view_for_list = view_choice;
+	let list_for_click = content_list;
+	let links_for_click = Rc::clone(links);
+	let pages_for_click = Rc::clone(pages);
+	let selected_for_list = Rc::clone(selected_offset);
 	let dialog_for_list = dialog;
-	links_list.on_item_double_clicked(move |event| {
-		let selection = event.get_selection().unwrap_or(-1);
-		if selection >= 0
-			&& let Ok(index) = usize::try_from(selection)
-			&& let Some(offset) = offsets_for_list.get(index)
-		{
-			selected_offset_for_list.set(*offset);
+	content_list.on_item_double_clicked(move |_| {
+		if let Some(offset) = flat_selected_offset(
+			view_for_list.get_selection().unwrap_or(VIEW_HEADINGS),
+			list_for_click,
+			&links_for_click,
+			&pages_for_click,
+		) {
+			selected_for_list.set(offset);
 			dialog_for_list.end_modal(ID_OK);
 		}
 	});
@@ -457,17 +575,21 @@ fn bind_elements_ok_action(
 	dialog: Dialog,
 	view_choice: Choice,
 	headings_tree: TreeCtrl,
-	links_list: ListBox,
-	link_offsets: &Rc<Vec<i64>>,
+	content_list: ListBox,
 	selected_offset: &Rc<Cell<i64>>,
+	links: &Rc<FlatView>,
+	pages: &Rc<FlatView>,
 	ok_button: Button,
 ) {
-	let offsets_for_ok = Rc::clone(link_offsets);
 	let selected_offset_for_ok = Rc::clone(selected_offset);
 	let dialog_for_ok = dialog;
+	let view_for_ok = view_choice;
+	let list_for_ok = content_list;
+	let links_for_ok = Rc::clone(links);
+	let pages_for_ok = Rc::clone(pages);
 	ok_button.on_click(move |_| {
-		let selection = view_choice.get_selection().unwrap_or(0);
-		if selection == 0 {
+		let selection = view_for_ok.get_selection().unwrap_or(VIEW_HEADINGS);
+		if selection == VIEW_HEADINGS {
 			if let Some(item) = headings_tree.get_selection()
 				&& let Some(data) = headings_tree.get_custom_data(&item)
 				&& let Some(offset) = data.downcast_ref::<i64>()
@@ -475,17 +597,14 @@ fn bind_elements_ok_action(
 				selected_offset_for_ok.set(*offset);
 				dialog_for_ok.end_modal(ID_OK);
 			}
-		} else if let Some(idx) = links_list.get_selection()
-			&& let Ok(index) = usize::try_from(idx)
-			&& let Some(offset) = offsets_for_ok.get(index)
-		{
-			selected_offset_for_ok.set(*offset);
+		} else if let Some(offset) = flat_selected_offset(selection, list_for_ok, &links_for_ok, &pages_for_ok) {
+			selected_offset_for_ok.set(offset);
 			dialog_for_ok.end_modal(ID_OK);
 		}
 	});
 }
 
-// ── Shared helpers ─────────────────────────────────────────────────────────────
+// ── Layout helpers ─────────────────────────────────────────────────────────────
 
 fn build_elements_buttons(dialog: Dialog) -> (Button, Button) {
 	// TRANSLATORS: Label for the confirmation button

--- a/crates/paperback/src/ui/dialogs/elements.rs
+++ b/crates/paperback/src/ui/dialogs/elements.rs
@@ -171,14 +171,15 @@ fn bind_elements_view_toggle_dv(
 ) {
 	view_choice.on_selection_changed(move |_| {
 		let selection = view_choice.get_selection().unwrap_or(0);
+		// Switch which pane is shown. Focus is deliberately left where it is: the change
+		// comes from the user arrowing through the view choice, and throwing them into the
+		// newly shown pane with every arrow makes the dropdown impossible to browse.
 		if selection == 0 {
 			headings_tree.show(true);
 			links_list.show(false);
-			headings_tree.set_focus();
 		} else {
 			headings_tree.show(false);
 			links_list.show(true);
-			links_list.set_focus();
 		}
 		dialog.layout();
 	});
@@ -402,14 +403,15 @@ fn bind_elements_view_toggle(view_choice: Choice, headings_tree: TreeCtrl, links
 	let dialog_for_layout = dialog;
 	view_choice.on_selection_changed(move |_| {
 		let selection = view_choice.get_selection().unwrap_or(0);
+		// Switch which pane is shown. Focus is deliberately left where it is: the change
+		// comes from the user arrowing through the view choice, and throwing them into the
+		// newly shown pane with every arrow makes the dropdown impossible to browse.
 		if selection == 0 {
 			headings_tree_for_choice.show(true);
 			links_list_for_choice.show(false);
-			headings_tree_for_choice.set_focus();
 		} else {
 			headings_tree_for_choice.show(false);
 			links_list_for_choice.show(true);
-			links_list_for_choice.set_focus();
 		}
 		dialog_for_layout.layout();
 	});

--- a/crates/paperback/src/ui/main_window.rs
+++ b/crates/paperback/src/ui/main_window.rs
@@ -725,7 +725,7 @@ impl MainWindow {
 					menu_tools::handle_table_of_contents(&frame_copy, &dm, &config, live_region_label);
 				}
 				menu_ids::ELEMENTS_LIST => {
-					menu_tools::handle_elements_list(&frame_copy, &dm, &config);
+					menu_tools::handle_elements_list(&frame_copy, &dm, &config, live_region_label);
 				}
 				menu_ids::OPEN_IN_WEB_VIEW => {
 					menu_tools::handle_open_in_web_view(&frame_copy, &dm);

--- a/crates/paperback/src/ui/main_window/menu_tools.rs
+++ b/crates/paperback/src/ui/main_window/menu_tools.rs
@@ -98,13 +98,13 @@ pub(super) fn handle_elements_list(
 				return;
 			};
 			let current_pos = navigation::doc_caret(tab);
-			let Some(offset) = dialogs::show_elements_dialog(frame, &tab.session, current_pos) else {
+			let Some((offset, kind)) = dialogs::show_elements_dialog(frame, &tab.session, current_pos) else {
 				return;
 			};
 			let update = navigation::move_to_offset_and_record_history(tab, offset);
 			// Capture the line the jump lands on while the document lock is held; it is
 			// spoken after focus has returned to the book, cutting off the focus chain.
-			let message = elements_announcement(&tab.session, offset);
+			let message = elements_announcement(&tab.session, offset, kind);
 			(message, update)
 		};
 		drop(dm_guard);
@@ -114,15 +114,20 @@ pub(super) fn handle_elements_list(
 	navigation::announce_after_delay(frame, live_region_label, message);
 }
 
-/// The announcement for landing on document offset `offset`. A jump to a page marker reads
-/// like page navigation ("Page N: <first content line>", skipping the page's fabricated
-/// "Page N" header); any other jump reads the line it lands on, falling back to the bare
-/// line number when that line is blank.
-fn elements_announcement(session: &DocumentSession, offset: i64) -> String {
-	let page_count = i32::try_from(session.page_count()).unwrap_or(0);
-	if let Some(page) = (1..=page_count).find(|&page| session.page_offset(page) == offset) {
-		let content = session.first_content_line_after(offset);
-		return navigation::page_announcement(page, &content);
+/// The announcement for landing on document offset `offset` from the Elements view `kind`.
+/// Only a jump from the Pages view reads like page navigation ("Page N: <first content
+/// line>", skipping the page's fabricated "Page N" header), since a page row's target is a
+/// page marker; a heading or link reads the line it lands on, even when that element happens
+/// to begin at the top of a page (there its offset coincides with the page marker, and a
+/// "Page N:" prefix would be redundant). Falls back to the bare line number when the
+/// destination line is blank.
+fn elements_announcement(session: &DocumentSession, offset: i64, kind: dialogs::ElementsKind) -> String {
+	if kind == dialogs::ElementsKind::Page {
+		let page_count = i32::try_from(session.page_count()).unwrap_or(0);
+		if let Some(page) = (1..=page_count).find(|&page| session.page_offset(page) == offset) {
+			let content = session.first_content_line_after(offset);
+			return navigation::page_announcement(page, &content);
+		}
 	}
 	let content = session.get_line_text(offset).trim().to_string();
 	if content.is_empty() {

--- a/crates/paperback/src/ui/main_window/menu_tools.rs
+++ b/crates/paperback/src/ui/main_window/menu_tools.rs
@@ -114,11 +114,16 @@ pub(super) fn handle_elements_list(
 	navigation::announce_after_delay(frame, live_region_label, message);
 }
 
-/// The announcement for landing on document offset `offset`: the text of the line the jump
-/// lands on, falling back to the bare line number when that line is blank. Mirrors how
-/// Go to Line announces its jumps, so a jump from the Elements list reads the same as one
-/// made by heading/link navigation.
+/// The announcement for landing on document offset `offset`. A jump to a page marker reads
+/// like page navigation ("Page N: <first content line>", skipping the page's fabricated
+/// "Page N" header); any other jump reads the line it lands on, falling back to the bare
+/// line number when that line is blank.
 fn elements_announcement(session: &DocumentSession, offset: i64) -> String {
+	let page_count = i32::try_from(session.page_count()).unwrap_or(0);
+	if let Some(page) = (1..=page_count).find(|&page| session.page_offset(page) == offset) {
+		let content = session.first_content_line_after(offset);
+		return navigation::page_announcement(page, &content);
+	}
 	let content = session.get_line_text(offset).trim().to_string();
 	if content.is_empty() {
 		// TRANSLATORS: Announced when landing on a blank line; %d is the line number

--- a/crates/paperback/src/ui/main_window/menu_tools.rs
+++ b/crates/paperback/src/ui/main_window/menu_tools.rs
@@ -7,7 +7,11 @@ use std::cell::RefCell;
 use std::{env, path::Path, rc::Rc, sync::Mutex};
 
 use paperback_core::{
-	config::ConfigManager, document::DocumentStats, export::ExportFormat, parser::is_external_url, session::SourceView,
+	config::ConfigManager,
+	document::DocumentStats,
+	export::ExportFormat,
+	parser::is_external_url,
+	session::{DocumentSession, SourceView},
 };
 use patois::t;
 use wxdragon::prelude::*;
@@ -81,14 +85,46 @@ pub(super) fn handle_table_of_contents(
 	}
 }
 
-pub(super) fn handle_elements_list(frame: &Frame, dm: &Rc<Mutex<DocumentManager>>, config: &Rc<Mutex<ConfigManager>>) {
-	let mut dm_guard = dm.lock().unwrap();
-	if let Some(tab) = dm_guard.active_tab_mut() {
-		let current_pos = navigation::doc_caret(tab);
-		if let Some(offset) = dialogs::show_elements_dialog(frame, &tab.session, current_pos) {
+pub(super) fn handle_elements_list(
+	frame: &Frame,
+	dm: &Rc<Mutex<DocumentManager>>,
+	config: &Rc<Mutex<ConfigManager>>,
+	live_region_label: StaticText,
+) {
+	let (message, update) = {
+		let mut dm_guard = dm.lock().unwrap();
+		let (message, update) = {
+			let Some(tab) = dm_guard.active_tab_mut() else {
+				return;
+			};
+			let current_pos = navigation::doc_caret(tab);
+			let Some(offset) = dialogs::show_elements_dialog(frame, &tab.session, current_pos) else {
+				return;
+			};
 			let update = navigation::move_to_offset_and_record_history(tab, offset);
-			navigation::persist_navigation_history(config, Some(&update));
-		}
+			// Capture the line the jump lands on while the document lock is held; it is
+			// spoken after focus has returned to the book, cutting off the focus chain.
+			let message = elements_announcement(&tab.session, offset);
+			(message, update)
+		};
+		drop(dm_guard);
+		(message, update)
+	};
+	navigation::persist_navigation_history(config, Some(&update));
+	navigation::announce_after_delay(frame, live_region_label, message);
+}
+
+/// The announcement for landing on document offset `offset`: the text of the line the jump
+/// lands on, falling back to the bare line number when that line is blank. Mirrors how
+/// Go to Line announces its jumps, so a jump from the Elements list reads the same as one
+/// made by heading/link navigation.
+fn elements_announcement(session: &DocumentSession, offset: i64) -> String {
+	let content = session.get_line_text(offset).trim().to_string();
+	if content.is_empty() {
+		// TRANSLATORS: Announced when landing on a blank line; %d is the line number
+		t("Line %d").replacen("%d", &session.line_from_position(offset).to_string(), 1)
+	} else {
+		content
 	}
 }
 


### PR DESCRIPTION
# Elements dialog (F7): cut the focus chain, keep focus in the View choice, add a Pages view, and read heading/link jumps as content

Four improvements to the Elements dialog (F7 / Tools → "Elements", the jump-to-heading/link dialog). Four commits.

## 1. Interrupt the focus-chain announcement

Closing the Elements dialog made NVDA announce the whole focus-return chain ("Paperback, tab control, ...") before anything useful. Reuse the shared delay-announce helper (`announce_after_delay`) and apply it after the jump, so the destination line is raised ~30ms later and the chain is cut off — the same treatment Go to Line and the other Go dialogs got. A jump to a page announces like page navigation ("Page N: <first content line>") rather than reading a fabricated "Page N" header.

## 2. Keep focus in the View choice while arrowing through it

Changing the View dropdown (Headings/Links) used to throw focus into the newly shown pane, so a screen-reader user arrowing through the options was yanked out of the dropdown on every keystroke and couldn't browse the choices. The pane toggle now leaves focus where it is; Tab moves into whichever pane is visible. The handler no longer hard-codes a per-pane focus target, which keeps it simple as more view options are added.

## 3. Add a Pages view

A third choice, "Pages", lists one row per page — "Page N: <first content line>", the same line page navigation (p / Shift+P) announces — with the page's marker offset as the jump target.

Links and Pages share the **same flat list pane**, which is repopulated when the view changes; only Headings keeps its tree (it is genuinely hierarchical). Adding another flat view later is just a dropdown entry plus one `FlatView`. The shared-pane structure also meant the pane-toggle focus fix applies uniformly.

## 4. Only the Pages view announces a jump as a page

The announcement formatted any destination whose offset coincided with a page marker as page navigation ("Page N: <first content line>"). A heading or link that begins at the very top of a page shares its offset with the page marker, so jumping to it announced "Page N: ..." even though it is content, not a page — the same quirk fixed for the Table of Contents dialog.

The dialog now reports which view produced a jump (it returns the offset together with an `ElementsKind`), and only a **Pages** row announces like page navigation, since its target genuinely is a page marker. A **heading** or **link** reads the line it lands on, whether or not it opens a page.

## Notes

- The macOS/Linux variant (a `DataViewTreeCtrl` mirror of the Windows path) is updated alongside Windows; it is compiled out on Windows so it is verified by the macOS/Android CI checks.
- New translatable strings: "Pages" (the dropdown option). "Page %d" / "Page %d: %s" are already used by page navigation.
- Only NVDA is verified, same caveat as the other PRs.

## Testing

Tested with NVDA on Windows 11: F7 → pick an element → Enter reads the destination line with no focus chain after it; arrowing the View dropdown stays in the dropdown and Tab moves into the shown pane; the Pages view lists "Page N: <first content line>" rows and jumping announces like page navigation; a heading that starts at the top of a page reads just its line (no "Page N:" prefix) while a Pages-row jump to the same spot still announces the page; ESC/Cancel unchanged.
