### PR TITLE
Find All: list every line with a match from the Find dialog

### DIFF
--- a/crates/paperback-core/src/reader_core.rs
+++ b/crates/paperback-core/src/reader_core.rs
@@ -12,4 +12,4 @@ pub use bookmarks::{bookmark_navigate, bookmark_note_at_position, get_filtered_b
 pub use history::{HistoryNavResult, history_go_next, history_go_previous, record_history_position};
 pub use links::{LinkNavigation, encode_url_fragment, nearest_fragment_before, resolve_link};
 pub use navigation::{reader_container_navigate, reader_navigate};
-pub use search::{SearchOptions, reader_search, reader_search_with_wrap};
+pub use search::{SearchOptions, reader_search, reader_search_all, reader_search_with_wrap};

--- a/crates/paperback-core/src/reader_core/search.rs
+++ b/crates/paperback-core/src/reader_core/search.rs
@@ -2,7 +2,7 @@
 //! (display positions are UTF-16 code units) and wrap-around retry.
 
 use bitflags::bitflags;
-use regex::RegexBuilder;
+use regex::{Regex, RegexBuilder};
 
 use crate::types as ffi;
 
@@ -16,35 +16,33 @@ bitflags! {
 	}
 }
 
-#[must_use]
-pub fn reader_search(haystack: &str, needle: &str, start: i64, options: SearchOptions) -> i64 {
-	if needle.is_empty() {
-		return -1;
+fn utf16_to_byte_index(s: &str, utf16_idx: usize) -> usize {
+	let mut utf16_count = 0usize;
+	for (byte_idx, ch) in s.char_indices() {
+		let len16 = ch.len_utf16();
+		if utf16_count >= utf16_idx {
+			return byte_idx;
+		}
+		utf16_count += len16;
 	}
-	let start_utf16 = usize::try_from(start.clamp(0, i64::MAX)).unwrap_or(0);
-	let utf16_to_byte_index = |s: &str, utf16_idx: usize| -> usize {
-		let mut utf16_count = 0usize;
-		for (byte_idx, ch) in s.char_indices() {
-			let len16 = ch.len_utf16();
-			if utf16_count >= utf16_idx {
-				return byte_idx;
-			}
-			utf16_count += len16;
+	s.len()
+}
+
+fn byte_to_utf16_index(s: &str, byte_idx: usize) -> usize {
+	let mut utf16_count = 0usize;
+	for (idx, ch) in s.char_indices() {
+		if idx >= byte_idx {
+			break;
 		}
-		s.len()
-	};
-	let byte_to_utf16_index = |s: &str, byte_idx: usize| -> usize {
-		let mut utf16_count = 0usize;
-		for (idx, ch) in s.char_indices() {
-			if idx >= byte_idx {
-				break;
-			}
-			utf16_count += ch.len_utf16();
-		}
-		utf16_count
-	};
-	let start_byte = utf16_to_byte_index(haystack, start_utf16);
-	// Build regex for search - this avoids copying/lowercasing the entire haystack
+		utf16_count += ch.len_utf16();
+	}
+	utf16_count
+}
+
+/// The matcher both `reader_search` and `reader_search_all` run, honouring `options`: the needle
+/// is escaped unless it is already a regex, wrapped in `\b…\b` for whole-word search, and matched
+/// case-insensitively unless `MATCH_CASE` is set. `None` for an invalid regex.
+fn build_matcher(needle: &str, options: SearchOptions) -> Option<Regex> {
 	let escaped_needle =
 		if options.contains(SearchOptions::REGEX) { needle.to_string() } else { regex::escape(needle) };
 	let pattern =
@@ -53,7 +51,18 @@ pub fn reader_search(haystack: &str, needle: &str, start: i64, options: SearchOp
 	if !options.contains(SearchOptions::MATCH_CASE) {
 		builder.case_insensitive(true);
 	}
-	let Ok(re) = builder.build() else {
+	builder.build().ok()
+}
+
+#[must_use]
+pub fn reader_search(haystack: &str, needle: &str, start: i64, options: SearchOptions) -> i64 {
+	if needle.is_empty() {
+		return -1;
+	}
+	let start_utf16 = usize::try_from(start.clamp(0, i64::MAX)).unwrap_or(0);
+	let start_byte = utf16_to_byte_index(haystack, start_utf16);
+	// Build regex for search - this avoids copying/lowercasing the entire haystack.
+	let Some(re) = build_matcher(needle, options) else {
 		return -1;
 	};
 	if options.contains(SearchOptions::FORWARD) {
@@ -74,6 +83,27 @@ pub fn reader_search(haystack: &str, needle: &str, start: i64, options: SearchOp
 		}
 	}
 	-1
+}
+
+/// Every match of `needle` in `haystack`, as UTF-16 `(start, end)` spans in document order.
+/// Direction and wrap have no meaning here. Zero-length matches (e.g. an empty `x*` regex match)
+/// are skipped; an empty needle or an invalid regex yields no spans.
+#[must_use]
+pub fn reader_search_all(haystack: &str, needle: &str, options: SearchOptions) -> Vec<(i64, i64)> {
+	if needle.is_empty() {
+		return Vec::new();
+	}
+	let Some(re) = build_matcher(needle, options) else {
+		return Vec::new();
+	};
+	re.find_iter(haystack)
+		.filter(|m| m.start() != m.end())
+		.map(|m| {
+			let start = i64::try_from(byte_to_utf16_index(haystack, m.start())).unwrap_or(-1);
+			let end = i64::try_from(byte_to_utf16_index(haystack, m.end())).unwrap_or(-1);
+			(start, end)
+		})
+		.collect()
 }
 
 #[must_use]
@@ -171,5 +201,65 @@ mod tests {
 		assert!(result.found);
 		assert!(result.wrapped);
 		assert_eq!(result.position, 3);
+	}
+
+	#[test]
+	fn reader_search_all_returns_every_plain_match_in_order() {
+		let haystack = "blah on page one, blah again, and blah";
+		let options = SearchOptions::empty();
+		let spans = reader_search_all(haystack, "blah", options);
+		assert_eq!(spans.len(), 3);
+		assert_eq!(spans[0].0, 0);
+		// "blah" is four ASCII chars, so every span is four UTF-16 units long.
+		assert!(spans.iter().all(|(start, end)| end - start == 4));
+		assert!(spans.windows(2).all(|w| w[0].0 < w[1].0));
+	}
+
+	#[test]
+	fn reader_search_all_respects_match_case() {
+		let haystack = "Hello hello HELLO";
+		let case_sensitive = SearchOptions::MATCH_CASE;
+		assert_eq!(reader_search_all(haystack, "hello", case_sensitive).len(), 1);
+		let insensitive = SearchOptions::empty();
+		assert_eq!(reader_search_all(haystack, "hello", insensitive).len(), 3);
+	}
+
+	#[test]
+	fn reader_search_all_respects_whole_word() {
+		let haystack = "the cat and the theater";
+		let options = SearchOptions::WHOLE_WORD;
+		assert_eq!(reader_search_all(haystack, "the", options).len(), 2);
+		let options = SearchOptions::empty();
+		assert_eq!(reader_search_all(haystack, "the", options).len(), 3);
+	}
+
+	#[test]
+	fn reader_search_all_regex_spans_the_actual_match() {
+		let haystack = "12 and 345 and 6";
+		let options = SearchOptions::REGEX;
+		let spans = reader_search_all(haystack, r"\d+", options);
+		assert_eq!(spans.len(), 3);
+		// Each span covers the whole run of digits, not just one.
+		assert_eq!((spans[0].1 - spans[0].0), 2);
+		assert_eq!((spans[1].1 - spans[1].0), 3);
+		assert_eq!((spans[2].1 - spans[2].0), 1);
+	}
+
+	#[test]
+	fn reader_search_all_skips_zero_length_matches() {
+		// `a*` also matches the empty gaps between characters; only the real run should survive.
+		let haystack = "aaab";
+		let options = SearchOptions::REGEX;
+		let spans = reader_search_all(haystack, "a*", options);
+		assert_eq!(spans.len(), 1);
+		assert_eq!((spans[0].0, spans[0].1), (0, 3));
+	}
+
+	#[test]
+	fn reader_search_all_invalid_regex_yields_no_spans() {
+		let haystack = "abc";
+		let options = SearchOptions::REGEX;
+		assert!(reader_search_all(haystack, "(", options).is_empty());
+		assert!(reader_search_all(haystack, "", options).is_empty());
 	}
 }

--- a/crates/paperback-core/src/session.rs
+++ b/crates/paperback-core/src/session.rs
@@ -8,12 +8,14 @@ use crate::{
 
 mod audio;
 mod export;
+mod find_all;
 mod links;
 mod navigation;
 mod search;
 mod stats;
 mod window;
 
+pub use find_all::{FindAllLine, FindSpan};
 pub use window::WindowSlice;
 
 const MAX_HISTORY_LEN: usize = 10;

--- a/crates/paperback-core/src/session/find_all.rs
+++ b/crates/paperback-core/src/session/find_all.rs
@@ -1,0 +1,64 @@
+//! The Find All result rows: every line of a document that holds at least one match for a
+//! query, in document order, each with the page it sits on and the full list of that line's
+//! match spans. Built by [`DocumentSession::find_all_lines`] from
+//! [`crate::reader_core::reader_search_all`]; the UI renders one row per line and jumps to the
+//! chosen match span.
+
+use super::DocumentSession;
+use crate::reader_core::SearchOptions;
+
+/// One match's extent, in the same display units (UTF-16 code units on Windows/macOS) as the
+/// GUI caret and page markers, so a caller can hand it straight to a range selector.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct FindSpan {
+	pub start: i64,
+	pub end: i64,
+}
+
+/// One result line: the trimmed text of a line holding at least one match, the page it is on
+/// (`0` when the document has no page markers), and every match's span on that line.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FindAllLine {
+	pub text: String,
+	pub page: i32,
+	pub matches: Vec<FindSpan>,
+}
+
+impl DocumentSession {
+	/// Every line that contains at least one match of `query`, one row per distinct line in
+	/// document order (a line holding several matches appears once). Match spans and the `page`
+	/// are computed in display units, so a caller can compare spans against the caret and select
+	/// ranges without further conversion. Returns an empty list for an empty query, an invalid
+	/// regex, or a document with no matches.
+	#[must_use]
+	pub fn find_all_lines(&self, query: &str, options: SearchOptions) -> Vec<FindAllLine> {
+		let buffer = &self.handle.document().buffer;
+		let matches = crate::reader_core::reader_search_all(&buffer.content, query, options);
+		if matches.is_empty() {
+			return Vec::new();
+		}
+		let newline_bytes: Vec<usize> = buffer.content.match_indices('\n').map(|(idx, _)| idx).collect();
+		let content_len = buffer.content.len();
+		let mut rows: Vec<FindAllLine> = Vec::new();
+		let mut open_line_start: Option<usize> = None;
+		for (start, end) in matches {
+			let start_byte = buffer.byte_index_for_display(usize::try_from(start.max(0)).unwrap_or(0)).min(content_len);
+			let line_idx = newline_bytes.partition_point(|&p| p < start_byte);
+			let line_start = if line_idx == 0 { 0 } else { newline_bytes[line_idx - 1] + 1 };
+			let line_end = newline_bytes.get(line_idx).copied().unwrap_or(content_len);
+			if open_line_start != Some(line_start) {
+				let text = buffer.content[line_start..line_end].trim().to_string();
+				if text.is_empty() {
+					continue;
+				}
+				let page = if self.page_count() > 0 { self.current_page(start).max(1) } else { 0 };
+				rows.push(FindAllLine { text, page, matches: Vec::new() });
+				open_line_start = Some(line_start);
+			}
+			if let Some(row) = rows.last_mut() {
+				row.matches.push(FindSpan { start, end });
+			}
+		}
+		rows
+	}
+}

--- a/crates/paperback-core/src/session/tests.rs
+++ b/crates/paperback-core/src/session/tests.rs
@@ -3,6 +3,7 @@ use crate::document::{Document, DocumentBuffer, Marker};
 
 mod accessors;
 mod audio;
+mod find_all;
 mod links;
 mod navigation;
 mod webview;

--- a/crates/paperback-core/src/session/tests/find_all.rs
+++ b/crates/paperback-core/src/session/tests/find_all.rs
@@ -1,0 +1,130 @@
+use super::*;
+use crate::reader_core::SearchOptions;
+
+fn session_with_marks(content: &str, markers: Vec<Marker>) -> DocumentSession {
+	let mut buffer = DocumentBuffer::with_content(content.to_string());
+	for marker in markers {
+		buffer.add_marker(marker);
+	}
+	let mut doc = Document::new().with_title("Title".to_string()).with_author("Author".to_string());
+	doc.set_buffer(buffer);
+	DocumentSession {
+		handle: DocumentHandle::new(doc),
+		file_path: "book.epub".to_string(),
+		history: Vec::new(),
+		history_index: 0,
+		parser_flags: ParserFlags::empty(),
+		last_stable_position: None,
+	}
+}
+
+#[test]
+fn find_all_groups_by_line_and_orders_rows() {
+	let session = session_with_content("alpha beta\ngamma beta\n\ndelta beta\n");
+	let rows = session.find_all_lines("beta", SearchOptions::empty());
+	assert_eq!(rows.len(), 3, "the blank middle line holds no match and is skipped");
+	assert_eq!(rows[0].text, "alpha beta");
+	assert_eq!(rows[1].text, "gamma beta");
+	assert_eq!(rows[2].text, "delta beta");
+	assert_eq!(rows[0].page, 0);
+	assert!(rows.iter().all(|row| row.matches.len() == 1));
+}
+
+#[test]
+fn find_all_dedupes_by_line_identity_not_text() {
+	let session = session_with_content("same word same\nother\nsame word same\n");
+	let rows = session.find_all_lines("same", SearchOptions::empty());
+	assert_eq!(rows.len(), 2, "two identical sentences on two lines are two rows");
+	assert_eq!(rows[0].text, "same word same");
+	assert_eq!(rows[1].text, "same word same");
+	assert_eq!(rows[0].matches.len(), 2, "both occurrences on the line are kept on its one row");
+	assert_eq!(rows[1].matches.len(), 2);
+	assert_eq!((rows[0].matches[0].start, rows[0].matches[0].end), (0, 4));
+	assert_eq!((rows[0].matches[1].start, rows[0].matches[1].end), (10, 14));
+}
+
+#[test]
+fn find_all_multiple_matches_on_a_line_preserve_order() {
+	let session = session_with_content("a a a\n");
+	let rows = session.find_all_lines("a", SearchOptions::empty());
+	assert_eq!(rows.len(), 1);
+	let spans = &rows[0].matches;
+	assert_eq!(spans.len(), 3);
+	assert_eq!((spans[0].start, spans[0].end), (0, 1));
+	assert_eq!((spans[1].start, spans[1].end), (2, 3));
+	assert_eq!((spans[2].start, spans[2].end), (4, 5));
+}
+
+#[test]
+fn find_all_respects_case_and_whole_word() {
+	let session = session_with_content("The cat. the the theatre\n");
+	let options = SearchOptions::WHOLE_WORD | SearchOptions::MATCH_CASE;
+	let rows = session.find_all_lines("the", options);
+	assert_eq!(rows.len(), 1);
+	assert_eq!(rows[0].matches.len(), 2, "\"The\" and \"theatre\" are excluded");
+}
+
+#[test]
+fn find_all_uses_regex_and_real_spans() {
+	let session = session_with_content("a12 b345 c6\n");
+	let rows = session.find_all_lines(r"\d+", SearchOptions::REGEX);
+	assert_eq!(rows.len(), 1);
+	let spans = &rows[0].matches;
+	assert_eq!(spans.len(), 3);
+	assert_eq!((spans[0].start, spans[0].end), (1, 3));
+	assert_eq!((spans[1].start, spans[1].end), (5, 8));
+	assert_eq!((spans[2].start, spans[2].end), (10, 11));
+}
+
+#[test]
+fn find_all_without_page_markers_reports_page_zero() {
+	let session = session_with_content("just beta here\n");
+	let rows = session.find_all_lines("beta", SearchOptions::empty());
+	assert_eq!(rows.len(), 1);
+	assert_eq!(rows[0].page, 0);
+}
+
+#[test]
+fn find_all_assigns_pages_from_page_break_markers() {
+	// Three lines of identical length; a PageBreak marker sits at each line's start.
+	let session = session_with_marks(
+		"aaa beta\nbbb beta\nccc beta\n",
+		vec![
+			Marker::new(MarkerType::PageBreak, 0),
+			Marker::new(MarkerType::PageBreak, 9),
+			Marker::new(MarkerType::PageBreak, 18),
+		],
+	);
+	let rows = session.find_all_lines("beta", SearchOptions::empty());
+	assert_eq!(rows.len(), 3);
+	let pages: Vec<i32> = rows.iter().map(|row| row.page).collect();
+	assert_eq!(pages, vec![1, 2, 3]);
+}
+
+#[test]
+fn find_all_keeps_the_whole_line_across_an_astral_char() {
+	// The emoji is inside the line, between the two matches; the row must still be the whole
+	// line, whichever side of the astral character the match sits on.
+	let session = session_with_content("beta 😀 beta\n");
+	let rows = session.find_all_lines("beta", SearchOptions::empty());
+	assert_eq!(rows.len(), 1);
+	assert_eq!(rows[0].text, "beta 😀 beta");
+	assert_eq!(rows[0].matches.len(), 2);
+}
+
+#[cfg(any(target_os = "windows", target_os = "macos"))]
+#[test]
+fn find_all_reports_utf16_spans_past_an_astral_char() {
+	// On Windows/macOS the display unit is a UTF-16 code unit, so the emoji is two units and the
+	// second match starts at 8.
+	let session = session_with_content("beta 😀 beta\n");
+	let rows = session.find_all_lines("beta", SearchOptions::empty());
+	assert_eq!((rows[0].matches[1].start, rows[0].matches[1].end), (8, 12));
+}
+
+#[test]
+fn find_all_is_empty_for_no_matches_or_empty_query() {
+	let session = session_with_content("nothing to see\n");
+	assert!(session.find_all_lines("zzz", SearchOptions::empty()).is_empty());
+	assert!(session.find_all_lines("", SearchOptions::empty()).is_empty());
+}

--- a/crates/paperback/src/ui/find.rs
+++ b/crates/paperback/src/ui/find.rs
@@ -1,7 +1,11 @@
-use std::{cell::Cell, rc::Rc, sync::Mutex};
+use std::{
+	cell::{Cell, RefCell},
+	rc::Rc,
+	sync::Mutex,
+};
 
 use bitflags::bitflags;
-use paperback_core::{config::ConfigManager, reader_core, util::text::display_len};
+use paperback_core::{config::ConfigManager, reader_core, session::FindAllLine, util::text::display_len};
 use patois::t;
 use wx_utils::dpi;
 use wxdragon::prelude::*;
@@ -49,14 +53,33 @@ pub fn find_text_with_wrap(haystack: &str, needle: &str, start: i64, options: Fi
 	SearchResult { found: result.found, wrapped: result.wrapped, position: result.position }
 }
 
+/// Which of the dialog's two views is showing: the query (find-what, options, find buttons) or
+/// the Find All results list. Switching hides one view's windows and shows the other's, then
+/// refits the dialog, so Enter always triggers the visible primary button.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum FindView {
+	Query,
+	Results,
+}
+
 #[derive(Clone)]
 pub struct FindDialogState {
 	pub dialog: Dialog,
+	find_label: StaticText,
 	find_combo: ComboBox,
+	options_static_box: Option<StaticBox>,
 	match_case: CheckBox,
 	whole_word: CheckBox,
 	use_regex: CheckBox,
+	find_prev_btn: Button,
+	find_next_btn: Button,
+	find_all_btn: Button,
+	results_list: ListBox,
+	go_btn: Button,
 	in_progress: Rc<Cell<bool>>,
+	view: Rc<Cell<FindView>>,
+	origin: Rc<Cell<i64>>,
+	result_rows: Rc<RefCell<Vec<FindAllLine>>>,
 }
 
 impl FindDialogState {
@@ -70,13 +93,18 @@ impl FindDialogState {
 		// TRANSLATORS: Title of the Find dialog
 		let dialog = Dialog::builder(frame, &t("Find")).build();
 		let FindDialogWidgets {
+			find_label,
 			find_combo,
+			options_static_box,
 			match_case,
 			whole_word,
 			use_regex,
 			find_prev_btn,
 			find_next_btn,
+			find_all_btn,
 			cancel_btn,
+			results_list,
+			go_btn,
 		} = build_find_dialog_ui(dialog);
 		bind_find_dialog_actions(FindDialogActionParams {
 			frame: *frame,
@@ -84,14 +112,33 @@ impl FindDialogState {
 			find_combo,
 			find_prev_btn,
 			find_next_btn,
+			find_all_btn,
+			go_btn,
+			results_list,
 			cancel_btn,
 			config: Rc::clone(config),
 			doc_manager: Rc::clone(doc_manager),
 			find_dialog: Rc::clone(find_dialog),
 			live_region_label,
 		});
-		let state =
-			Self { dialog, find_combo, match_case, whole_word, use_regex, in_progress: Rc::new(Cell::new(false)) };
+		let state = Self {
+			dialog,
+			find_label,
+			find_combo,
+			options_static_box,
+			match_case,
+			whole_word,
+			use_regex,
+			find_prev_btn,
+			find_next_btn,
+			find_all_btn,
+			results_list,
+			go_btn,
+			in_progress: Rc::new(Cell::new(false)),
+			view: Rc::new(Cell::new(FindView::Query)),
+			origin: Rc::new(Cell::new(0)),
+			result_rows: Rc::new(RefCell::new(Vec::new())),
+		};
 		state.reload_history(config);
 		state.save_settings(config);
 		state
@@ -148,16 +195,74 @@ impl FindDialogState {
 		}
 		Some(FindInProgressGuard { flag: Rc::clone(&self.in_progress) })
 	}
+
+	/// Shows or hides every window that belongs to the query view. The Cancel button is shared by
+	/// both views, so it is not part of either set.
+	fn set_query_windows(&self, visible: bool) {
+		self.find_label.show(visible);
+		self.find_combo.show(visible);
+		if let Some(static_box) = &self.options_static_box {
+			static_box.show(visible);
+		}
+		self.match_case.show(visible);
+		self.whole_word.show(visible);
+		self.use_regex.show(visible);
+		self.find_prev_btn.show(visible);
+		self.find_next_btn.show(visible);
+		self.find_all_btn.show(visible);
+	}
+
+	/// Shows or hides every window that belongs to the Find All results view.
+	fn set_results_windows(&self, visible: bool) {
+		self.results_list.show(visible);
+		self.go_btn.show(visible);
+	}
+
+	/// Refits the dialog to whichever view is showing.
+	fn refit(&self) {
+		self.dialog.layout();
+		self.dialog.fit();
+		self.dialog.centre();
+	}
+
+	/// Shows the query view, hiding the results view if it is showing.
+	fn switch_to_query_view(&self) {
+		if self.view.get() == FindView::Query {
+			return;
+		}
+		self.set_query_windows(true);
+		self.set_results_windows(false);
+		self.view.set(FindView::Query);
+		self.find_next_btn.set_default();
+		self.refit();
+	}
+
+	/// Shows the Find All results view, hiding the query view if it is showing.
+	fn switch_to_results_view(&self) {
+		if self.view.get() == FindView::Results {
+			return;
+		}
+		self.set_query_windows(false);
+		self.set_results_windows(true);
+		self.view.set(FindView::Results);
+		self.go_btn.set_default();
+		self.refit();
+	}
 }
 
 struct FindDialogWidgets {
+	find_label: StaticText,
 	find_combo: ComboBox,
+	options_static_box: Option<StaticBox>,
 	match_case: CheckBox,
 	whole_word: CheckBox,
 	use_regex: CheckBox,
 	find_prev_btn: Button,
 	find_next_btn: Button,
+	find_all_btn: Button,
 	cancel_btn: Button,
+	results_list: ListBox,
+	go_btn: Button,
 }
 
 struct FindDialogActionParams {
@@ -166,6 +271,9 @@ struct FindDialogActionParams {
 	find_combo: ComboBox,
 	find_prev_btn: Button,
 	find_next_btn: Button,
+	find_all_btn: Button,
+	go_btn: Button,
+	results_list: ListBox,
 	cancel_btn: Button,
 	config: Rc<Mutex<ConfigManager>>,
 	doc_manager: Rc<Mutex<DocumentManager>>,
@@ -185,6 +293,7 @@ fn build_find_dialog_ui(dialog: Dialog) -> FindDialogWidgets {
 		.build();
 	// TRANSLATORS: Group box heading for the search options in the Find dialog
 	let options_box = StaticBoxSizerBuilder::new_with_label(Orientation::Vertical, &dialog, &t("Options")).build();
+	let options_static_box = options_box.get_static_box();
 	// TRANSLATORS: Checkbox to make the search case-sensitive
 	let match_case = CheckBox::builder(&dialog).with_label(&t("&Match case")).build();
 	// TRANSLATORS: Checkbox to only match whole words, not substrings
@@ -198,6 +307,8 @@ fn build_find_dialog_ui(dialog: Dialog) -> FindDialogWidgets {
 	let find_prev_btn = Button::builder(&dialog).with_label(&t("Find &Previous")).build();
 	// TRANSLATORS: Button to search forward for the next match
 	let find_next_btn = Button::builder(&dialog).with_id(ID_OK).with_label(&t("Find &Next")).build();
+	// TRANSLATORS: Button that finds and lists every occurrence of the search text
+	let find_all_btn = Button::builder(&dialog).with_label(&t("Find &All")).build();
 	// TRANSLATORS: Cancel button that closes the Find dialog
 	let cancel_btn = Button::builder(&dialog).with_id(ID_CANCEL).with_label(&t("Cancel")).build();
 	dialog.set_escape_id(ID_CANCEL);
@@ -208,8 +319,28 @@ fn build_find_dialog_ui(dialog: Dialog) -> FindDialogWidgets {
 	let button_sizer = BoxSizer::builder(Orientation::Horizontal).build();
 	button_sizer.add(&find_prev_btn, 0, SizerFlag::Right, button_spacing);
 	button_sizer.add(&find_next_btn, 0, SizerFlag::Right, button_spacing);
-	button_sizer.add_stretch_spacer(1);
-	button_sizer.add(&cancel_btn, 0, SizerFlag::All, 0);
+	button_sizer.add(&find_all_btn, 0, SizerFlag::Right, button_spacing);
+	// The Find All results view, hidden until a search with matches switches to it.
+	let results_sizer = BoxSizer::builder(Orientation::Vertical).build();
+	let results_list = ListBox::builder(&dialog).with_size(dpi::scale_size(&dialog, Size::new(400, 500))).build();
+	// TRANSLATORS: Accessible name of the list of Find All results
+	results_list.set_accessibility_label(&t("Results"));
+	results_sizer.add(&results_list, 1, SizerFlag::Expand | SizerFlag::All, DIALOG_PADDING);
+	let results_button_sizer = BoxSizer::builder(Orientation::Horizontal).build();
+	// TRANSLATORS: Button that jumps to the selected find result
+	let go_btn = Button::builder(&dialog).with_label(&t("&Go")).build();
+	results_button_sizer.add(&go_btn, 0, SizerFlag::Right, button_spacing);
+	results_sizer.add_sizer(
+		&results_button_sizer,
+		0,
+		SizerFlag::Expand | SizerFlag::Left | SizerFlag::Right | SizerFlag::Bottom,
+		DIALOG_PADDING,
+	);
+	// A single Cancel is shared by both views and always visible, so Escape always maps to one
+	// available button.
+	let cancel_sizer = BoxSizer::builder(Orientation::Horizontal).build();
+	cancel_sizer.add_stretch_spacer(1);
+	cancel_sizer.add(&cancel_btn, 0, SizerFlag::All, 0);
 	let main_sizer = BoxSizer::builder(Orientation::Vertical).build();
 	main_sizer.add_sizer(&find_sizer, 0, SizerFlag::Expand | SizerFlag::All, DIALOG_PADDING);
 	main_sizer.add_sizer(
@@ -224,9 +355,56 @@ fn build_find_dialog_ui(dialog: Dialog) -> FindDialogWidgets {
 		SizerFlag::Expand | SizerFlag::Left | SizerFlag::Right | SizerFlag::Bottom,
 		DIALOG_PADDING,
 	);
+	main_sizer.add_sizer(
+		&results_sizer,
+		0,
+		SizerFlag::Expand | SizerFlag::Left | SizerFlag::Right | SizerFlag::Bottom,
+		DIALOG_PADDING,
+	);
+	main_sizer.add_sizer(
+		&cancel_sizer,
+		0,
+		SizerFlag::Expand | SizerFlag::Left | SizerFlag::Right | SizerFlag::Bottom,
+		DIALOG_PADDING,
+	);
+	// Open on the query view: hide the results windows before sizing so the dialog starts small.
+	results_list.show(false);
+	go_btn.show(false);
+	find_next_btn.set_default();
 	dialog.set_sizer_and_fit(main_sizer, true);
 	dialog.centre();
-	FindDialogWidgets { find_combo, match_case, whole_word, use_regex, find_prev_btn, find_next_btn, cancel_btn }
+	FindDialogWidgets {
+		find_label,
+		find_combo,
+		options_static_box,
+		match_case,
+		whole_word,
+		use_regex,
+		find_prev_btn,
+		find_next_btn,
+		find_all_btn,
+		cancel_btn,
+		results_list,
+		go_btn,
+	}
+}
+
+/// Binds a Cancel button to hide the dialog and save its settings.
+fn bind_cancel_button(
+	button: Button,
+	dialog: Dialog,
+	find_dialog: &Rc<Mutex<Option<FindDialogState>>>,
+	config: &Rc<Mutex<ConfigManager>>,
+) {
+	let dialog_for_cancel = dialog;
+	let find_dialog_for_cancel = Rc::clone(find_dialog);
+	let config_for_cancel = Rc::clone(config);
+	button.on_click(move |_| {
+		if let Some(state) = find_dialog_for_cancel.lock().unwrap().as_ref() {
+			state.save_settings(&config_for_cancel);
+		}
+		dialog_for_cancel.show(false);
+	});
 }
 
 fn bind_find_dialog_actions(params: FindDialogActionParams) {
@@ -236,6 +414,9 @@ fn bind_find_dialog_actions(params: FindDialogActionParams) {
 		find_combo,
 		find_prev_btn,
 		find_next_btn,
+		find_all_btn,
+		go_btn,
+		results_list,
 		cancel_btn,
 		config,
 		doc_manager,
@@ -270,15 +451,15 @@ fn bind_find_dialog_actions(params: FindDialogActionParams) {
 			false,
 		);
 	});
-	let dialog_for_cancel = dialog;
-	let find_dialog_for_cancel = Rc::clone(&find_dialog);
-	let config_for_cancel = Rc::clone(&config);
-	cancel_btn.on_click(move |_| {
-		if let Some(state) = find_dialog_for_cancel.lock().unwrap().as_ref() {
-			state.save_settings(&config_for_cancel);
-			dialog_for_cancel.show(false);
+	let find_dialog_for_all = Rc::clone(&find_dialog);
+	let doc_manager_for_all = Rc::clone(&doc_manager);
+	let config_for_all = Rc::clone(&config);
+	find_all_btn.on_click(move |_| {
+		if let Some(state) = find_dialog_for_all.lock().unwrap().as_ref() {
+			do_find_all(state, &doc_manager_for_all, &config_for_all, live_region_label);
 		}
 	});
+	bind_cancel_button(cancel_btn, dialog, &find_dialog, &config);
 	let frame_for_enter = frame;
 	let find_dialog_for_enter = Rc::clone(&find_dialog);
 	let doc_manager_for_enter = Rc::clone(&doc_manager);
@@ -303,6 +484,22 @@ fn bind_find_dialog_actions(params: FindDialogActionParams) {
 		}
 		dialog_for_close.show(false);
 		event.skip(false);
+	});
+	let frame_for_go = frame;
+	let find_dialog_for_go = Rc::clone(&find_dialog);
+	let doc_manager_for_go = Rc::clone(&doc_manager);
+	go_btn.on_click(move |_| {
+		if let Some(state) = find_dialog_for_go.lock().unwrap().as_ref() {
+			handle_result_go(&frame_for_go, state, &doc_manager_for_go, live_region_label);
+		}
+	});
+	let frame_for_list = frame;
+	let find_dialog_for_list = Rc::clone(&find_dialog);
+	let doc_manager_for_list = Rc::clone(&doc_manager);
+	results_list.on_item_double_clicked(move |_| {
+		if let Some(state) = find_dialog_for_list.lock().unwrap().as_ref() {
+			handle_result_go(&frame_for_list, state, &doc_manager_for_list, live_region_label);
+		}
 	});
 }
 
@@ -346,6 +543,7 @@ pub fn show_find_dialog(
 	let Some(state) = state else {
 		return;
 	};
+	state.switch_to_query_view();
 	let text_ctrl = {
 		let dm = doc_manager.lock().unwrap();
 		dm.active_tab().map(|tab| tab.text_ctrl)
@@ -360,6 +558,26 @@ pub fn show_find_dialog(
 	state.dialog.show(true);
 	state.dialog.raise();
 	state.focus_find_text();
+}
+
+/// Makes sure the combo has a query, pulling the current document selection into it if it is
+/// empty. Returns whether a query is now present.
+fn ensure_query(state: &FindDialogState, doc_manager: &Rc<Mutex<DocumentManager>>) -> bool {
+	if !state.find_text().trim().is_empty() {
+		return true;
+	}
+	let text_ctrl = {
+		let dm = doc_manager.lock().unwrap();
+		dm.active_tab().map(|tab| tab.text_ctrl)
+	};
+	if let Some(text_ctrl) = text_ctrl {
+		let (start, end) = text_ctrl.get_selection();
+		if start != end {
+			let selection = text_ctrl.get_string_selection();
+			state.set_find_text(&selection);
+		}
+	}
+	!state.find_text().trim().is_empty()
 }
 
 pub fn handle_find_action(
@@ -378,24 +596,119 @@ pub fn handle_find_action(
 	let Some(state) = state else {
 		return;
 	};
-	if state.find_text().trim().is_empty() {
-		let text_ctrl = {
-			let dm = doc_manager.lock().unwrap();
-			dm.active_tab().map(|tab| tab.text_ctrl)
-		};
-		if let Some(text_ctrl) = text_ctrl {
-			let (start, end) = text_ctrl.get_selection();
-			if start != end {
-				let selection = text_ctrl.get_string_selection();
-				state.set_find_text(&selection);
-			}
-		}
-	}
-	if state.find_text().trim().is_empty() {
+	state.switch_to_query_view();
+	if !ensure_query(&state, doc_manager) {
 		show_find_dialog(frame, doc_manager, config, find_dialog, live_region_label);
 		return;
 	}
 	do_find(frame, forward, &state, doc_manager, config, live_region_label);
+}
+
+/// Lists every line holding a match for the current query under the dialog's options. With no
+/// matches it reports "Not found." exactly like [`do_find`]; with matches it switches the dialog
+/// to the results view, focused on the first line whose match follows the caret.
+fn do_find_all(
+	state: &FindDialogState,
+	doc_manager: &Rc<Mutex<DocumentManager>>,
+	config: &Rc<Mutex<ConfigManager>>,
+	live_region_label: StaticText,
+) {
+	let Some(_find_guard) = state.try_begin_find() else {
+		return;
+	};
+	if !ensure_query(state, doc_manager) {
+		state.dialog.show(true);
+		state.dialog.raise();
+		state.focus_find_text();
+		return;
+	}
+	let query = state.find_text();
+	state.save_settings(config);
+	state.add_to_history(config, &query);
+	let mut options = reader_core::SearchOptions::empty();
+	if state.match_case.is_checked() {
+		options |= reader_core::SearchOptions::MATCH_CASE;
+	}
+	if state.whole_word.is_checked() {
+		options |= reader_core::SearchOptions::WHOLE_WORD;
+	}
+	if state.use_regex.is_checked() {
+		options |= reader_core::SearchOptions::REGEX;
+	}
+	let (rows, origin) = {
+		let dm = doc_manager.lock().unwrap();
+		let Some(tab) = dm.active_tab() else {
+			return;
+		};
+		if !tab.text_ctrl.is_valid() {
+			return;
+		}
+		let (_, origin) = navigation::doc_selected_range(tab);
+		let rows = tab.session.find_all_lines(&query, options);
+		drop(dm);
+		(rows, origin)
+	};
+	tracing::debug!(query = %query, count = rows.len(), "find all search");
+	if rows.is_empty() {
+		live_region::announce(live_region_label, &t("Not found."));
+		state.switch_to_query_view();
+		state.dialog.show(true);
+		state.dialog.raise();
+		state.focus_find_text();
+		return;
+	}
+	let selected = rows.iter().position(|row| row.matches.iter().any(|m| m.start >= origin)).unwrap_or(0);
+	state.origin.set(origin);
+	*state.result_rows.borrow_mut() = rows;
+	state.results_list.clear();
+	{
+		let rows = state.result_rows.borrow();
+		for row in rows.iter() {
+			let label =
+				if row.page > 0 { navigation::page_announcement(row.page, &row.text) } else { row.text.clone() };
+			state.results_list.append(&label);
+		}
+	}
+	state.results_list.set_selection(u32::try_from(selected).unwrap_or(0), true);
+	state.switch_to_results_view();
+	state.results_list.set_focus();
+	state.results_list.ensure_visible(i32::try_from(selected).unwrap_or(0));
+}
+
+/// Jumps to the selected results row, landing on the match on that line that follows the caret
+/// origin (falling back to the line's first match), then behaves like a found Find: selects the
+/// range, hides the dialog, and announces the line after the focus chain is cut.
+fn handle_result_go(
+	frame: &Frame,
+	state: &FindDialogState,
+	doc_manager: &Rc<Mutex<DocumentManager>>,
+	live_region_label: StaticText,
+) {
+	let (start, end, announce) = {
+		let rows = state.result_rows.borrow();
+		let selected = state.results_list.get_selection().and_then(|index| usize::try_from(index).ok()).unwrap_or(0);
+		let Some(row) = rows.get(selected) else {
+			return;
+		};
+		let origin = state.origin.get();
+		let Some(span) = row.matches.iter().find(|m| m.start >= origin).or_else(|| row.matches.first()) else {
+			return;
+		};
+		(span.start, span.end, row.text.clone())
+	};
+	let mut dm = doc_manager.lock().unwrap();
+	let Some(tab) = dm.active_tab_mut() else {
+		return;
+	};
+	if !tab.text_ctrl.is_valid() {
+		return;
+	}
+	navigation::select_doc_range(tab, start, end);
+	drop(dm);
+	state.dialog.show(false);
+	if !announce.trim().is_empty() {
+		navigation::announce_after_delay(frame, live_region_label, announce);
+	}
 }
 
 fn do_find(
@@ -447,6 +760,7 @@ fn do_find(
 		drop(dm);
 		// TRANSLATORS: Announced when a search finds no matches in the document
 		live_region::announce(live_region_label, &t("Not found."));
+		state.switch_to_query_view();
 		state.dialog.show(true);
 		state.dialog.raise();
 		state.focus_find_text();


### PR DESCRIPTION
## Find All: list every occurrence from the Find dialog

The Find dialog (Ctrl+F) gains a **Find &All** button. Instead of jumping to the next match, it
lists every line that holds a match for the current query, so you can browse the occurrences and
jump to any of them. Sighted people can flip through find results from within standard Find dialogues; this is my attempt to make something similar available to us.

### Behavior

* A **Find &All** button sits beside Find Previous / Find Next in the dialog.
* It uses exactly the dialog's options — **match case**, **whole word**, and **regular
  expressions** — i.e. it lists every match that Find Next would eventually find for that query.
  Direction and wrap are irrelevant.
* **No matches**: announces "Not found." and stays in the query view, exactly like Find.
* **With matches**: the dialog hides its query controls and shows the results view — a list of
  results, a **Go** button, and a **Cancel** button.
* Each row is one **line** of the document (a line holding several matches appears once). Rows
  read `Page 5: there is blah on this page` when the document has page numbers, or just the
  line text when it does not.
* The list opens focused on the first line whose match **follows the caret**, so Enter/Go lands
  near where you're reading. **Go** (Enter or double-click on a row) selects the matched text,
  closes the dialog, and announces the line — the same behavior as a successful Find.
* On a row whose line has several matches, Go lands on the match that follows your original
  caret position (falling back to the line's first match).
* Cancel / Escape close the dialog from either view; reopening with Ctrl+F always returns to the
  query view with the query and options preserved.

### What changed

* **paperback-core**
  * `reader_search_all` — enumerates every match as a real `(start, end)` span (so a regex like
    `\d+` selects the actual digits), reusing the existing matcher construction. Zero-length
    matches are skipped.
  * `DocumentSession::find_all_lines` — groups matches into one result per line with the page
    number, ready for the dialog to label.
  * Unit tests for both (dedupe by line, page assignment, whole-word/case/regex, UTF-16 spans).
* **paperback (ui/find.rs)** — the persistent Find dialog now has two views (query and
  results) that swap by hiding/showing their windows and refitting. The Cancel button is shared
  and always visible so Escape works in both views; the results list is named "Results" for
  screen readers.
* Two new translatable strings: `"Find &All"` and `"&Go"` (plus `"Results"` as the list's
  accessible name) — they reach translators through the usual auto-translate workflow.

### Testing

* Confirmed on **Windows** (release build) with NVDA: PDFs with real page numbers show `Page N:`
  rows, a document without pagination shows plain lines, options (case / whole word / regex) are
  respected, Escape closes the results view, and the list announces as "Results".
* `cargo test -p paperback-core` (760 tests) passes; clippy and the nightly format check are
  clean.
* `find.rs` is a single cross-platform module, but only the Windows build was exercised on this
  machine — it has not been compiled or run on macOS/Linux yet.
