### PR TITLE
Fix macOS Clippy errors and add Clippy to macOS CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,6 +109,8 @@ jobs:
   test-macos:
     name: Tests (macOS)
     runs-on: macos-latest
+    env:
+      WXWIDGETS_DIR: ${{ github.workspace }}/wxWidgets
     steps:
       - uses: actions/checkout@v7
         with:
@@ -117,10 +119,11 @@ jobs:
       - name: Install CMake, Ninja, Pandoc, and Gettext
         run: |
           brew install cmake ninja pandoc gettext
-          echo "/opt/homebrew/opt/gettext/bin" >> $GITHUB_PATH
+          echo "/opt/homebrew/opt/gettext/bin" >> "$GITHUB_PATH"
       - uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: stable
+          components: clippy
       - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@v2
       - name: Cache wxWidgets source
@@ -133,9 +136,10 @@ jobs:
         if: steps.wxwidgets-cache.outputs.cache-hit != 'true'
         run: git clone --recurse-submodules https://github.com/wxWidgets/wxWidgets.git
       - name: Run tests
-        env:
-          WXWIDGETS_DIR: ${{ github.workspace }}/wxWidgets
         run: cargo test --workspace
+      # The default profile shares the wxWidgets build with the workspace tests.
+      - name: Run clippy
+        run: cargo clippy --workspace --all-targets
   clippy:
     name: Clippy
     runs-on: windows-latest

--- a/crates/paperback/src/config_ext.rs
+++ b/crates/paperback/src/config_ext.rs
@@ -70,12 +70,12 @@ pub fn config_dir() -> PathBuf {
 	}
 	let exe_dir = get_exe_directory();
 	#[cfg(target_os = "macos")]
