### PR TITLE
Android: keep the position a table of contents jump moved to, part two

### DIFF
--- a/android/app/src/main/kotlin/dev/paperback/android/ui/ListScrollPosition.kt
+++ b/android/app/src/main/kotlin/dev/paperback/android/ui/ListScrollPosition.kt
@@ -1,0 +1,23 @@
+package dev.paperback.android.ui
+
+import kotlinx.coroutines.FlowPreview
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.debounce
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.drop
+
+/** How long the list has to stand still before where it stopped becomes the reading position. */
+private const val SCROLL_SETTLE_MS = 500L
+
+/**
+ * The scroll indices of a text list that are worth saving as the reading position.
+ *
+ * A list reports where it already is as soon as anything listens, and that first value is not a
+ * place the reader went. MainScreen is composed afresh every time another screen is popped off
+ * the back stack, and the list it builds then starts at the index the document was opened at
+ * rather than wherever reading has since got to, so saving that value replaces a section chosen
+ * in the table of contents with the start of the book. Everything after it is a real scroll,
+ * reported once the list has settled.
+ */
+@OptIn(FlowPreview::class)
+fun Flow<Int>.scrollsWorthSaving(): Flow<Int> = distinctUntilChanged().drop(1).debounce(SCROLL_SETTLE_MS)

--- a/android/app/src/main/kotlin/dev/paperback/android/ui/MainScreen.kt
+++ b/android/app/src/main/kotlin/dev/paperback/android/ui/MainScreen.kt
@@ -34,9 +34,6 @@ import dev.paperback.android.SettingsRoute
 import dev.paperback.android.t
 import dev.paperback.android.ui.dialogs.*
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.FlowPreview
-import kotlinx.coroutines.flow.debounce
-import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import java.io.File
@@ -55,7 +52,7 @@ internal fun needsNotificationPermission(context: Context): Boolean =
 		ContextCompat.checkSelfPermission(context, Manifest.permission.POST_NOTIFICATIONS) !=
 		PackageManager.PERMISSION_GRANTED
 
-@OptIn(ExperimentalMaterial3Api::class, FlowPreview::class)
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun MainScreen(
 	modifier: Modifier = Modifier,
@@ -493,8 +490,7 @@ fun MainScreen(
 							}
 							LaunchedEffect(docState.documentUri) {
 								snapshotFlow { listState.firstVisibleItemIndex }
-									.distinctUntilChanged()
-									.debounce(500)
+									.scrollsWorthSaving()
 									.collect { index -> viewModel.savePosition(docState.session, docState.documentUri, index) }
 							}
 							if (!isTextMode) {

--- a/android/app/src/test/kotlin/dev/paperback/android/ui/ListScrollPositionTest.kt
+++ b/android/app/src/test/kotlin/dev/paperback/android/ui/ListScrollPositionTest.kt
@@ -1,0 +1,48 @@
+package dev.paperback.android.ui
+
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class ListScrollPositionTest {
+	// The case behind issue #794: the reader picks a chapter in the table of contents, the list
+	// is rebuilt at the index the document was opened at, and saving that opening index sends
+	// read-aloud back to the start of the book.
+	@Test
+	fun `the index the list starts at is not saved`() =
+		runTest {
+			assertEquals(emptyList<Int>(), flowOf(120).scrollsWorthSaving().toList())
+		}
+
+	@Test
+	fun `a scroll after the starting index is saved`() =
+		runTest {
+			assertEquals(listOf(140), flowOf(120, 140).scrollsWorthSaving().toList())
+		}
+
+	@Test
+	fun `only where a scroll came to rest is saved`() =
+		runTest {
+			val scroll = flow {
+				emit(120)
+				emit(121)
+				emit(122)
+				delay(1000)
+				emit(200)
+				emit(201)
+			}
+			assertEquals(listOf(122, 201), scroll.scrollsWorthSaving().toList())
+		}
+
+	@Test
+	fun `a repeated index is reported once`() =
+		runTest {
+			assertEquals(listOf(140), flowOf(120, 140, 140).scrollsWorthSaving().toList())
+		}
+}


### PR DESCRIPTION
Closes #794.

Picking a chapter in the table of contents while read-aloud was running still sent the reader back to the start of the book a moment later. #743 fixed one of the two paths that did this; here is the other.

The reading position is also saved from the text list's scroll offset:

```kotlin
snapshotFlow { listState.firstVisibleItemIndex }.distinctUntilChanged().debounce(500)
```

`snapshotFlow` reports where the list already is as soon as anything collects it. Opening the table of contents pops MainScreen off the back stack, so coming back composes it afresh and builds a new `LazyListState` at `initialScrollIndex`, the line the document was opened at. That opening index is the flow's first value, and half a second later `savePosition` writes it over the section just chosen, in `_ttsPosition` and in the config both. The title and the paragraph after it were already queued with the text-to-speech engine, so they play before the jump shows up, which is why it looks like the book reads on for a sentence or two and then starts over.

The first value a list reports is never a place the reader went, so it is not saved. Everything after it is a real scroll.