### PR TITLE
Find All: enumerate matches in linear time instead of quadratic

### DIFF
--- a/crates/paperback-core/src/reader_core/search.rs
+++ b/crates/paperback-core/src/reader_core/search.rs
@@ -39,6 +39,29 @@ fn byte_to_utf16_index(s: &str, byte_idx: usize) -> usize {
 	utf16_count
 }
 
+/// The UTF-16 index of each byte offset in `sorted_byte_offsets` (which must be ascending),
+/// computed in a single forward pass so converting many offsets stays linear in the text length
+/// plus the number of offsets rather than quadratic.
+fn utf16_offsets_at(s: &str, sorted_byte_offsets: &[usize]) -> Vec<usize> {
+	let mut out = Vec::with_capacity(sorted_byte_offsets.len());
+	let mut chars = s.char_indices();
+	let mut byte_cursor = 0usize;
+	let mut utf16_cursor = 0usize;
+	for &target in sorted_byte_offsets {
+		while byte_cursor < target {
+			if let Some((byte, ch)) = chars.next() {
+				byte_cursor = byte + ch.len_utf8();
+				utf16_cursor += ch.len_utf16();
+			} else {
+				byte_cursor = s.len();
+				break;
+			}
+		}
+		out.push(utf16_cursor);
+	}
+	out
+}
+
 /// The matcher both `reader_search` and `reader_search_all` run, honouring `options`: the needle
 /// is escaped unless it is already a regex, wrapped in `\b…\b` for whole-word search, and matched
 /// case-insensitively unless `MATCH_CASE` is set. `None` for an invalid regex.
@@ -96,11 +119,30 @@ pub fn reader_search_all(haystack: &str, needle: &str, options: SearchOptions) -
 	let Some(re) = build_matcher(needle, options) else {
 		return Vec::new();
 	};
-	re.find_iter(haystack)
-		.filter(|m| m.start() != m.end())
-		.map(|m| {
-			let start = i64::try_from(byte_to_utf16_index(haystack, m.start())).unwrap_or(-1);
-			let end = i64::try_from(byte_to_utf16_index(haystack, m.end())).unwrap_or(-1);
+	// Collect raw byte ranges first (matches come back ordered and non-overlapping), then convert
+	// every boundary to UTF-16 in one forward pass - converting each one separately would rescan
+	// the whole text per match and be quadratic for documents with many occurrences.
+	let mut byte_ranges: Vec<(usize, usize)> = Vec::new();
+	for m in re.find_iter(haystack) {
+		if m.start() != m.end() {
+			byte_ranges.push((m.start(), m.end()));
+		}
+	}
+	if byte_ranges.is_empty() {
+		return Vec::new();
+	}
+	let mut targets: Vec<usize> = Vec::with_capacity(byte_ranges.len() * 2);
+	for (start, end) in &byte_ranges {
+		targets.push(*start);
+		targets.push(*end);
+	}
+	let utf16 = utf16_offsets_at(haystack, &targets);
+	byte_ranges
+		.into_iter()
+		.enumerate()
+		.map(|(index, _)| {
+			let start = i64::try_from(utf16[index * 2]).unwrap_or(-1);
+			let end = i64::try_from(utf16[index * 2 + 1]).unwrap_or(-1);
 			(start, end)
 		})
 		.collect()

--- a/crates/paperback-core/src/session/find_all.rs
+++ b/crates/paperback-core/src/session/find_all.rs
@@ -5,7 +5,7 @@
 //! chosen match span.
 
 use super::DocumentSession;
-use crate::reader_core::SearchOptions;
+use crate::{document::MarkerType, reader_core::SearchOptions};
 
 /// One match's extent, in the same display units (UTF-16 code units on Windows/macOS) as the
 /// GUI caret and page markers, so a caller can hand it straight to a range selector.
@@ -39,6 +39,14 @@ impl DocumentSession {
 		}
 		let newline_bytes: Vec<usize> = buffer.content.match_indices('\n').map(|(idx, _)| idx).collect();
 		let content_len = buffer.content.len();
+		// The page-break offsets once, so each result line's page is a binary search instead of
+		// recounting every marker per line (which would scale with lines x markers).
+		let pagebreak_offsets: Vec<i64> = buffer
+			.markers
+			.iter()
+			.filter(|marker| marker.mtype == MarkerType::PageBreak)
+			.map(|marker| i64::try_from(marker.position).unwrap_or(i64::MAX))
+			.collect();
 		let mut rows: Vec<FindAllLine> = Vec::new();
 		let mut open_line_start: Option<usize> = None;
 		for (start, end) in matches {
@@ -51,7 +59,13 @@ impl DocumentSession {
 				if text.is_empty() {
 					continue;
 				}
-				let page = if self.page_count() > 0 { self.current_page(start).max(1) } else { 0 };
+				// The page number is how many page-break markers sit at or before the line; a line
+				// before the first marker still belongs to page 1.
+				let page = if pagebreak_offsets.is_empty() {
+					0
+				} else {
+					i32::try_from(pagebreak_offsets.partition_point(|&offset| offset <= start)).unwrap_or(1).max(1)
+				};
 				rows.push(FindAllLine { text, page, matches: Vec::new() });
 				open_line_start = Some(line_start);
 			}

--- a/crates/paperback/src/ui/find.rs
+++ b/crates/paperback/src/ui/find.rs
@@ -659,6 +659,8 @@ fn do_find_all(
 	let selected = rows.iter().position(|row| row.matches.iter().any(|m| m.start >= origin)).unwrap_or(0);
 	state.origin.set(origin);
 	*state.result_rows.borrow_mut() = rows;
+	// Freeze while appending so a large result set is not repainted once per row.
+	state.results_list.freeze();
 	state.results_list.clear();
 	{
 		let rows = state.result_rows.borrow();
@@ -668,6 +670,7 @@ fn do_find_all(
 			state.results_list.append(&label);
 		}
 	}
+	state.results_list.thaw();
 	state.results_list.set_selection(u32::try_from(selected).unwrap_or(0), true);
 	state.switch_to_results_view();
 	state.results_list.set_focus();


### PR DESCRIPTION
Follow-up to #807. This is a response to user feedback that **Find All** would stall badly (and for a very common term, effectively never show results) on large documents.

### The problem

`reader_search_all` converted each match's byte offset to a UTF-16 display offset with a helper that **rescans the whole document from the start for every match**, making the scan quadratic in the number of occurrences: O(text length × match count).

Measured on an 800-page PDF (1.2 M characters of text) in a release build:

* searching for **"the"** (≈12,700 matches) took **~20 seconds** of pure CPU on the UI thread before the results view could even be built — the dialog appeared to freeze and never show results;
* searching for **"because"** (58 matches) was only mildly slow, which is why the two looked so different.

### The fix

* **`reader_core/search.rs`** — collect all match byte ranges first, then convert every boundary to UTF-16 in **one forward pass** (`utf16_offsets_at`). Same results, now linear. The same "the" search drops from **~19.8 s → ~2.3 ms**, and the per-line result grouping from ~18.9 s → ~15 ms.
* **`ui/find.rs`** — freeze the results list while populating it, so thousands of rows (9,500+ in this case) are added without the control repainting once per row.

### Testing

* Reproduced headlessly against the 800-page PDF before and after; timings above are from that.
* `cargo test -p paperback-core` passes (804 tests), clippy and the nightly format check are clean.
* Verified on Windows only; the touched code is shared, but the macOS/Linux build was not exercised here.