### PR TITLE
Elements dialog: linear Pages listing and a virtual flat-list pane

### DIFF
--- a/crates/paperback-core/src/session/stats.rs
+++ b/crates/paperback-core/src/session/stats.rs
@@ -311,6 +311,21 @@ impl DocumentSession {
 		self.handle.count_markers_by_type(MarkerType::PageBreak)
 	}
 
+	/// The display-unit offset of every page-break marker in document order — one entry per page.
+	/// Collected in a single O(markers) pass; [`Self::page_offset`] is O(markers) per call, so
+	/// callers that want every page should use this once instead of calling it in a loop.
+	#[must_use]
+	pub fn page_offsets(&self) -> Vec<i64> {
+		self.handle
+			.document()
+			.buffer
+			.markers
+			.iter()
+			.filter(|marker| marker.mtype == MarkerType::PageBreak)
+			.map(|marker| i64::try_from(marker.position).unwrap_or(i64::MAX))
+			.collect()
+	}
+
 	#[must_use]
 	pub fn current_page(&self, position: i64) -> i32 {
 		let pos = usize::try_from(position.max(0)).unwrap_or(0);

--- a/crates/paperback-core/src/session/tests/accessors.rs
+++ b/crates/paperback-core/src/session/tests/accessors.rs
@@ -36,6 +36,35 @@ fn page_helpers_report_counts_and_offsets() {
 }
 
 #[test]
+fn page_offsets_returns_every_page_break_in_document_order() {
+	let session = sample_session(ParserFlags::NONE);
+	let offsets = session.page_offsets();
+	assert_eq!(offsets, vec![0, 8]);
+	assert_eq!(offsets.len(), session.page_count());
+	for (index, &offset) in offsets.iter().enumerate() {
+		let page = i32::try_from(index).unwrap_or(0) + 1;
+		assert_eq!(offset, session.page_offset(page), "page {page} offset must match page_offset");
+	}
+}
+
+#[test]
+fn page_offsets_is_empty_without_page_breaks() {
+	let session = session_with_content("no pages here\n");
+	assert!(session.page_offsets().is_empty());
+	assert_eq!(session.page_count(), 0);
+}
+
+#[test]
+fn page_offsets_are_in_document_order_even_for_unsorted_insertion() {
+	let mut buffer = DocumentBuffer::with_content("aaaaaaaaa\nbbbbbbbbb\n".to_string());
+	// Inserted out of order: the buffer sorts markers at DocumentHandle::new.
+	buffer.add_marker(Marker::new(MarkerType::PageBreak, 9));
+	buffer.add_marker(Marker::new(MarkerType::PageBreak, 0));
+	let session = session_from_buffer(buffer);
+	assert_eq!(session.page_offsets(), vec![0, 9]);
+}
+
+#[test]
 fn text_range_and_line_text_extract_expected_content() {
 	let session = sample_session(ParserFlags::NONE);
 	assert_eq!(session.get_text_range(0, 5), "line1");

--- a/crates/paperback/src/ui/dialogs/elements.rs
+++ b/crates/paperback/src/ui/dialogs/elements.rs
@@ -1,4 +1,7 @@
-use std::{cell::Cell, rc::Rc};
+use std::{
+	cell::{Cell, RefCell},
+	rc::Rc,
+};
 #[cfg(not(target_os = "windows"))]
 use std::{collections::HashMap, ffi::c_void};
 
@@ -9,6 +12,11 @@ use wxdragon::prelude::*;
 /// The view choice indices for [`show_elements_dialog`]. Headings is a tree; every other
 /// view (Links, Pages, Tables, Lists, ...) is a flat list shown in the same list pane.
 const VIEW_HEADINGS: u32 = 0;
+/// How long a flat view's (empty) list is left shown before it is filled. Mirror of the Find All
+/// results-list fix: NVDA intermittently spent ~10 s enumerating a list when it serviced the
+/// "list just appeared" event after the rows had been added; showing an empty list first and
+/// filling it later removes that stall.
+const FLAT_POPULATE_DELAY_MS: i32 = 150;
 const VIEW_LINKS: u32 = 1;
 const VIEW_PAGES: u32 = 2;
 const VIEW_TABLES: u32 = 3;
@@ -58,10 +66,12 @@ struct PageEntry {
 /// One entry per page, labelled "Page N: <first content line>" (the same line that page
 /// navigation (p / Shift+P) announces), or just "Page N" when the page has no readable line.
 fn page_entries(session: &DocumentSession) -> Vec<PageEntry> {
-	(0..session.page_count())
-		.map(|index| {
+	session
+		.page_offsets()
+		.iter()
+		.enumerate()
+		.map(|(index, &offset)| {
 			let page = i32::try_from(index).unwrap_or(0) + 1;
-			let offset = session.page_offset(page);
 			let content = session.first_content_line_after(offset);
 			PageEntry { offset, label: page_label(page, &content) }
 		})
@@ -153,24 +163,183 @@ impl FlatViews {
 	}
 }
 
-/// Replaces `list`'s rows with `view`'s, selecting the row nearest the current position.
-fn fill_flat_list(list: ListBox, view: &FlatView) {
-	list.clear();
+// The flat (non-headings) pane. Its rows can number in the tens of thousands (the Pages view of
+// a long document), so, as with the Find All results list, it is a virtual wxListCtrl on
+// Windows/Linux and a store-backed wxDataViewListCtrl on macOS (the split the All Documents
+// dialog uses): the control keeps no rows and asks for text only for the rows it shows, so
+// switching to a flat view is O(1) instead of appending every row. This mirrors ui/find.rs; if a
+// third control needs the same glue, factor it into a shared module.
+#[cfg(target_os = "macos")]
+type FlatList = DataViewListCtrl;
+#[cfg(not(target_os = "macos"))]
+type FlatList = ListCtrl;
+
+fn flat_list_size(dialog: Dialog) -> Size {
+	dialog.from_dip(Size::new(400, 500))
+}
+
+#[cfg(not(target_os = "macos"))]
+fn build_flat_list(dialog: Dialog, flat_labels: Rc<RefCell<Vec<String>>>) -> FlatList {
+	let size = flat_list_size(dialog);
+	let list = ListCtrl::builder(&dialog)
+		.with_style(ListCtrlStyle::Report | ListCtrlStyle::Virtual | ListCtrlStyle::SingleSel)
+		.with_size(size)
+		.build();
+	list.insert_column(0, "", ListColumnFormat::Left, dialog.from_dip_int(400));
+	list.set_min_size(size);
+	list.set_max_size(size);
+	// The control asks for text on demand; hand back a prebuilt label (a cheap clone).
+	list.set_virtual_text_callback(move |index, _column| {
+		let labels = flat_labels.borrow();
+		usize::try_from(index).ok().and_then(|index| labels.get(index)).cloned().unwrap_or_default()
+	});
+	list.set_item_count(0);
+	list
+}
+
+#[cfg(target_os = "macos")]
+fn build_flat_list(dialog: Dialog, _flat_labels: Rc<RefCell<Vec<String>>>) -> FlatList {
+	let size = flat_list_size(dialog);
+	let list = DataViewListCtrl::builder(&dialog).with_style(DataViewStyle::RowLines).with_size(size).build();
+	list.append_text_column("", 0, DataViewAlign::Left, dialog.from_dip_int(400), DataViewColumnFlags::Resizable);
+	list.set_min_size(size);
+	list.set_max_size(size);
+	list
+}
+
+#[cfg(not(target_os = "macos"))]
+fn populate_flat_list(list: FlatList, flat_labels: &Rc<RefCell<Vec<String>>>, view: &FlatView) {
+	// Reset to zero rows first so a previous run's selection never lingers when the new view has
+	// no row nearest the caret.
+	list.set_item_count(0);
+	// Build the labels, dropping the borrow before the count changes: setting the count can make
+	// the native control ask the virtual callback for text, which must not find the cache still
+	// mutably borrowed (that would panic across the FFI boundary).
+	let len = {
+		let mut labels = flat_labels.borrow_mut();
+		labels.clear();
+		labels.reserve(view.entries.len());
+		for (label, _) in &view.entries {
+			labels.push(label.clone());
+		}
+		labels.len()
+	};
+	list.set_item_count(i64::try_from(len).unwrap_or(0));
+	if let Some(index) = view.closest {
+		select_flat_row(list, i32::try_from(index).unwrap_or(0));
+	}
+}
+
+#[cfg(target_os = "macos")]
+fn populate_flat_list(list: FlatList, _flat_labels: &Rc<RefCell<Vec<String>>>, view: &FlatView) {
+	list.delete_all_items();
 	for (label, _) in &view.entries {
-		list.append(label);
+		list.append_item(&[Variant::from(label.clone())]);
 	}
 	if let Some(index) = view.closest {
-		list.set_selection(index, true);
+		select_flat_row(list, i32::try_from(index).unwrap_or(0));
+	}
+}
+
+#[cfg(not(target_os = "macos"))]
+fn select_flat_row(list: FlatList, index: i32) {
+	if index < 0 {
+		return;
+	}
+	list.set_item_state(
+		i64::from(index),
+		ListItemState::Selected | ListItemState::Focused,
+		ListItemState::Selected | ListItemState::Focused,
+	);
+	list.ensure_visible(i64::from(index));
+}
+
+#[cfg(target_os = "macos")]
+fn select_flat_row(list: FlatList, index: i32) {
+	let Ok(index) = usize::try_from(index) else { return };
+	list.select_row(index);
+	if let Some(item) = list.row_to_item(index) {
+		list.set_current_item(&item);
+		list.ensure_visible(&item);
+	}
+}
+
+#[cfg(not(target_os = "macos"))]
+fn flat_list_selected_index(list: FlatList) -> Option<usize> {
+	let index = list.get_first_selected_item();
+	if index >= 0 { usize::try_from(index).ok() } else { None }
+}
+
+#[cfg(target_os = "macos")]
+fn flat_list_selected_index(list: FlatList) -> Option<usize> {
+	list.get_selected_row()
+}
+
+/// Shows `view`'s rows in the shared flat pane, naming the list after the view the user chose.
+fn present_flat_view(list: FlatList, flat_labels: &Rc<RefCell<Vec<String>>>, view: &FlatView, name: &str) {
+	list.set_accessibility_label(name);
+	populate_flat_list(list, flat_labels, view);
+}
+
+#[cfg(not(target_os = "macos"))]
+fn clear_flat_list(list: FlatList) {
+	list.set_item_count(0);
+}
+
+#[cfg(target_os = "macos")]
+fn clear_flat_list(list: FlatList) {
+	list.delete_all_items();
+}
+
+/// Switches the flat pane to `view` (the list entry whose `VIEW_*` index is `selection`) a short
+/// moment after it was shown empty, so the screen reader settles on the newly-shown pane before it
+/// fills with rows. If the user has since chosen a different view, the pending fill is skipped.
+fn schedule_flat_fill(
+	frame: Frame,
+	list: FlatList,
+	flat_labels: Rc<RefCell<Vec<String>>>,
+	views: Rc<FlatViews>,
+	view_choice: Choice,
+	selection: u32,
+) {
+	let timer_holder: Rc<RefCell<Option<Timer<Frame>>>> = Rc::new(RefCell::new(None));
+	let holder = Rc::clone(&timer_holder);
+	let labels_for_tick = Rc::clone(&flat_labels);
+	let views_for_tick = Rc::clone(&views);
+	let timer = Timer::new(&frame);
+	timer.on_tick(move |_event| {
+		if view_choice.get_selection() == Some(selection) {
+			fill_flat_view(list, &labels_for_tick, &views_for_tick, view_choice, selection);
+		}
+		*holder.borrow_mut() = None;
+	});
+	if !timer.start(FLAT_POPULATE_DELAY_MS, true) {
+		fill_flat_view(list, &flat_labels, &views, view_choice, selection);
+		return;
+	}
+	*timer_holder.borrow_mut() = Some(timer);
+}
+
+/// Fills the list with `views.view(selection)`'s rows while it is hidden, then shows it.
+fn fill_flat_view(
+	list: FlatList,
+	flat_labels: &Rc<RefCell<Vec<String>>>,
+	views: &Rc<FlatViews>,
+	view_choice: Choice,
+	selection: u32,
+) {
+	if let Some(view) = views.view(selection) {
+		let name = view_choice.get_string_selection().unwrap_or_default();
+		list.show(false);
+		present_flat_view(list, flat_labels, view, &name);
+		list.show(true);
 	}
 }
 
 /// The offset of the row selected in the flat list pane for `view`, if any.
-fn flat_selected_offset(view: u32, list: ListBox, views: &FlatViews) -> Option<i64> {
+fn flat_selected_offset(view: u32, list: FlatList, views: &FlatViews) -> Option<i64> {
 	let entries = &views.view(view)?.entries;
-	list.get_selection()
-		.and_then(|index| usize::try_from(index).ok())
-		.and_then(|index| entries.get(index))
-		.map(|(_, offset)| *offset)
+	flat_list_selected_index(list).and_then(|index| entries.get(index)).map(|(_, offset)| *offset)
 }
 
 // ── DataViewTreeCtrl implementation (Linux + macOS) ───────────────────────────
@@ -182,19 +351,20 @@ struct ElementsDialogUiDv {
 	headings_tree: DataViewTreeCtrl,
 	// The flat-list pane, shared by every non-headings view (Links, Pages, ...): its
 	// contents are swapped in when the view changes.
-	content_list: ListBox,
+	content_list: FlatList,
 }
 
 #[cfg(not(target_os = "windows"))]
 fn show_elements_dialog_dv(parent: &Frame, session: &DocumentSession, current_pos: i64) -> Option<(i64, ElementsKind)> {
 	// TRANSLATORS: Title of the Elements dialog
 	let dialog = Dialog::builder(parent, &t("Elements")).build();
+	let flat_labels = Rc::new(RefCell::new(Vec::new()));
 	let ElementsDialogUiDv { content_sizer, view_choice, headings_tree, content_list } =
-		build_elements_dialog_ui_dv(dialog);
+		build_elements_dialog_ui_dv(dialog, Rc::clone(&flat_labels));
 	let (selected_offset, item_offsets) = populate_elements_dialog_dv(session, current_pos, headings_tree);
 	let item_offsets = Rc::new(item_offsets);
 	let views = Rc::new(FlatViews::for_session(session, current_pos));
-	bind_elements_view_toggle_dv(view_choice, headings_tree, content_list, dialog, &views);
+	bind_elements_view_toggle_dv(*parent, view_choice, headings_tree, content_list, dialog, &views, &flat_labels);
 	bind_elements_activation_dv(
 		dialog,
 		view_choice,
@@ -229,7 +399,7 @@ fn show_elements_dialog_dv(parent: &Frame, session: &DocumentSession, current_po
 }
 
 #[cfg(not(target_os = "windows"))]
-fn build_elements_dialog_ui_dv(dialog: Dialog) -> ElementsDialogUiDv {
+fn build_elements_dialog_ui_dv(dialog: Dialog, flat_labels: Rc<RefCell<Vec<String>>>) -> ElementsDialogUiDv {
 	let content_sizer = BoxSizer::builder(Orientation::Vertical).build();
 	let choice_sizer = BoxSizer::builder(Orientation::Horizontal).build();
 	// TRANSLATORS: Label for the view selection dropdown in the Elements dialog
@@ -259,7 +429,7 @@ fn build_elements_dialog_ui_dv(dialog: Dialog) -> ElementsDialogUiDv {
 		SizerFlag::Expand | SizerFlag::Left | SizerFlag::Right | SizerFlag::Bottom,
 		super::DIALOG_PADDING,
 	);
-	let content_list = ListBox::builder(&dialog).build();
+	let content_list = build_flat_list(dialog, flat_labels);
 	content_sizer.add(
 		&content_list,
 		1,
@@ -279,12 +449,17 @@ fn populate_elements_dialog_dv(
 	let selected_offset = Rc::new(Cell::new(-1i64));
 	let mut item_offsets: HashMap<usize, i64> = HashMap::new();
 	let tree_data = session.heading_tree(current_pos);
-	// Precompute which items have children so we can use append_container vs append_item.
-	let has_children_vec: Vec<bool> = (0..tree_data.items.len())
-		.map(|i| {
-			tree_data.items.iter().any(|it| it.parent_index >= 0 && usize::try_from(it.parent_index).ok() == Some(i))
-		})
-		.collect();
+	// Precompute which items have children (single pass over items) so we can use append_container
+	// vs append_item.
+	let mut has_children_vec = vec![false; tree_data.items.len()];
+	for item in &tree_data.items {
+		if item.parent_index >= 0
+			&& let Ok(parent_idx) = usize::try_from(item.parent_index)
+			&& let Some(flag) = has_children_vec.get_mut(parent_idx)
+		{
+			*flag = true;
+		}
+	}
 	let root = DataViewItem::default();
 	let mut item_ids: Vec<DataViewItem> = Vec::new();
 	for (current_idx, item) in tree_data.items.iter().enumerate() {
@@ -324,31 +499,43 @@ fn populate_elements_dialog_dv(
 
 #[cfg(not(target_os = "windows"))]
 fn bind_elements_view_toggle_dv(
+	frame: Frame,
 	view_choice: Choice,
 	headings_tree: DataViewTreeCtrl,
-	content_list: ListBox,
+	content_list: FlatList,
 	dialog: Dialog,
 	views: &Rc<FlatViews>,
+	flat_labels: &Rc<RefCell<Vec<String>>>,
 ) {
 	let headings_tree_for_choice = headings_tree;
 	let content_list_for_choice = content_list;
 	let dialog_for_layout = dialog;
 	let views_for_choice = Rc::clone(views);
+	let flat_labels_for_choice = Rc::clone(flat_labels);
 	view_choice.on_selection_changed(move |_| {
 		let selection = view_choice.get_selection().unwrap_or(VIEW_HEADINGS);
-		// Switch which pane is shown, repopulating the shared flat list for a non-headings
-		// view. Focus is deliberately left where it is: the change comes from the user
-		// arrowing through the view choice, and throwing them into the newly shown pane
-		// with every arrow makes the dropdown impossible to browse.
+		// Switch which pane is shown. Focus is deliberately left in the view choice (the change
+		// comes from the user arrowing through it, and throwing them into the newly shown pane
+		// with every arrow makes the dropdown impossible to browse).
 		if selection == VIEW_HEADINGS {
 			headings_tree_for_choice.show(true);
 			content_list_for_choice.show(false);
 		} else {
 			headings_tree_for_choice.show(false);
+			// Show the pane empty first, then fill it a moment later so the screen reader settles
+			// on the newly-shown list before it grows to its full size (see the Find All fix).
+			clear_flat_list(content_list_for_choice);
+			let name = view_choice.get_string_selection().unwrap_or_default();
+			content_list_for_choice.set_accessibility_label(&name);
 			content_list_for_choice.show(true);
-			if let Some(view) = views_for_choice.view(selection) {
-				fill_flat_list(content_list_for_choice, view);
-			}
+			schedule_flat_fill(
+				frame,
+				content_list_for_choice,
+				Rc::clone(&flat_labels_for_choice),
+				Rc::clone(&views_for_choice),
+				view_choice,
+				selection,
+			);
 		}
 		dialog_for_layout.layout();
 	});
@@ -359,7 +546,7 @@ fn bind_elements_activation_dv(
 	dialog: Dialog,
 	view_choice: Choice,
 	headings_tree: DataViewTreeCtrl,
-	content_list: ListBox,
+	content_list: FlatList,
 	item_offsets: &Rc<HashMap<usize, i64>>,
 	views: &Rc<FlatViews>,
 	selected_offset: &Rc<Cell<i64>>,
@@ -382,7 +569,7 @@ fn bind_elements_activation_dv(
 	let views_for_click = Rc::clone(views);
 	let selected_for_list = Rc::clone(selected_offset);
 	let dialog_for_list = dialog;
-	content_list.on_item_double_clicked(move |_| {
+	content_list.on_item_activated(move |_| {
 		if let Some(offset) = flat_selected_offset(
 			view_for_list.get_selection().unwrap_or(VIEW_HEADINGS),
 			list_for_click,
@@ -399,7 +586,7 @@ fn bind_elements_ok_action_dv(
 	dialog: Dialog,
 	view_choice: Choice,
 	headings_tree: DataViewTreeCtrl,
-	content_list: ListBox,
+	content_list: FlatList,
 	item_offsets: &Rc<HashMap<usize, i64>>,
 	views: &Rc<FlatViews>,
 	selected_offset: &Rc<Cell<i64>>,
@@ -438,17 +625,19 @@ struct ElementsDialogUi {
 	headings_tree: TreeCtrl,
 	// The flat-list pane, shared by every non-headings view (Links, Pages, ...): its
 	// contents are swapped in when the view changes.
-	content_list: ListBox,
+	content_list: FlatList,
 }
 
 #[cfg(target_os = "windows")]
 fn show_elements_dialog_wx(parent: &Frame, session: &DocumentSession, current_pos: i64) -> Option<(i64, ElementsKind)> {
 	// TRANSLATORS: Title of the Elements dialog
 	let dialog = Dialog::builder(parent, &t("Elements")).build();
-	let ElementsDialogUi { content_sizer, view_choice, headings_tree, content_list } = build_elements_dialog_ui(dialog);
+	let flat_labels = Rc::new(RefCell::new(Vec::new()));
+	let ElementsDialogUi { content_sizer, view_choice, headings_tree, content_list } =
+		build_elements_dialog_ui(dialog, Rc::clone(&flat_labels));
 	let selected_offset = populate_elements_dialog(session, current_pos, headings_tree);
 	let views = Rc::new(FlatViews::for_session(session, current_pos));
-	bind_elements_view_toggle(view_choice, headings_tree, content_list, dialog, &views);
+	bind_elements_view_toggle(*parent, view_choice, headings_tree, content_list, dialog, &views, &flat_labels);
 	bind_elements_activation(dialog, view_choice, headings_tree, content_list, &selected_offset, &views);
 	let (ok_button, cancel_button) = build_elements_buttons(dialog);
 	bind_elements_ok_action(dialog, view_choice, headings_tree, content_list, &selected_offset, &views, ok_button);
@@ -466,7 +655,7 @@ fn show_elements_dialog_wx(parent: &Frame, session: &DocumentSession, current_po
 }
 
 #[cfg(target_os = "windows")]
-fn build_elements_dialog_ui(dialog: Dialog) -> ElementsDialogUi {
+fn build_elements_dialog_ui(dialog: Dialog, flat_labels: Rc<RefCell<Vec<String>>>) -> ElementsDialogUi {
 	let content_sizer = BoxSizer::builder(Orientation::Vertical).build();
 	let choice_sizer = BoxSizer::builder(Orientation::Horizontal).build();
 	// TRANSLATORS: Label for the view selection dropdown in the Elements dialog
@@ -502,7 +691,7 @@ fn build_elements_dialog_ui(dialog: Dialog) -> ElementsDialogUi {
 		super::DIALOG_PADDING,
 	);
 	let list_sizer = BoxSizer::builder(Orientation::Vertical).build();
-	let content_list = ListBox::builder(&dialog).build();
+	let content_list = build_flat_list(dialog, flat_labels);
 	list_sizer.add(&content_list, 1, SizerFlag::Expand, 0);
 	content_sizer.add_sizer(
 		&list_sizer,
@@ -558,31 +747,43 @@ fn populate_elements_dialog(session: &DocumentSession, current_pos: i64, heading
 
 #[cfg(target_os = "windows")]
 fn bind_elements_view_toggle(
+	frame: Frame,
 	view_choice: Choice,
 	headings_tree: TreeCtrl,
-	content_list: ListBox,
+	content_list: FlatList,
 	dialog: Dialog,
 	views: &Rc<FlatViews>,
+	flat_labels: &Rc<RefCell<Vec<String>>>,
 ) {
 	let headings_tree_for_choice = headings_tree;
 	let content_list_for_choice = content_list;
 	let dialog_for_layout = dialog;
 	let views_for_choice = Rc::clone(views);
+	let flat_labels_for_choice = Rc::clone(flat_labels);
 	view_choice.on_selection_changed(move |_| {
 		let selection = view_choice.get_selection().unwrap_or(VIEW_HEADINGS);
-		// Switch which pane is shown, repopulating the shared flat list for a non-headings
-		// view. Focus is deliberately left where it is: the change comes from the user
-		// arrowing through the view choice, and throwing them into the newly shown pane
-		// with every arrow makes the dropdown impossible to browse.
+		// Switch which pane is shown. Focus is deliberately left in the view choice (the change
+		// comes from the user arrowing through it, and throwing them into the newly shown pane
+		// with every arrow makes the dropdown impossible to browse).
 		if selection == VIEW_HEADINGS {
 			headings_tree_for_choice.show(true);
 			content_list_for_choice.show(false);
 		} else {
 			headings_tree_for_choice.show(false);
+			// Show the pane empty first, then fill it a moment later so the screen reader settles
+			// on the newly-shown list before it grows to its full size (see the Find All fix).
+			clear_flat_list(content_list_for_choice);
+			let name = view_choice.get_string_selection().unwrap_or_default();
+			content_list_for_choice.set_accessibility_label(&name);
 			content_list_for_choice.show(true);
-			if let Some(view) = views_for_choice.view(selection) {
-				fill_flat_list(content_list_for_choice, view);
-			}
+			schedule_flat_fill(
+				frame,
+				content_list_for_choice,
+				Rc::clone(&flat_labels_for_choice),
+				Rc::clone(&views_for_choice),
+				view_choice,
+				selection,
+			);
 		}
 		dialog_for_layout.layout();
 	});
@@ -593,7 +794,7 @@ fn bind_elements_activation(
 	dialog: Dialog,
 	view_choice: Choice,
 	headings_tree: TreeCtrl,
-	content_list: ListBox,
+	content_list: FlatList,
 	selected_offset: &Rc<Cell<i64>>,
 	views: &Rc<FlatViews>,
 ) {
@@ -614,7 +815,7 @@ fn bind_elements_activation(
 	let views_for_click = Rc::clone(views);
 	let selected_for_list = Rc::clone(selected_offset);
 	let dialog_for_list = dialog;
-	content_list.on_item_double_clicked(move |_| {
+	content_list.on_item_activated(move |_| {
 		if let Some(offset) = flat_selected_offset(
 			view_for_list.get_selection().unwrap_or(VIEW_HEADINGS),
 			list_for_click,
@@ -631,7 +832,7 @@ fn bind_elements_ok_action(
 	dialog: Dialog,
 	view_choice: Choice,
 	headings_tree: TreeCtrl,
-	content_list: ListBox,
+	content_list: FlatList,
 	selected_offset: &Rc<Cell<i64>>,
 	views: &Rc<FlatViews>,
 	ok_button: Button,


### PR DESCRIPTION
Performance fixes for the Elements (F7) dialog, applying the lessons from the Find All work.

### What changed

* **Pages view was O(pages × markers).** `page_entries` called `page_offset(page)` per page, and
  `page_offset` rescans every marker to find the Nth page break. New `DocumentSession::page_offsets()`
  collects all page-break offsets in one O(markers) pass, and `page_entries` iterates it. (+ core tests.)
* **DataView heading tree was O(headings²).** The "has children" precompute scanned all headings
  for every heading; it is now a single O(H) pass. (The Windows tree was already O(H).)
* **Flat-list pane is now virtual.** Links/Pages/Tables/Lists previously used a `wxListBox`
  appended one row per item on every view switch. It is now a virtual `wxListCtrl` on Windows/Linux
  and a `wxDataViewListCtrl` on macOS (the same split All Documents / Find All use), so switching
  to a flat view is O(1); labels are prebuilt once, and the control asks for text only for the
  rows it shows. The pane is shown empty first and filled after ~150 ms so the screen reader
  settles on it before it grows (mirrors the Find All fix). The list is named after the chosen
  view (e.g. "Pages").

### Known issue — still under investigation

Selecting **Pages** in a very long document can still pause for ~10 seconds while the large list
is presented. The delay is suspected to be on the NVDA/toolkit side enumerating the 10k-row list
and needs further testing; presenting a bounded number of rows (a cap) is a candidate follow-up.
The Elements dialog work in this PR has been exercised on Windows only.

### Testing

* `cargo test -p paperback-core` (807 tests) passes; clippy and the nightly format check are clean.
* Windows release build tested.
* The macOS/Linux DataView half and the macOS `DataViewListCtrl` path are written to mirror the
  Find All / All Documents code but were **not** compiled or run on this machine (Windows-only
  testing) — they need a macOS/Linux check.