### PR TITLE
Elements dialog (F7): add Tables and Lists views

### DIFF
--- a/crates/paperback-core/src/session/links.rs
+++ b/crates/paperback-core/src/session/links.rs
@@ -31,12 +31,17 @@ impl DocumentSession {
 		ffi::BookmarkDisplayAtPosition { found: true, note: bookmark.note, snippet }
 	}
 
+	/// One row per marker of `mtype`, in document order, for the Elements dialog's flat views.
+	/// Each row shows the marker's own text (a table's caption) or, when the marker carries none,
+	/// the whole line the marker sits on (a list's first rendered item) — the same text reading
+	/// navigation announces for it. `closest_index` is the index of the last row whose marker is
+	/// at or before `position`.
 	#[must_use]
-	pub fn link_list(&self, position: i64) -> ffi::LinkList {
+	pub fn element_list(&self, mtype: MarkerType, position: i64) -> ffi::ElementList {
 		let pos = usize::try_from(position.max(0)).unwrap_or(0);
 		let mut closest_index = -1;
 		let mut items = Vec::new();
-		for marker in self.handle.document().buffer.markers.iter().filter(|marker| marker.mtype == MarkerType::Link) {
+		for marker in self.handle.document().buffer.markers.iter().filter(|marker| marker.mtype == mtype) {
 			let text = if marker.text.is_empty() {
 				self.get_line_text(i64::try_from(marker.position).unwrap_or(0))
 			} else {
@@ -45,9 +50,22 @@ impl DocumentSession {
 			if marker.position <= pos {
 				closest_index = i32::try_from(items.len()).unwrap_or(-1);
 			}
-			items.push(ffi::LinkListItem { offset: marker.position, text });
+			items.push(ffi::ElementListItem { offset: marker.position, text });
 		}
-		ffi::LinkList { items, closest_index }
+		ffi::ElementList { items, closest_index }
+	}
+
+	#[must_use]
+	pub fn link_list(&self, position: i64) -> ffi::LinkList {
+		let list = self.element_list(MarkerType::Link, position);
+		ffi::LinkList {
+			items: list
+				.items
+				.iter()
+				.map(|item| ffi::LinkListItem { offset: item.offset, text: item.text.clone() })
+				.collect(),
+			closest_index: list.closest_index,
+		}
 	}
 
 	#[must_use]

--- a/crates/paperback-core/src/session/tests.rs
+++ b/crates/paperback-core/src/session/tests.rs
@@ -52,3 +52,16 @@ fn session_with_content(content: &str) -> DocumentSession {
 		last_stable_position: None,
 	}
 }
+
+fn session_from_buffer(buffer: DocumentBuffer) -> DocumentSession {
+	let mut doc = Document::new().with_title("Title".to_string()).with_author("Author".to_string());
+	doc.set_buffer(buffer);
+	DocumentSession {
+		handle: DocumentHandle::new(doc),
+		file_path: "book.epub".to_string(),
+		history: Vec::new(),
+		history_index: 0,
+		parser_flags: ParserFlags::empty(),
+		last_stable_position: None,
+	}
+}

--- a/crates/paperback-core/src/session/tests/links.rs
+++ b/crates/paperback-core/src/session/tests/links.rs
@@ -28,6 +28,71 @@ fn link_list_reports_closest_index_and_text() {
 }
 
 #[test]
+fn element_list_returns_table_markers_with_their_caption_text() {
+	let session = sample_session(ParserFlags::NONE);
+	let list = session.element_list(MarkerType::Table, 0);
+	assert_eq!(list.items.len(), 1);
+	assert_eq!(list.items[0].offset, 12);
+	assert_eq!(list.items[0].text, "line3");
+	assert_eq!(list.closest_index, -1);
+	assert_eq!(session.element_list(MarkerType::Table, 12).closest_index, 0);
+}
+
+#[test]
+fn element_list_lists_markers_fall_back_to_the_line_they_sit_on() {
+	// sample_session's List marker at 6 carries no text, and the ListItem marker at the same
+	// offset must not leak into the List rows.
+	let session = sample_session(ParserFlags::NONE);
+	let list = session.element_list(MarkerType::List, 7);
+	assert_eq!(list.items.len(), 1);
+	assert_eq!(list.items[0].offset, 6);
+	assert_eq!(list.items[0].text, "line2");
+	assert_eq!(list.closest_index, 0);
+}
+
+#[test]
+fn element_list_prefers_a_marker_caption_over_the_line_content() {
+	let mut buffer = DocumentBuffer::with_content("Price list    Quantity\n".to_string());
+	buffer.add_marker(Marker::new(MarkerType::Table, 0).with_text("Annual Report".to_string()).with_length(24));
+	let session = session_from_buffer(buffer);
+	let list = session.element_list(MarkerType::Table, 0);
+	assert_eq!(list.items[0].text, "Annual Report");
+}
+
+#[test]
+fn element_list_preserves_the_indented_first_list_line() {
+	let mut buffer = DocumentBuffer::with_content("  - Alpha\n".to_string());
+	buffer.add_marker(Marker::new(MarkerType::List, 0).with_level(1));
+	let session = session_from_buffer(buffer);
+	let list = session.element_list(MarkerType::List, 0);
+	assert_eq!(list.items[0].text, "  - Alpha");
+}
+
+#[test]
+fn element_list_closest_index_tracks_the_last_marker_at_or_before_position() {
+	let mut buffer = DocumentBuffer::with_content("AAA\nBBB\nCCC\n".to_string());
+	// Added out of order to prove rows come back sorted by position.
+	buffer.add_marker(Marker::new(MarkerType::List, 4).with_level(1));
+	buffer.add_marker(Marker::new(MarkerType::List, 0).with_level(1));
+	let session = session_from_buffer(buffer);
+	let rows = session.element_list(MarkerType::List, 4);
+	assert_eq!(rows.items.len(), 2);
+	assert_eq!((rows.items[0].offset, rows.items[0].text.as_str()), (0, "AAA"));
+	assert_eq!((rows.items[1].offset, rows.items[1].text.as_str()), (4, "BBB"));
+	assert_eq!(session.element_list(MarkerType::List, 0).closest_index, 0);
+	assert_eq!(session.element_list(MarkerType::List, 3).closest_index, 0);
+	assert_eq!(session.element_list(MarkerType::List, 4).closest_index, 1);
+}
+
+#[test]
+fn element_list_is_empty_when_the_type_is_absent() {
+	let session = sample_session(ParserFlags::NONE);
+	let list = session.element_list(MarkerType::Image, 0);
+	assert!(list.items.is_empty());
+	assert_eq!(list.closest_index, -1);
+}
+
+#[test]
 fn activate_link_returns_not_found_when_reference_missing() {
 	let mut buffer = DocumentBuffer::with_content("line1\nline2".to_string());
 	buffer.add_marker(Marker::new(MarkerType::Link, 6).with_text("line2".to_string()));

--- a/crates/paperback-core/src/types.rs
+++ b/crates/paperback-core/src/types.rs
@@ -157,6 +157,18 @@ pub struct LinkList {
 }
 
 #[derive(Debug, Clone)]
+pub struct ElementListItem {
+	pub offset: usize,
+	pub text: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct ElementList {
+	pub items: Vec<ElementListItem>,
+	pub closest_index: i32,
+}
+
+#[derive(Debug, Clone)]
 pub struct HeadingTreeItem {
 	pub offset: usize,
 	pub text: String,

--- a/crates/paperback/src/ui/dialogs/elements.rs
+++ b/crates/paperback/src/ui/dialogs/elements.rs
@@ -2,8 +2,7 @@ use std::{cell::Cell, rc::Rc};
 #[cfg(not(target_os = "windows"))]
 use std::{collections::HashMap, ffi::c_void};
 
-use paperback_core::document::MarkerType;
-use paperback_core::session::DocumentSession;
+use paperback_core::{document::MarkerType, session::DocumentSession};
 use patois::t;
 use wx_utils::dpi;
 use wxdragon::prelude::*;

--- a/crates/paperback/src/ui/dialogs/elements.rs
+++ b/crates/paperback/src/ui/dialogs/elements.rs
@@ -2,16 +2,19 @@ use std::{cell::Cell, rc::Rc};
 #[cfg(not(target_os = "windows"))]
 use std::{collections::HashMap, ffi::c_void};
 
+use paperback_core::document::MarkerType;
 use paperback_core::session::DocumentSession;
 use patois::t;
 use wx_utils::dpi;
 use wxdragon::prelude::*;
 
 /// The view choice indices for [`show_elements_dialog`]. Headings is a tree; every other
-/// view (Links, Pages, ...) is a flat list shown in the same list pane.
+/// view (Links, Pages, Tables, Lists, ...) is a flat list shown in the same list pane.
 const VIEW_HEADINGS: u32 = 0;
 const VIEW_LINKS: u32 = 1;
 const VIEW_PAGES: u32 = 2;
+const VIEW_TABLES: u32 = 3;
+const VIEW_LISTS: u32 = 4;
 
 /// Which view of the dialog a jump came from, so the caller can announce it appropriately: a
 /// page row announces like page navigation, while a heading or link reads the line it lands on.
@@ -80,19 +83,35 @@ fn page_label(page: i32, content: &str) -> String {
 }
 
 /// The rows for one flat (non-headings) view: what each row shows, the document offset it
-/// jumps to, and which row is nearest the current position. The Links and Pages views each
-/// have one; the shared list pane is repopulated from whichever is selected.
+/// jumps to, and which row is nearest the current position. The Links, Pages, Tables and Lists
+/// views each have one; the shared list pane is repopulated from whichever is selected.
 struct FlatView {
 	entries: Vec<(String, i64)>,
 	closest: Option<u32>,
 }
 
-fn link_flat_view(session: &DocumentSession, position: i64) -> FlatView {
-	let data = session.link_list(position);
+/// The rows of a document-marker element view (Links, Tables, Lists): each shows the same text
+/// reading navigation announces for that element, and the row nearest the current position is
+/// preselected. A marker with its own text (a table's caption, a link's label) uses it; a
+/// text-less marker (a list) reads the line it sits on.
+fn marker_flat_view(session: &DocumentSession, mtype: MarkerType, position: i64) -> FlatView {
+	let data = session.element_list(mtype, position);
 	let entries =
 		data.items.iter().map(|item| (item.text.clone(), i64::try_from(item.offset).unwrap_or(i64::MAX))).collect();
 	let closest = if data.closest_index >= 0 { u32::try_from(data.closest_index).ok() } else { None };
 	FlatView { entries, closest }
+}
+
+fn link_flat_view(session: &DocumentSession, position: i64) -> FlatView {
+	marker_flat_view(session, MarkerType::Link, position)
+}
+
+fn table_flat_view(session: &DocumentSession, position: i64) -> FlatView {
+	marker_flat_view(session, MarkerType::Table, position)
+}
+
+fn list_flat_view(session: &DocumentSession, position: i64) -> FlatView {
+	marker_flat_view(session, MarkerType::List, position)
 }
 
 fn page_flat_view(session: &DocumentSession, position: i64) -> FlatView {
@@ -102,6 +121,38 @@ fn page_flat_view(session: &DocumentSession, position: i64) -> FlatView {
 		if page >= 1 { u32::try_from(page - 1).ok() } else { None }
 	};
 	FlatView { entries, closest }
+}
+
+/// The flat (non-headings) views, keyed by their `VIEW_*` selection. Holding them together lets
+/// the toggle, double-click and OK handlers look up the active view without threading each view
+/// through as its own argument; a future flat view adds one field here and one arm of
+/// [`FlatViews::view`].
+struct FlatViews {
+	links: FlatView,
+	pages: FlatView,
+	tables: FlatView,
+	lists: FlatView,
+}
+
+impl FlatViews {
+	fn for_session(session: &DocumentSession, position: i64) -> Self {
+		Self {
+			links: link_flat_view(session, position),
+			pages: page_flat_view(session, position),
+			tables: table_flat_view(session, position),
+			lists: list_flat_view(session, position),
+		}
+	}
+
+	const fn view(&self, selection: u32) -> Option<&FlatView> {
+		match selection {
+			VIEW_LINKS => Some(&self.links),
+			VIEW_PAGES => Some(&self.pages),
+			VIEW_TABLES => Some(&self.tables),
+			VIEW_LISTS => Some(&self.lists),
+			_ => None,
+		}
+	}
 }
 
 /// Replaces `list`'s rows with `view`'s, selecting the row nearest the current position.
@@ -116,12 +167,8 @@ fn fill_flat_list(list: ListBox, view: &FlatView) {
 }
 
 /// The offset of the row selected in the flat list pane for `view`, if any.
-fn flat_selected_offset(view: u32, list: ListBox, links: &FlatView, pages: &FlatView) -> Option<i64> {
-	let entries = match view {
-		VIEW_LINKS => &links.entries,
-		VIEW_PAGES => &pages.entries,
-		_ => return None,
-	};
+fn flat_selected_offset(view: u32, list: ListBox, views: &FlatViews) -> Option<i64> {
+	let entries = &views.view(view)?.entries;
 	list.get_selection()
 		.and_then(|index| usize::try_from(index).ok())
 		.and_then(|index| entries.get(index))
@@ -148,17 +195,15 @@ fn show_elements_dialog_dv(parent: &Frame, session: &DocumentSession, current_po
 		build_elements_dialog_ui_dv(dialog);
 	let (selected_offset, item_offsets) = populate_elements_dialog_dv(session, current_pos, headings_tree);
 	let item_offsets = Rc::new(item_offsets);
-	let links = Rc::new(link_flat_view(session, current_pos));
-	let pages = Rc::new(page_flat_view(session, current_pos));
-	bind_elements_view_toggle_dv(view_choice, headings_tree, content_list, dialog, &links, &pages);
+	let views = Rc::new(FlatViews::for_session(session, current_pos));
+	bind_elements_view_toggle_dv(view_choice, headings_tree, content_list, dialog, &views);
 	bind_elements_activation_dv(
 		dialog,
 		view_choice,
 		headings_tree,
 		content_list,
 		&item_offsets,
-		&links,
-		&pages,
+		&views,
 		&selected_offset,
 	);
 	let (ok_button, cancel_button) = build_elements_buttons(dialog);
@@ -168,8 +213,7 @@ fn show_elements_dialog_dv(parent: &Frame, session: &DocumentSession, current_po
 		headings_tree,
 		content_list,
 		&item_offsets,
-		&links,
-		&pages,
+		&views,
 		&selected_offset,
 		ok_button,
 	);
@@ -200,6 +244,10 @@ fn build_elements_dialog_ui_dv(dialog: Dialog) -> ElementsDialogUiDv {
 	view_choice.append(&t("Links"));
 	// TRANSLATORS: Choice option in the view dropdown to show the list of pages
 	view_choice.append(&t("Pages"));
+	// TRANSLATORS: Choice option in the view dropdown to show the list of tables
+	view_choice.append(&t("Tables"));
+	// TRANSLATORS: Choice option in the view dropdown to show the list of lists
+	view_choice.append(&t("Lists"));
 	view_choice.set_selection(VIEW_HEADINGS);
 	#[cfg(target_os = "macos")]
 	view_choice.set_accessibility_label(choice_label_text.replace('&', "").trim_end_matches(':').trim());
@@ -283,14 +331,12 @@ fn bind_elements_view_toggle_dv(
 	headings_tree: DataViewTreeCtrl,
 	content_list: ListBox,
 	dialog: Dialog,
-	links: &Rc<FlatView>,
-	pages: &Rc<FlatView>,
+	views: &Rc<FlatViews>,
 ) {
 	let headings_tree_for_choice = headings_tree;
 	let content_list_for_choice = content_list;
 	let dialog_for_layout = dialog;
-	let links_for_choice = Rc::clone(links);
-	let pages_for_choice = Rc::clone(pages);
+	let views_for_choice = Rc::clone(views);
 	view_choice.on_selection_changed(move |_| {
 		let selection = view_choice.get_selection().unwrap_or(VIEW_HEADINGS);
 		// Switch which pane is shown, repopulating the shared flat list for a non-headings
@@ -303,8 +349,9 @@ fn bind_elements_view_toggle_dv(
 		} else {
 			headings_tree_for_choice.show(false);
 			content_list_for_choice.show(true);
-			let view = if selection == VIEW_LINKS { &links_for_choice } else { &pages_for_choice };
-			fill_flat_list(content_list_for_choice, view);
+			if let Some(view) = views_for_choice.view(selection) {
+				fill_flat_list(content_list_for_choice, view);
+			}
 		}
 		dialog_for_layout.layout();
 	});
@@ -317,8 +364,7 @@ fn bind_elements_activation_dv(
 	headings_tree: DataViewTreeCtrl,
 	content_list: ListBox,
 	item_offsets: &Rc<HashMap<usize, i64>>,
-	links: &Rc<FlatView>,
-	pages: &Rc<FlatView>,
+	views: &Rc<FlatViews>,
 	selected_offset: &Rc<Cell<i64>>,
 ) {
 	let offsets_for_tree = Rc::clone(item_offsets);
@@ -336,16 +382,14 @@ fn bind_elements_activation_dv(
 	});
 	let view_for_list = view_choice;
 	let list_for_click = content_list;
-	let links_for_click = Rc::clone(links);
-	let pages_for_click = Rc::clone(pages);
+	let views_for_click = Rc::clone(views);
 	let selected_for_list = Rc::clone(selected_offset);
 	let dialog_for_list = dialog;
 	content_list.on_item_double_clicked(move |_| {
 		if let Some(offset) = flat_selected_offset(
 			view_for_list.get_selection().unwrap_or(VIEW_HEADINGS),
 			list_for_click,
-			&links_for_click,
-			&pages_for_click,
+			&views_for_click,
 		) {
 			selected_for_list.set(offset);
 			dialog_for_list.end_modal(wxdragon::id::ID_OK);
@@ -360,8 +404,7 @@ fn bind_elements_ok_action_dv(
 	headings_tree: DataViewTreeCtrl,
 	content_list: ListBox,
 	item_offsets: &Rc<HashMap<usize, i64>>,
-	links: &Rc<FlatView>,
-	pages: &Rc<FlatView>,
+	views: &Rc<FlatViews>,
 	selected_offset: &Rc<Cell<i64>>,
 	ok_button: Button,
 ) {
@@ -370,8 +413,7 @@ fn bind_elements_ok_action_dv(
 	let dialog_for_ok = dialog;
 	let view_for_ok = view_choice;
 	let list_for_ok = content_list;
-	let links_for_ok = Rc::clone(links);
-	let pages_for_ok = Rc::clone(pages);
+	let views_for_ok = Rc::clone(views);
 	ok_button.on_click(move |_| {
 		let selection = view_for_ok.get_selection().unwrap_or(VIEW_HEADINGS);
 		if selection == VIEW_HEADINGS {
@@ -383,7 +425,7 @@ fn bind_elements_ok_action_dv(
 					}
 				}
 			}
-		} else if let Some(offset) = flat_selected_offset(selection, list_for_ok, &links_for_ok, &pages_for_ok) {
+		} else if let Some(offset) = flat_selected_offset(selection, list_for_ok, &views_for_ok) {
 			selected_for_ok.set(offset);
 			dialog_for_ok.end_modal(wxdragon::id::ID_OK);
 		}
@@ -408,21 +450,11 @@ fn show_elements_dialog_wx(parent: &Frame, session: &DocumentSession, current_po
 	let dialog = Dialog::builder(parent, &t("Elements")).build();
 	let ElementsDialogUi { content_sizer, view_choice, headings_tree, content_list } = build_elements_dialog_ui(dialog);
 	let selected_offset = populate_elements_dialog(session, current_pos, headings_tree);
-	let links = Rc::new(link_flat_view(session, current_pos));
-	let pages = Rc::new(page_flat_view(session, current_pos));
-	bind_elements_view_toggle(view_choice, headings_tree, content_list, dialog, &links, &pages);
-	bind_elements_activation(dialog, view_choice, headings_tree, content_list, &selected_offset, &links, &pages);
+	let views = Rc::new(FlatViews::for_session(session, current_pos));
+	bind_elements_view_toggle(view_choice, headings_tree, content_list, dialog, &views);
+	bind_elements_activation(dialog, view_choice, headings_tree, content_list, &selected_offset, &views);
 	let (ok_button, cancel_button) = build_elements_buttons(dialog);
-	bind_elements_ok_action(
-		dialog,
-		view_choice,
-		headings_tree,
-		content_list,
-		&selected_offset,
-		&links,
-		&pages,
-		ok_button,
-	);
+	bind_elements_ok_action(dialog, view_choice, headings_tree, content_list, &selected_offset, &views, ok_button);
 	finalize_elements_layout(dialog, content_sizer, ok_button, cancel_button);
 	// The dialog opens on Headings (the choice is set to index 0 when it is built), so the
 	// tree is the visible pane.
@@ -450,6 +482,10 @@ fn build_elements_dialog_ui(dialog: Dialog) -> ElementsDialogUi {
 	view_choice.append(&t("Links"));
 	// TRANSLATORS: Choice option in the view dropdown to show the list of pages
 	view_choice.append(&t("Pages"));
+	// TRANSLATORS: Choice option in the view dropdown to show the list of tables
+	view_choice.append(&t("Tables"));
+	// TRANSLATORS: Choice option in the view dropdown to show the list of lists
+	view_choice.append(&t("Lists"));
 	view_choice.set_selection(VIEW_HEADINGS);
 	#[cfg(target_os = "macos")]
 	view_choice.set_accessibility_label(choice_label_text.replace('&', "").trim_end_matches(':').trim());
@@ -529,14 +565,12 @@ fn bind_elements_view_toggle(
 	headings_tree: TreeCtrl,
 	content_list: ListBox,
 	dialog: Dialog,
-	links: &Rc<FlatView>,
-	pages: &Rc<FlatView>,
+	views: &Rc<FlatViews>,
 ) {
 	let headings_tree_for_choice = headings_tree;
 	let content_list_for_choice = content_list;
 	let dialog_for_layout = dialog;
-	let links_for_choice = Rc::clone(links);
-	let pages_for_choice = Rc::clone(pages);
+	let views_for_choice = Rc::clone(views);
 	view_choice.on_selection_changed(move |_| {
 		let selection = view_choice.get_selection().unwrap_or(VIEW_HEADINGS);
 		// Switch which pane is shown, repopulating the shared flat list for a non-headings
@@ -549,8 +583,9 @@ fn bind_elements_view_toggle(
 		} else {
 			headings_tree_for_choice.show(false);
 			content_list_for_choice.show(true);
-			let view = if selection == VIEW_LINKS { &links_for_choice } else { &pages_for_choice };
-			fill_flat_list(content_list_for_choice, view);
+			if let Some(view) = views_for_choice.view(selection) {
+				fill_flat_list(content_list_for_choice, view);
+			}
 		}
 		dialog_for_layout.layout();
 	});
@@ -563,8 +598,7 @@ fn bind_elements_activation(
 	headings_tree: TreeCtrl,
 	content_list: ListBox,
 	selected_offset: &Rc<Cell<i64>>,
-	links: &Rc<FlatView>,
-	pages: &Rc<FlatView>,
+	views: &Rc<FlatViews>,
 ) {
 	let selected_offset_for_tree = Rc::clone(selected_offset);
 	let tree_for_activate = headings_tree;
@@ -580,16 +614,14 @@ fn bind_elements_activation(
 	});
 	let view_for_list = view_choice;
 	let list_for_click = content_list;
-	let links_for_click = Rc::clone(links);
-	let pages_for_click = Rc::clone(pages);
+	let views_for_click = Rc::clone(views);
 	let selected_for_list = Rc::clone(selected_offset);
 	let dialog_for_list = dialog;
 	content_list.on_item_double_clicked(move |_| {
 		if let Some(offset) = flat_selected_offset(
 			view_for_list.get_selection().unwrap_or(VIEW_HEADINGS),
 			list_for_click,
-			&links_for_click,
-			&pages_for_click,
+			&views_for_click,
 		) {
 			selected_for_list.set(offset);
 			dialog_for_list.end_modal(ID_OK);
@@ -604,16 +636,14 @@ fn bind_elements_ok_action(
 	headings_tree: TreeCtrl,
 	content_list: ListBox,
 	selected_offset: &Rc<Cell<i64>>,
-	links: &Rc<FlatView>,
-	pages: &Rc<FlatView>,
+	views: &Rc<FlatViews>,
 	ok_button: Button,
 ) {
 	let selected_offset_for_ok = Rc::clone(selected_offset);
 	let dialog_for_ok = dialog;
 	let view_for_ok = view_choice;
 	let list_for_ok = content_list;
-	let links_for_ok = Rc::clone(links);
-	let pages_for_ok = Rc::clone(pages);
+	let views_for_ok = Rc::clone(views);
 	ok_button.on_click(move |_| {
 		let selection = view_for_ok.get_selection().unwrap_or(VIEW_HEADINGS);
 		if selection == VIEW_HEADINGS {
@@ -624,7 +654,7 @@ fn bind_elements_ok_action(
 				selected_offset_for_ok.set(*offset);
 				dialog_for_ok.end_modal(ID_OK);
 			}
-		} else if let Some(offset) = flat_selected_offset(selection, list_for_ok, &links_for_ok, &pages_for_ok) {
+		} else if let Some(offset) = flat_selected_offset(selection, list_for_ok, &views_for_ok) {
 			selected_offset_for_ok.set(offset);
 			dialog_for_ok.end_modal(ID_OK);
 		}


### PR DESCRIPTION
## Elements dialog (F7): add Tables and Lists views

Follow-up to the Pages-view work (#775). The Elements dialog's View dropdown now offers
**Headings / Links / Pages / Tables / Lists**. The two new views each show one row per
`Table` / `List` marker in the document — the same containers that Go → Next/Previous Table and
Next/Previous List already jump between.

### Behavior

* A **Tables** row shows the table's caption — the text the table's first row reads, as next/previous
  Table navigation announces it (or, for a table with no caption, the line it sits on).
* A **Lists** row shows the list's first rendered item — exactly what next/previous List navigation
  announces (List markers carry no text of their own).
* No numbering: rows read like the Links view and like container navigation, so what you pick in
  the list and what you hear when you land match.
* Choosing a row (double-click or OK on the selection) jumps to the container and announces the
  landing line, like the Links/Headings views already do — no change to `ElementsKind`, the
  announcement code, or `navigation.rs`.

### What changed

* **`paperback-core`** — new `DocumentSession::element_list(mtype, position)`, returning one row
  per marker of a type with the text reading navigation announces, plus the row nearest the
  current position so the dialog can preselect it. `link_list` is now a thin wrapper over it.
  New `ElementListItem`/`ElementList` types and unit tests cover captions, the line-text
  fallback, closest-index tracking, and that `ListItem` markers don't leak into the Lists view.
* **`paperback`** — `Tables` and `Lists` entries in the View dropdown on both the Windows and the
  macOS/Linux (DataView) code paths. The two `Rc<FlatView>` arguments threaded through the
  toggle/double-click/OK handlers are grouped into a single `FlatViews` struct keyed by view, so
  a future flat view stays a one-entry change (the pattern the Pages view set up).

Two new translatable strings: `"Tables"` and `"Lists"` (they'll reach the translators through
the usual auto-translate workflow).

### Testing

* Confirmed working on **Windows** (release build) with PDFs — tables and lists appear in the
  Elements dialog and jumps land correctly.
* `cargo test -p paperback-core` (663 tests) and `cargo clippy` pass.
* The macOS/Linux DataView half is edited symmetrically but was **not** compiled or run on this
  machine (Windows host) — it needs a check there before relying on it.