-	if is_app_bundle(&exe_dir) {
-		if let Some(home) = env::var_os("HOME") {
-			let dir = PathBuf::from(home).join("Library/Application Support/Paperback");
-			let _ = fs::create_dir_all(&dir);
-			return dir;
-		}
+	if is_app_bundle(&exe_dir)
+		&& let Some(home) = env::var_os("HOME")
+	{
+		let dir = PathBuf::from(home).join("Library/Application Support/Paperback");
+		let _ = fs::create_dir_all(&dir);
+		return dir;
 	}
 	#[cfg(target_os = "windows")]
 	{

--- a/crates/paperback/src/ui/dialogs/elements.rs
+++ b/crates/paperback/src/ui/dialogs/elements.rs
@@ -313,11 +313,11 @@ fn populate_elements_dialog_dv(
 	} else {
 		None
 	};
-	if let Some(idx) = select_idx {
-		if let Some(item) = item_ids.get(idx) {
-			headings_tree.select(item);
-			headings_tree.ensure_visible(item);
-		}
+	if let Some(idx) = select_idx
+		&& let Some(item) = item_ids.get(idx)
+	{
+		headings_tree.select(item);
+		headings_tree.ensure_visible(item);
 	}
 	(selected_offset, item_offsets)
 }
@@ -368,13 +368,12 @@ fn bind_elements_activation_dv(
 	let selected_for_tree = Rc::clone(selected_offset);
 	let dialog_for_tree = dialog;
 	headings_tree.on_item_activated(move |event| {
-		if let Some(item) = event.get_item() {
-			if let Some(id_ptr) = item.get_id::<c_void>() {
-				if let Some(&offset) = offsets_for_tree.get(&(id_ptr as usize)) {
-					selected_for_tree.set(offset);
-					dialog_for_tree.end_modal(wxdragon::id::ID_OK);
-				}
-			}
+		if let Some(item) = event.get_item()
+			&& let Some(id_ptr) = item.get_id::<c_void>()
+			&& let Some(&offset) = offsets_for_tree.get(&(id_ptr as usize))
+		{
+			selected_for_tree.set(offset);
+			dialog_for_tree.end_modal(wxdragon::id::ID_OK);
 		}
 	});
 	let view_for_list = view_choice;
@@ -414,13 +413,12 @@ fn bind_elements_ok_action_dv(
 	ok_button.on_click(move |_| {
 		let selection = view_for_ok.get_selection().unwrap_or(VIEW_HEADINGS);
 		if selection == VIEW_HEADINGS {
-			if let Some(item) = headings_tree.get_selection() {
-				if let Some(id_ptr) = item.get_id::<c_void>() {
-					if let Some(&offset) = offsets_for_ok.get(&(id_ptr as usize)) {
-						selected_for_ok.set(offset);
-						dialog_for_ok.end_modal(wxdragon::id::ID_OK);
-					}
-				}
+			if let Some(item) = headings_tree.get_selection()
+				&& let Some(id_ptr) = item.get_id::<c_void>()
+				&& let Some(&offset) = offsets_for_ok.get(&(id_ptr as usize))
+			{
+				selected_for_ok.set(offset);
+				dialog_for_ok.end_modal(wxdragon::id::ID_OK);
 			}
 		} else if let Some(offset) = flat_selected_offset(selection, list_for_ok, &views_for_ok) {
 			selected_for_ok.set(offset);

--- a/crates/paperback/src/ui/dialogs/toc.rs
+++ b/crates/paperback/src/ui/dialogs/toc.rs
@@ -90,12 +90,11 @@ fn bind_toc_selection_dv(
 	selected_offset: Rc<Cell<i32>>,
 ) {
 	tree.on_selection_changed(move |event| {
-		if let Some(item) = event.get_item() {
-			if let Some(id_ptr) = item.get_id::<c_void>() {
-				if let Some(&offset) = item_offsets.get(&(id_ptr as usize)) {
-					selected_offset.set(offset);
-				}
-			}
+		if let Some(item) = event.get_item()
+			&& let Some(id_ptr) = item.get_id::<c_void>()
+			&& let Some(&offset) = item_offsets.get(&(id_ptr as usize))
+		{
+			selected_offset.set(offset);
 		}
 	});
 }
@@ -109,13 +108,12 @@ fn bind_toc_activation_dv(
 ) {
 	let dialog_for_activate = dialog;
 	tree.on_item_activated(move |event| {
-		if let Some(item) = event.get_item() {
-			if let Some(id_ptr) = item.get_id::<c_void>() {
-				if let Some(&offset) = item_offsets.get(&(id_ptr as usize)) {
-					selected_offset.set(offset);
-					dialog_for_activate.end_modal(wxdragon::id::ID_OK);
-				}
-			}
+		if let Some(item) = event.get_item()
+			&& let Some(id_ptr) = item.get_id::<c_void>()
+			&& let Some(&offset) = item_offsets.get(&(id_ptr as usize))
+		{
+			selected_offset.set(offset);
+			dialog_for_activate.end_modal(wxdragon::id::ID_OK);
 		}
 	});
 }
@@ -158,12 +156,12 @@ fn find_and_select_dv(
 	let count = tree.get_child_count(parent);
 	for i in 0..count {
 		let child = tree.get_nth_child(parent, i);
-		if let Some(id_ptr) = child.get_id::<c_void>() {
-			if item_offsets.get(&(id_ptr as usize)) == Some(&offset) {
-				tree.select(&child);
-				tree.ensure_visible(&child);
-				return true;
-			}
+		if let Some(id_ptr) = child.get_id::<c_void>()
+			&& item_offsets.get(&(id_ptr as usize)) == Some(&offset)
+		{
+			tree.select(&child);
+			tree.ensure_visible(&child);
+			return true;
 		}
 		if find_and_select_dv(tree, &child, offset, item_offsets) {
 			return true;


### PR DESCRIPTION
Fix eleven `collapsible_if` errors in macOS configuration code and the Elements and Table of Contents dialogs shared with Linux. These branches were excluded from the Windows Clippy job.

Run `cargo clippy --workspace --all-targets` after the macOS tests, reusing their wxWidgets build. Windows retains its separate Clippy job. This saves macOS build time, but means Clippy is skipped if tests fail.

Validation: all 972 workspace tests, Clippy, formatting, and workflow validation pass locally.
