### PR TITLE
Table of Contents (Ctrl+T): cut the focus chain, fix OK on the preselected entry, and read the destination line

### DIFF
--- a/crates/paperback/src/ui/dialogs/toc.rs
+++ b/crates/paperback/src/ui/dialogs/toc.rs
@@ -36,7 +36,20 @@ fn show_toc_dialog_dv(parent: &Frame, toc_items: &[TocItem], current_offset: i32
 	bind_toc_selection_dv(tree, Rc::clone(&item_offsets), Rc::clone(&selected_offset));
 	bind_toc_activation_dv(dialog, tree, Rc::clone(&item_offsets), Rc::clone(&selected_offset));
 	let (ok_button, cancel_button) = build_toc_buttons(dialog);
-	bind_toc_ok(dialog, ok_button, Rc::clone(&selected_offset));
+	// OK confirms the tree's current selection at click time, as Enter does, rather than
+	// trusting a cached offset: the entry nearest the reader is preselected while the tree
+	// is being built, before the selection-changed listener is attached, so that listener
+	// never records it and OK would otherwise claim nothing is selected.
+	let resolve_selected: Rc<dyn Fn() -> Option<i32>> = {
+		let tree_for_ok = tree;
+		let offsets_for_ok = Rc::clone(&item_offsets);
+		Rc::new(move || {
+			let item = tree_for_ok.get_selection()?;
+			let id_ptr = item.get_id::<c_void>()?;
+			offsets_for_ok.get(&(id_ptr as usize)).copied()
+		})
+	};
+	bind_toc_ok(dialog, ok_button, Rc::clone(&selected_offset), resolve_selected);
 	bind_toc_layout_dv(dialog, tree, ok_button, cancel_button);
 	tree.set_focus();
 	if dialog.show_modal() == wxdragon::id::ID_OK {
@@ -174,7 +187,19 @@ fn show_toc_dialog_wx(parent: &Frame, toc_items: &[TocItem], current_offset: i32
 	bind_toc_activation(dialog, tree, Rc::clone(&selected_offset));
 	bind_toc_search(tree);
 	let (ok_button, cancel_button) = build_toc_buttons(dialog);
-	bind_toc_ok(dialog, ok_button, Rc::clone(&selected_offset));
+	// OK confirms the tree's current selection at click time, as Enter does, rather than
+	// trusting a cached offset: the entry nearest the reader is preselected while the tree
+	// is being built, before the selection-changed listener is attached, so that listener
+	// never records it and OK would otherwise claim nothing is selected.
+	let resolve_selected: Rc<dyn Fn() -> Option<i32>> = {
+		let tree_for_ok = tree;
+		Rc::new(move || {
+			let item = tree_for_ok.get_selection()?;
+			let data = tree_for_ok.get_custom_data(&item)?;
+			data.downcast_ref::<i32>().copied()
+		})
+	};
+	bind_toc_ok(dialog, ok_button, Rc::clone(&selected_offset), resolve_selected);
 	bind_toc_layout(dialog, tree, ok_button, cancel_button);
 	tree.set_focus();
 	if dialog.show_modal() == ID_OK {
@@ -306,11 +331,17 @@ fn build_toc_buttons(dialog: Dialog) -> (Button, Button) {
 	(ok_button, cancel_button)
 }
 
-fn bind_toc_ok(dialog: Dialog, ok_button: Button, selected_offset: Rc<Cell<i32>>) {
+fn bind_toc_ok(
+	dialog: Dialog,
+	ok_button: Button,
+	selected_offset: Rc<Cell<i32>>,
+	resolve_selected: Rc<dyn Fn() -> Option<i32>>,
+) {
 	dialog.set_escape_id(ID_CANCEL);
 	let dialog_for_ok = dialog;
 	ok_button.on_click(move |_| {
-		if selected_offset.get() >= 0 {
+		if let Some(offset) = resolve_selected() {
+			selected_offset.set(offset);
 			dialog_for_ok.end_modal(ID_OK);
 		} else {
 			MessageDialog::builder(

--- a/crates/paperback/src/ui/main_window/menu_tools.rs
+++ b/crates/paperback/src/ui/main_window/menu_tools.rs
@@ -100,21 +100,17 @@ pub(super) fn handle_table_of_contents(
 }
 
 /// The announcement for landing on document offset `offset` after picking a table of contents
-/// entry. Mirrors the Elements dialog: an entry that points at a page marker reads like page
-/// navigation ("Page N: <first content line>"); any other entry reads the line it lands on,
-/// falling back to the bare line number when that line is blank.
+/// entry. Always reads the content line at the destination, never announcing it as a page jump:
+/// a section that begins at the top of a page shares its offset with the page marker, and a
+/// "Page N:" prefix there would be redundant. Falls back to the bare line number when the
+/// destination has no content line.
 fn toc_announcement(session: &DocumentSession, offset: i64) -> String {
-	let page_count = i32::try_from(session.page_count()).unwrap_or(0);
-	if let Some(page) = (1..=page_count).find(|&page| session.page_offset(page) == offset) {
-		let content = session.first_content_line_after(offset);
-		return navigation::page_announcement(page, &content);
-	}
-	let content = session.get_line_text(offset).trim().to_string();
-	if content.is_empty() {
+	let content = session.first_content_line_after(offset);
+	if content.trim().is_empty() {
 		// TRANSLATORS: Announced when landing on a blank line; %d is the line number
 		t("Line %d").replacen("%d", &session.line_from_position(offset).to_string(), 1)
 	} else {
-		content
+		content.trim().to_string()
 	}
 }
 

--- a/crates/paperback/src/ui/main_window/menu_tools.rs
+++ b/crates/paperback/src/ui/main_window/menu_tools.rs
@@ -7,7 +7,11 @@ use std::cell::RefCell;
 use std::{env, path::Path, rc::Rc, sync::Mutex};
 
 use paperback_core::{
-	config::ConfigManager, document::DocumentStats, export::ExportFormat, parser::is_external_url, session::SourceView,
+	config::ConfigManager,
+	document::DocumentStats,
+	export::ExportFormat,
+	parser::is_external_url,
+	session::{DocumentSession, SourceView},
 };
 use patois::t;
 use wxdragon::prelude::*;
@@ -61,23 +65,56 @@ pub(super) fn handle_table_of_contents(
 	config: &Rc<Mutex<ConfigManager>>,
 	live_region_label: StaticText,
 ) {
-	let mut dm_guard = dm.lock().unwrap();
-	if let Some(tab) = dm_guard.active_tab_mut() {
-		let toc_items = &tab.session.handle().document().toc_items;
-		if toc_items.is_empty() {
-			// TRANSLATORS: Announced when opening the Table of Contents for a document that has none
-			live_region::announce(live_region_label, &t("No table of contents."));
-			return;
-		}
-		let current_pos = navigation::doc_caret(tab);
-		let current_pos_usize = usize::try_from(current_pos).unwrap_or(0);
-		let current_toc_offset = tab.session.handle().find_closest_toc_offset(current_pos_usize);
-		if let Some(offset) =
-			dialogs::show_toc_dialog(frame, toc_items, i32::try_from(current_toc_offset).unwrap_or(i32::MAX))
-		{
-			let update = navigation::move_to_offset_and_record_history(tab, i64::from(offset));
-			navigation::persist_navigation_history(config, Some(&update));
-		}
+	let (message, update) = {
+		let mut dm_guard = dm.lock().unwrap();
+		let (message, update) = {
+			let Some(tab) = dm_guard.active_tab_mut() else {
+				return;
+			};
+			let toc_items = &tab.session.handle().document().toc_items;
+			if toc_items.is_empty() {
+				// TRANSLATORS: Announced when opening the Table of Contents for a document that has none
+				live_region::announce(live_region_label, &t("No table of contents."));
+				return;
+			}
+			let current_pos = navigation::doc_caret(tab);
+			let current_pos_usize = usize::try_from(current_pos).unwrap_or(0);
+			let current_toc_offset = tab.session.handle().find_closest_toc_offset(current_pos_usize);
+			let Some(offset) =
+				dialogs::show_toc_dialog(frame, toc_items, i32::try_from(current_toc_offset).unwrap_or(i32::MAX))
+			else {
+				return;
+			};
+			let offset = i64::from(offset);
+			let update = navigation::move_to_offset_and_record_history(tab, offset);
+			// Capture the entry's announcement while the document lock is held; it is spoken
+			// after focus has returned to the book, cutting off the focus chain.
+			let message = toc_announcement(&tab.session, offset);
+			(message, update)
+		};
+		drop(dm_guard);
+		(message, update)
+	};
+	navigation::persist_navigation_history(config, Some(&update));
+	navigation::announce_after_delay(frame, live_region_label, message);
+}
+
+/// The announcement for landing on document offset `offset` after picking a table of contents
+/// entry. Mirrors the Elements dialog: an entry that points at a page marker reads like page
+/// navigation ("Page N: <first content line>"); any other entry reads the line it lands on,
+/// falling back to the bare line number when that line is blank.
+fn toc_announcement(session: &DocumentSession, offset: i64) -> String {
+	let page_count = i32::try_from(session.page_count()).unwrap_or(0);
+	if let Some(page) = (1..=page_count).find(|&page| session.page_offset(page) == offset) {
+		let content = session.first_content_line_after(offset);
+		return navigation::page_announcement(page, &content);
+	}
+	let content = session.get_line_text(offset).trim().to_string();
+	if content.is_empty() {
+		// TRANSLATORS: Announced when landing on a blank line; %d is the line number
+		t("Line %d").replacen("%d", &session.line_from_position(offset).to_string(), 1)
+	} else {
+		content
 	}
 }
 


### PR DESCRIPTION
# Table of Contents (Ctrl+T): cut the focus chain, fix OK on the preselected entry, and read the destination line

Three improvements to the Table of Contents dialog (Ctrl+T). Three commits.

## 1. Interrupt the focus-chain announcement

Closing the TOC dialog made NVDA announce the whole focus-return chain ("Paperback, tab control, ...") before anything useful. Reuse the shared delay-announce helper (`announce_after_delay`) after the jump so the section you land on is raised ~30ms later and the chain is cut off — the same treatment the Go dialogs and the Elements dialog got.

## 2. OK honors the preselected entry instead of reporting no selection

The dialog preselects the TOC entry nearest the reader while the tree is being built — *before* the selection-changed listener is attached — so that listener never records the preselection. The OK button trusted that cached offset, so confirming with OK (Tab to OK → activate) claimed nothing was selected and showed "Please select a section from the table of contents," while Enter worked because activation reads the event's item directly.

OK now confirms whatever the tree has selected **at click time**, exactly as Enter does (and as the Elements dialog's OK already did): it reads the current selection and resolves its offset, only falling back to the "Please select a section" message when the tree genuinely has no selection. Both the Windows and the DataView variants share this via `bind_toc_ok`.

## 3. Read the destination line, never as a page jump

A section that begins at the very top of a page shares its offset with the page marker, so the announcement's page special-case (borrowed from page navigation / the Elements dialog) formatted it as "Page N: <content>" even though a TOC entry is always a section, never a page. The TOC announcement now always reads the content line at the destination (skipping blank lines and bare page-number headers) and drops the page formatting, so the same entry reads the same way whether or not it opens a page.

## Notes

- The macOS/Linux DataView variant is updated alongside Windows for #2 (the OK fix); it is compiled out on Windows so it is verified by the macOS/Android CI checks. #1 and #3 are platform-neutral.
- No new translatable strings: "Line %d" and the existing "Please select a section from the table of contents." / "No Selection" are reused.
- Only NVDA is verified, same caveat as the other PRs.

## Testing

Tested with NVDA on Windows 11: Ctrl+T → Enter reads the section you land on with no focus chain after it; Tab to OK and activate jumps to the preselected section (no "no selection" error), and arrowing to a different entry first makes OK jump there; an entry that opens a page reads just its line, not "Page N: ..."; ESC/Cancel unchanged.
